### PR TITLE
Add Tailwind v3 extended color palette for all valid utilities

### DIFF
--- a/src/Tailwind/Utilities.elm
+++ b/src/Tailwind/Utilities.elm
@@ -10788,7 +10788,7 @@ bg_green_100 : Css.Style
 bg_green_100 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(209, 250, 229, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(220, 252, 231, var(--tw-bg-opacity))"
         ]
 
 
@@ -10801,7 +10801,7 @@ bg_green_200 : Css.Style
 bg_green_200 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(167, 243, 208, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(187, 247, 208, var(--tw-bg-opacity))"
         ]
 
 
@@ -10814,7 +10814,7 @@ bg_green_300 : Css.Style
 bg_green_300 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(110, 231, 183, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(134, 239, 172, var(--tw-bg-opacity))"
         ]
 
 
@@ -10827,7 +10827,7 @@ bg_green_400 : Css.Style
 bg_green_400 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(52, 211, 153, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(74, 222, 128, var(--tw-bg-opacity))"
         ]
 
 
@@ -10840,7 +10840,7 @@ bg_green_50 : Css.Style
 bg_green_50 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(236, 253, 245, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(240, 253, 244, var(--tw-bg-opacity))"
         ]
 
 
@@ -10853,7 +10853,7 @@ bg_green_500 : Css.Style
 bg_green_500 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(16, 185, 129, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(34, 197, 94, var(--tw-bg-opacity))"
         ]
 
 
@@ -10866,7 +10866,7 @@ bg_green_600 : Css.Style
 bg_green_600 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(5, 150, 105, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(22, 163, 74, var(--tw-bg-opacity))"
         ]
 
 
@@ -10879,7 +10879,7 @@ bg_green_700 : Css.Style
 bg_green_700 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(4, 120, 87, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(21, 128, 61, var(--tw-bg-opacity))"
         ]
 
 
@@ -10892,7 +10892,7 @@ bg_green_800 : Css.Style
 bg_green_800 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(6, 95, 70, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(22, 101, 52, var(--tw-bg-opacity))"
         ]
 
 
@@ -10905,7 +10905,7 @@ bg_green_900 : Css.Style
 bg_green_900 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(6, 78, 59, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(20, 83, 45, var(--tw-bg-opacity))"
         ]
 
 
@@ -11388,7 +11388,7 @@ bg_purple_100 : Css.Style
 bg_purple_100 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(237, 233, 254, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(243, 232, 255, var(--tw-bg-opacity))"
         ]
 
 
@@ -11401,7 +11401,7 @@ bg_purple_200 : Css.Style
 bg_purple_200 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(221, 214, 254, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(233, 213, 255, var(--tw-bg-opacity))"
         ]
 
 
@@ -11414,7 +11414,7 @@ bg_purple_300 : Css.Style
 bg_purple_300 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(196, 181, 253, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(216, 180, 254, var(--tw-bg-opacity))"
         ]
 
 
@@ -11427,7 +11427,7 @@ bg_purple_400 : Css.Style
 bg_purple_400 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(167, 139, 250, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(192, 132, 252, var(--tw-bg-opacity))"
         ]
 
 
@@ -11440,7 +11440,7 @@ bg_purple_50 : Css.Style
 bg_purple_50 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(245, 243, 255, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(250, 245, 255, var(--tw-bg-opacity))"
         ]
 
 
@@ -11453,7 +11453,7 @@ bg_purple_500 : Css.Style
 bg_purple_500 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(139, 92, 246, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(168, 85, 247, var(--tw-bg-opacity))"
         ]
 
 
@@ -11466,7 +11466,7 @@ bg_purple_600 : Css.Style
 bg_purple_600 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(124, 58, 237, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(147, 51, 234, var(--tw-bg-opacity))"
         ]
 
 
@@ -11479,7 +11479,7 @@ bg_purple_700 : Css.Style
 bg_purple_700 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(109, 40, 217, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(126, 34, 206, var(--tw-bg-opacity))"
         ]
 
 
@@ -11492,7 +11492,7 @@ bg_purple_800 : Css.Style
 bg_purple_800 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(91, 33, 182, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(107, 33, 168, var(--tw-bg-opacity))"
         ]
 
 
@@ -11505,7 +11505,7 @@ bg_purple_900 : Css.Style
 bg_purple_900 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(76, 29, 149, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(88, 28, 135, var(--tw-bg-opacity))"
         ]
 
 
@@ -11771,7 +11771,7 @@ bg_yellow_100 : Css.Style
 bg_yellow_100 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(254, 243, 199, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(254, 249, 195, var(--tw-bg-opacity))"
         ]
 
 
@@ -11784,7 +11784,7 @@ bg_yellow_200 : Css.Style
 bg_yellow_200 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(253, 230, 138, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(254, 240, 138, var(--tw-bg-opacity))"
         ]
 
 
@@ -11797,7 +11797,7 @@ bg_yellow_300 : Css.Style
 bg_yellow_300 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(252, 211, 77, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(253, 224, 71, var(--tw-bg-opacity))"
         ]
 
 
@@ -11810,7 +11810,7 @@ bg_yellow_400 : Css.Style
 bg_yellow_400 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(251, 191, 36, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(250, 204, 21, var(--tw-bg-opacity))"
         ]
 
 
@@ -11823,7 +11823,7 @@ bg_yellow_50 : Css.Style
 bg_yellow_50 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(255, 251, 235, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(254, 252, 232, var(--tw-bg-opacity))"
         ]
 
 
@@ -11836,7 +11836,7 @@ bg_yellow_500 : Css.Style
 bg_yellow_500 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(245, 158, 11, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(234, 179, 8, var(--tw-bg-opacity))"
         ]
 
 
@@ -11849,7 +11849,7 @@ bg_yellow_600 : Css.Style
 bg_yellow_600 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(217, 119, 6, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(202, 138, 4, var(--tw-bg-opacity))"
         ]
 
 
@@ -11862,7 +11862,7 @@ bg_yellow_700 : Css.Style
 bg_yellow_700 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(180, 83, 9, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(161, 98, 7, var(--tw-bg-opacity))"
         ]
 
 
@@ -11875,7 +11875,7 @@ bg_yellow_800 : Css.Style
 bg_yellow_800 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(146, 64, 14, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(133, 77, 14, var(--tw-bg-opacity))"
         ]
 
 
@@ -11888,7 +11888,7 @@ bg_yellow_900 : Css.Style
 bg_yellow_900 =
     Css.batch
         [ Css.property "--tw-bg-opacity" "1"
-        , Css.property "background-color" "rgba(120, 53, 15, var(--tw-bg-opacity))"
+        , Css.property "background-color" "rgba(113, 63, 18, var(--tw-bg-opacity))"
         ]
 
 
@@ -12414,7 +12414,7 @@ border_green_100 : Css.Style
 border_green_100 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(209, 250, 229, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(220, 252, 231, var(--tw-border-opacity))"
         ]
 
 
@@ -12427,7 +12427,7 @@ border_green_200 : Css.Style
 border_green_200 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(167, 243, 208, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(187, 247, 208, var(--tw-border-opacity))"
         ]
 
 
@@ -12440,7 +12440,7 @@ border_green_300 : Css.Style
 border_green_300 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(110, 231, 183, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(134, 239, 172, var(--tw-border-opacity))"
         ]
 
 
@@ -12453,7 +12453,7 @@ border_green_400 : Css.Style
 border_green_400 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(52, 211, 153, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(74, 222, 128, var(--tw-border-opacity))"
         ]
 
 
@@ -12466,7 +12466,7 @@ border_green_50 : Css.Style
 border_green_50 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(236, 253, 245, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(240, 253, 244, var(--tw-border-opacity))"
         ]
 
 
@@ -12479,7 +12479,7 @@ border_green_500 : Css.Style
 border_green_500 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(16, 185, 129, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(34, 197, 94, var(--tw-border-opacity))"
         ]
 
 
@@ -12492,7 +12492,7 @@ border_green_600 : Css.Style
 border_green_600 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(5, 150, 105, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(22, 163, 74, var(--tw-border-opacity))"
         ]
 
 
@@ -12505,7 +12505,7 @@ border_green_700 : Css.Style
 border_green_700 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(4, 120, 87, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(21, 128, 61, var(--tw-border-opacity))"
         ]
 
 
@@ -12518,7 +12518,7 @@ border_green_800 : Css.Style
 border_green_800 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(6, 95, 70, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(22, 101, 52, var(--tw-border-opacity))"
         ]
 
 
@@ -12531,7 +12531,7 @@ border_green_900 : Css.Style
 border_green_900 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(6, 78, 59, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(20, 83, 45, var(--tw-border-opacity))"
         ]
 
 
@@ -13014,7 +13014,7 @@ border_purple_100 : Css.Style
 border_purple_100 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(237, 233, 254, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(243, 232, 255, var(--tw-border-opacity))"
         ]
 
 
@@ -13027,7 +13027,7 @@ border_purple_200 : Css.Style
 border_purple_200 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(221, 214, 254, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(233, 213, 255, var(--tw-border-opacity))"
         ]
 
 
@@ -13040,7 +13040,7 @@ border_purple_300 : Css.Style
 border_purple_300 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(196, 181, 253, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(216, 180, 254, var(--tw-border-opacity))"
         ]
 
 
@@ -13053,7 +13053,7 @@ border_purple_400 : Css.Style
 border_purple_400 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(167, 139, 250, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(192, 132, 252, var(--tw-border-opacity))"
         ]
 
 
@@ -13066,7 +13066,7 @@ border_purple_50 : Css.Style
 border_purple_50 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(245, 243, 255, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(250, 245, 255, var(--tw-border-opacity))"
         ]
 
 
@@ -13079,7 +13079,7 @@ border_purple_500 : Css.Style
 border_purple_500 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(139, 92, 246, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(168, 85, 247, var(--tw-border-opacity))"
         ]
 
 
@@ -13092,7 +13092,7 @@ border_purple_600 : Css.Style
 border_purple_600 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(124, 58, 237, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(147, 51, 234, var(--tw-border-opacity))"
         ]
 
 
@@ -13105,7 +13105,7 @@ border_purple_700 : Css.Style
 border_purple_700 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(109, 40, 217, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(126, 34, 206, var(--tw-border-opacity))"
         ]
 
 
@@ -13118,7 +13118,7 @@ border_purple_800 : Css.Style
 border_purple_800 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(91, 33, 182, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(107, 33, 168, var(--tw-border-opacity))"
         ]
 
 
@@ -13131,7 +13131,7 @@ border_purple_900 : Css.Style
 border_purple_900 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(76, 29, 149, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(88, 28, 135, var(--tw-border-opacity))"
         ]
 
 
@@ -13417,7 +13417,7 @@ border_yellow_100 : Css.Style
 border_yellow_100 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(254, 243, 199, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(254, 249, 195, var(--tw-border-opacity))"
         ]
 
 
@@ -13430,7 +13430,7 @@ border_yellow_200 : Css.Style
 border_yellow_200 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(253, 230, 138, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(254, 240, 138, var(--tw-border-opacity))"
         ]
 
 
@@ -13443,7 +13443,7 @@ border_yellow_300 : Css.Style
 border_yellow_300 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(252, 211, 77, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(253, 224, 71, var(--tw-border-opacity))"
         ]
 
 
@@ -13456,7 +13456,7 @@ border_yellow_400 : Css.Style
 border_yellow_400 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(251, 191, 36, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(250, 204, 21, var(--tw-border-opacity))"
         ]
 
 
@@ -13469,7 +13469,7 @@ border_yellow_50 : Css.Style
 border_yellow_50 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(255, 251, 235, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(254, 252, 232, var(--tw-border-opacity))"
         ]
 
 
@@ -13482,7 +13482,7 @@ border_yellow_500 : Css.Style
 border_yellow_500 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(245, 158, 11, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(234, 179, 8, var(--tw-border-opacity))"
         ]
 
 
@@ -13495,7 +13495,7 @@ border_yellow_600 : Css.Style
 border_yellow_600 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(217, 119, 6, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(202, 138, 4, var(--tw-border-opacity))"
         ]
 
 
@@ -13508,7 +13508,7 @@ border_yellow_700 : Css.Style
 border_yellow_700 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(180, 83, 9, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(161, 98, 7, var(--tw-border-opacity))"
         ]
 
 
@@ -13521,7 +13521,7 @@ border_yellow_800 : Css.Style
 border_yellow_800 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(146, 64, 14, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(133, 77, 14, var(--tw-border-opacity))"
         ]
 
 
@@ -13534,7 +13534,7 @@ border_yellow_900 : Css.Style
 border_yellow_900 =
     Css.batch
         [ Css.property "--tw-border-opacity" "1"
-        , Css.property "border-color" "rgba(120, 53, 15, var(--tw-border-opacity))"
+        , Css.property "border-color" "rgba(113, 63, 18, var(--tw-border-opacity))"
         ]
 
 
@@ -15404,7 +15404,7 @@ divide_green_100 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(209, 250, 229, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(220, 252, 231, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15421,7 +15421,7 @@ divide_green_200 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(167, 243, 208, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(187, 247, 208, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15438,7 +15438,7 @@ divide_green_300 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(110, 231, 183, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(134, 239, 172, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15455,7 +15455,7 @@ divide_green_400 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(52, 211, 153, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(74, 222, 128, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15472,7 +15472,7 @@ divide_green_50 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(236, 253, 245, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(240, 253, 244, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15489,7 +15489,7 @@ divide_green_500 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(16, 185, 129, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(34, 197, 94, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15506,7 +15506,7 @@ divide_green_600 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(5, 150, 105, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(22, 163, 74, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15523,7 +15523,7 @@ divide_green_700 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(4, 120, 87, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(21, 128, 61, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15540,7 +15540,7 @@ divide_green_800 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(6, 95, 70, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(22, 101, 52, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -15557,7 +15557,7 @@ divide_green_900 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(6, 78, 59, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(20, 83, 45, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16170,7 +16170,7 @@ divide_purple_100 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(237, 233, 254, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(243, 232, 255, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16187,7 +16187,7 @@ divide_purple_200 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(221, 214, 254, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(233, 213, 255, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16204,7 +16204,7 @@ divide_purple_300 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(196, 181, 253, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(216, 180, 254, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16221,7 +16221,7 @@ divide_purple_400 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(167, 139, 250, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(192, 132, 252, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16238,7 +16238,7 @@ divide_purple_50 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(245, 243, 255, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(250, 245, 255, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16255,7 +16255,7 @@ divide_purple_500 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(139, 92, 246, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(168, 85, 247, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16272,7 +16272,7 @@ divide_purple_600 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(124, 58, 237, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(147, 51, 234, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16289,7 +16289,7 @@ divide_purple_700 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(109, 40, 217, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(126, 34, 206, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16306,7 +16306,7 @@ divide_purple_800 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(91, 33, 182, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(107, 33, 168, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16323,7 +16323,7 @@ divide_purple_900 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(76, 29, 149, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(88, 28, 135, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16771,7 +16771,7 @@ divide_yellow_100 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(254, 243, 199, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(254, 249, 195, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16788,7 +16788,7 @@ divide_yellow_200 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(253, 230, 138, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(254, 240, 138, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16805,7 +16805,7 @@ divide_yellow_300 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(252, 211, 77, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(253, 224, 71, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16822,7 +16822,7 @@ divide_yellow_400 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(251, 191, 36, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(250, 204, 21, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16839,7 +16839,7 @@ divide_yellow_50 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(255, 251, 235, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(254, 252, 232, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16856,7 +16856,7 @@ divide_yellow_500 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(245, 158, 11, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(234, 179, 8, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16873,7 +16873,7 @@ divide_yellow_600 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(217, 119, 6, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(202, 138, 4, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16890,7 +16890,7 @@ divide_yellow_700 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(180, 83, 9, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(161, 98, 7, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16907,7 +16907,7 @@ divide_yellow_800 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(146, 64, 14, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(133, 77, 14, var(--tw-border-opacity))"
                 ]
             ]
         ]
@@ -16924,7 +16924,7 @@ divide_yellow_900 =
         [ Css.Global.children
             [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
                 [ Css.property "--tw-divide-opacity" "1"
-                , Css.property "border-color" "rgba(120, 53, 15, var(--tw-divide-opacity))"
+                , Css.property "border-color" "rgba(113, 63, 18, var(--tw-border-opacity))"
                 ]
             ]
         ]

--- a/src/Tailwind/Utilities.elm
+++ b/src/Tailwind/Utilities.elm
@@ -3765,6 +3765,426 @@ module Tailwind.Utilities exposing
     , z_40
     , z_50
     , z_auto
+    , bg_slate_50
+    , bg_slate_100
+    , bg_slate_200
+    , bg_slate_300
+    , bg_slate_400
+    , bg_slate_500
+    , bg_slate_600
+    , bg_slate_700
+    , bg_slate_800
+    , bg_slate_900
+    , bg_zinc_50
+    , bg_zinc_100
+    , bg_zinc_200
+    , bg_zinc_300
+    , bg_zinc_400
+    , bg_zinc_500
+    , bg_zinc_600
+    , bg_zinc_700
+    , bg_zinc_800
+    , bg_zinc_900
+    , bg_neutral_50
+    , bg_neutral_100
+    , bg_neutral_200
+    , bg_neutral_300
+    , bg_neutral_400
+    , bg_neutral_500
+    , bg_neutral_600
+    , bg_neutral_700
+    , bg_neutral_800
+    , bg_neutral_900
+    , bg_stone_50
+    , bg_stone_100
+    , bg_stone_200
+    , bg_stone_300
+    , bg_stone_400
+    , bg_stone_500
+    , bg_stone_600
+    , bg_stone_700
+    , bg_stone_800
+    , bg_stone_900
+    , bg_orange_50
+    , bg_orange_100
+    , bg_orange_200
+    , bg_orange_300
+    , bg_orange_400
+    , bg_orange_500
+    , bg_orange_600
+    , bg_orange_700
+    , bg_orange_800
+    , bg_orange_900
+    , bg_amber_50
+    , bg_amber_100
+    , bg_amber_200
+    , bg_amber_300
+    , bg_amber_400
+    , bg_amber_500
+    , bg_amber_600
+    , bg_amber_700
+    , bg_amber_800
+    , bg_amber_900
+    , bg_lime_50
+    , bg_lime_100
+    , bg_lime_200
+    , bg_lime_300
+    , bg_lime_400
+    , bg_lime_500
+    , bg_lime_600
+    , bg_lime_700
+    , bg_lime_800
+    , bg_lime_900
+    , bg_emerald_50
+    , bg_emerald_100
+    , bg_emerald_200
+    , bg_emerald_300
+    , bg_emerald_400
+    , bg_emerald_500
+    , bg_emerald_600
+    , bg_emerald_700
+    , bg_emerald_800
+    , bg_emerald_900
+    , bg_teal_50
+    , bg_teal_100
+    , bg_teal_200
+    , bg_teal_300
+    , bg_teal_400
+    , bg_teal_500
+    , bg_teal_600
+    , bg_teal_700
+    , bg_teal_800
+    , bg_teal_900
+    , bg_cyan_50
+    , bg_cyan_100
+    , bg_cyan_200
+    , bg_cyan_300
+    , bg_cyan_400
+    , bg_cyan_500
+    , bg_cyan_600
+    , bg_cyan_700
+    , bg_cyan_800
+    , bg_cyan_900
+    , bg_sky_50
+    , bg_sky_100
+    , bg_sky_200
+    , bg_sky_300
+    , bg_sky_400
+    , bg_sky_500
+    , bg_sky_600
+    , bg_sky_700
+    , bg_sky_800
+    , bg_sky_900
+    , bg_violet_50
+    , bg_violet_100
+    , bg_violet_200
+    , bg_violet_300
+    , bg_violet_400
+    , bg_violet_500
+    , bg_violet_600
+    , bg_violet_700
+    , bg_violet_800
+    , bg_violet_900
+    , bg_fuchsia_50
+    , bg_fuchsia_100
+    , bg_fuchsia_200
+    , bg_fuchsia_300
+    , bg_fuchsia_400
+    , bg_fuchsia_500
+    , bg_fuchsia_600
+    , bg_fuchsia_700
+    , bg_fuchsia_800
+    , bg_fuchsia_900
+    , bg_rose_50
+    , bg_rose_100
+    , bg_rose_200
+    , bg_rose_300
+    , bg_rose_400
+    , bg_rose_500
+    , bg_rose_600
+    , bg_rose_700
+    , bg_rose_800
+    , bg_rose_900
+    , border_slate_50
+    , border_slate_100
+    , border_slate_200
+    , border_slate_300
+    , border_slate_400
+    , border_slate_500
+    , border_slate_600
+    , border_slate_700
+    , border_slate_800
+    , border_slate_900
+    , border_zinc_50
+    , border_zinc_100
+    , border_zinc_200
+    , border_zinc_300
+    , border_zinc_400
+    , border_zinc_500
+    , border_zinc_600
+    , border_zinc_700
+    , border_zinc_800
+    , border_zinc_900
+    , border_neutral_50
+    , border_neutral_100
+    , border_neutral_200
+    , border_neutral_300
+    , border_neutral_400
+    , border_neutral_500
+    , border_neutral_600
+    , border_neutral_700
+    , border_neutral_800
+    , border_neutral_900
+    , border_stone_50
+    , border_stone_100
+    , border_stone_200
+    , border_stone_300
+    , border_stone_400
+    , border_stone_500
+    , border_stone_600
+    , border_stone_700
+    , border_stone_800
+    , border_stone_900
+    , border_orange_50
+    , border_orange_100
+    , border_orange_200
+    , border_orange_300
+    , border_orange_400
+    , border_orange_500
+    , border_orange_600
+    , border_orange_700
+    , border_orange_800
+    , border_orange_900
+    , border_amber_50
+    , border_amber_100
+    , border_amber_200
+    , border_amber_300
+    , border_amber_400
+    , border_amber_500
+    , border_amber_600
+    , border_amber_700
+    , border_amber_800
+    , border_amber_900
+    , border_lime_50
+    , border_lime_100
+    , border_lime_200
+    , border_lime_300
+    , border_lime_400
+    , border_lime_500
+    , border_lime_600
+    , border_lime_700
+    , border_lime_800
+    , border_lime_900
+    , border_emerald_50
+    , border_emerald_100
+    , border_emerald_200
+    , border_emerald_300
+    , border_emerald_400
+    , border_emerald_500
+    , border_emerald_600
+    , border_emerald_700
+    , border_emerald_800
+    , border_emerald_900
+    , border_teal_50
+    , border_teal_100
+    , border_teal_200
+    , border_teal_300
+    , border_teal_400
+    , border_teal_500
+    , border_teal_600
+    , border_teal_700
+    , border_teal_800
+    , border_teal_900
+    , border_cyan_50
+    , border_cyan_100
+    , border_cyan_200
+    , border_cyan_300
+    , border_cyan_400
+    , border_cyan_500
+    , border_cyan_600
+    , border_cyan_700
+    , border_cyan_800
+    , border_cyan_900
+    , border_sky_50
+    , border_sky_100
+    , border_sky_200
+    , border_sky_300
+    , border_sky_400
+    , border_sky_500
+    , border_sky_600
+    , border_sky_700
+    , border_sky_800
+    , border_sky_900
+    , border_violet_50
+    , border_violet_100
+    , border_violet_200
+    , border_violet_300
+    , border_violet_400
+    , border_violet_500
+    , border_violet_600
+    , border_violet_700
+    , border_violet_800
+    , border_violet_900
+    , border_fuchsia_50
+    , border_fuchsia_100
+    , border_fuchsia_200
+    , border_fuchsia_300
+    , border_fuchsia_400
+    , border_fuchsia_500
+    , border_fuchsia_600
+    , border_fuchsia_700
+    , border_fuchsia_800
+    , border_fuchsia_900
+    , border_rose_50
+    , border_rose_100
+    , border_rose_200
+    , border_rose_300
+    , border_rose_400
+    , border_rose_500
+    , border_rose_600
+    , border_rose_700
+    , border_rose_800
+    , border_rose_900
+    , divide_slate_50
+    , divide_slate_100
+    , divide_slate_200
+    , divide_slate_300
+    , divide_slate_400
+    , divide_slate_500
+    , divide_slate_600
+    , divide_slate_700
+    , divide_slate_800
+    , divide_slate_900
+    , divide_zinc_50
+    , divide_zinc_100
+    , divide_zinc_200
+    , divide_zinc_300
+    , divide_zinc_400
+    , divide_zinc_500
+    , divide_zinc_600
+    , divide_zinc_700
+    , divide_zinc_800
+    , divide_zinc_900
+    , divide_neutral_50
+    , divide_neutral_100
+    , divide_neutral_200
+    , divide_neutral_300
+    , divide_neutral_400
+    , divide_neutral_500
+    , divide_neutral_600
+    , divide_neutral_700
+    , divide_neutral_800
+    , divide_neutral_900
+    , divide_stone_50
+    , divide_stone_100
+    , divide_stone_200
+    , divide_stone_300
+    , divide_stone_400
+    , divide_stone_500
+    , divide_stone_600
+    , divide_stone_700
+    , divide_stone_800
+    , divide_stone_900
+    , divide_orange_50
+    , divide_orange_100
+    , divide_orange_200
+    , divide_orange_300
+    , divide_orange_400
+    , divide_orange_500
+    , divide_orange_600
+    , divide_orange_700
+    , divide_orange_800
+    , divide_orange_900
+    , divide_amber_50
+    , divide_amber_100
+    , divide_amber_200
+    , divide_amber_300
+    , divide_amber_400
+    , divide_amber_500
+    , divide_amber_600
+    , divide_amber_700
+    , divide_amber_800
+    , divide_amber_900
+    , divide_lime_50
+    , divide_lime_100
+    , divide_lime_200
+    , divide_lime_300
+    , divide_lime_400
+    , divide_lime_500
+    , divide_lime_600
+    , divide_lime_700
+    , divide_lime_800
+    , divide_lime_900
+    , divide_emerald_50
+    , divide_emerald_100
+    , divide_emerald_200
+    , divide_emerald_300
+    , divide_emerald_400
+    , divide_emerald_500
+    , divide_emerald_600
+    , divide_emerald_700
+    , divide_emerald_800
+    , divide_emerald_900
+    , divide_teal_50
+    , divide_teal_100
+    , divide_teal_200
+    , divide_teal_300
+    , divide_teal_400
+    , divide_teal_500
+    , divide_teal_600
+    , divide_teal_700
+    , divide_teal_800
+    , divide_teal_900
+    , divide_cyan_50
+    , divide_cyan_100
+    , divide_cyan_200
+    , divide_cyan_300
+    , divide_cyan_400
+    , divide_cyan_500
+    , divide_cyan_600
+    , divide_cyan_700
+    , divide_cyan_800
+    , divide_cyan_900
+    , divide_sky_50
+    , divide_sky_100
+    , divide_sky_200
+    , divide_sky_300
+    , divide_sky_400
+    , divide_sky_500
+    , divide_sky_600
+    , divide_sky_700
+    , divide_sky_800
+    , divide_sky_900
+    , divide_violet_50
+    , divide_violet_100
+    , divide_violet_200
+    , divide_violet_300
+    , divide_violet_400
+    , divide_violet_500
+    , divide_violet_600
+    , divide_violet_700
+    , divide_violet_800
+    , divide_violet_900
+    , divide_fuchsia_50
+    , divide_fuchsia_100
+    , divide_fuchsia_200
+    , divide_fuchsia_300
+    , divide_fuchsia_400
+    , divide_fuchsia_500
+    , divide_fuchsia_600
+    , divide_fuchsia_700
+    , divide_fuchsia_800
+    , divide_fuchsia_900
+    , divide_rose_50
+    , divide_rose_100
+    , divide_rose_200
+    , divide_rose_300
+    , divide_rose_400
+    , divide_rose_500
+    , divide_rose_600
+    , divide_rose_700
+    , divide_rose_800
+    , divide_rose_900
     )
 
 {-|
@@ -7546,6 +7966,426 @@ This module contains
 @docs z_40
 @docs z_50
 @docs z_auto
+@docs bg_slate_50
+@docs bg_slate_100
+@docs bg_slate_200
+@docs bg_slate_300
+@docs bg_slate_400
+@docs bg_slate_500
+@docs bg_slate_600
+@docs bg_slate_700
+@docs bg_slate_800
+@docs bg_slate_900
+@docs bg_zinc_50
+@docs bg_zinc_100
+@docs bg_zinc_200
+@docs bg_zinc_300
+@docs bg_zinc_400
+@docs bg_zinc_500
+@docs bg_zinc_600
+@docs bg_zinc_700
+@docs bg_zinc_800
+@docs bg_zinc_900
+@docs bg_neutral_50
+@docs bg_neutral_100
+@docs bg_neutral_200
+@docs bg_neutral_300
+@docs bg_neutral_400
+@docs bg_neutral_500
+@docs bg_neutral_600
+@docs bg_neutral_700
+@docs bg_neutral_800
+@docs bg_neutral_900
+@docs bg_stone_50
+@docs bg_stone_100
+@docs bg_stone_200
+@docs bg_stone_300
+@docs bg_stone_400
+@docs bg_stone_500
+@docs bg_stone_600
+@docs bg_stone_700
+@docs bg_stone_800
+@docs bg_stone_900
+@docs bg_orange_50
+@docs bg_orange_100
+@docs bg_orange_200
+@docs bg_orange_300
+@docs bg_orange_400
+@docs bg_orange_500
+@docs bg_orange_600
+@docs bg_orange_700
+@docs bg_orange_800
+@docs bg_orange_900
+@docs bg_amber_50
+@docs bg_amber_100
+@docs bg_amber_200
+@docs bg_amber_300
+@docs bg_amber_400
+@docs bg_amber_500
+@docs bg_amber_600
+@docs bg_amber_700
+@docs bg_amber_800
+@docs bg_amber_900
+@docs bg_lime_50
+@docs bg_lime_100
+@docs bg_lime_200
+@docs bg_lime_300
+@docs bg_lime_400
+@docs bg_lime_500
+@docs bg_lime_600
+@docs bg_lime_700
+@docs bg_lime_800
+@docs bg_lime_900
+@docs bg_emerald_50
+@docs bg_emerald_100
+@docs bg_emerald_200
+@docs bg_emerald_300
+@docs bg_emerald_400
+@docs bg_emerald_500
+@docs bg_emerald_600
+@docs bg_emerald_700
+@docs bg_emerald_800
+@docs bg_emerald_900
+@docs bg_teal_50
+@docs bg_teal_100
+@docs bg_teal_200
+@docs bg_teal_300
+@docs bg_teal_400
+@docs bg_teal_500
+@docs bg_teal_600
+@docs bg_teal_700
+@docs bg_teal_800
+@docs bg_teal_900
+@docs bg_cyan_50
+@docs bg_cyan_100
+@docs bg_cyan_200
+@docs bg_cyan_300
+@docs bg_cyan_400
+@docs bg_cyan_500
+@docs bg_cyan_600
+@docs bg_cyan_700
+@docs bg_cyan_800
+@docs bg_cyan_900
+@docs bg_sky_50
+@docs bg_sky_100
+@docs bg_sky_200
+@docs bg_sky_300
+@docs bg_sky_400
+@docs bg_sky_500
+@docs bg_sky_600
+@docs bg_sky_700
+@docs bg_sky_800
+@docs bg_sky_900
+@docs bg_violet_50
+@docs bg_violet_100
+@docs bg_violet_200
+@docs bg_violet_300
+@docs bg_violet_400
+@docs bg_violet_500
+@docs bg_violet_600
+@docs bg_violet_700
+@docs bg_violet_800
+@docs bg_violet_900
+@docs bg_fuchsia_50
+@docs bg_fuchsia_100
+@docs bg_fuchsia_200
+@docs bg_fuchsia_300
+@docs bg_fuchsia_400
+@docs bg_fuchsia_500
+@docs bg_fuchsia_600
+@docs bg_fuchsia_700
+@docs bg_fuchsia_800
+@docs bg_fuchsia_900
+@docs bg_rose_50
+@docs bg_rose_100
+@docs bg_rose_200
+@docs bg_rose_300
+@docs bg_rose_400
+@docs bg_rose_500
+@docs bg_rose_600
+@docs bg_rose_700
+@docs bg_rose_800
+@docs bg_rose_900
+@docs border_slate_50
+@docs border_slate_100
+@docs border_slate_200
+@docs border_slate_300
+@docs border_slate_400
+@docs border_slate_500
+@docs border_slate_600
+@docs border_slate_700
+@docs border_slate_800
+@docs border_slate_900
+@docs border_zinc_50
+@docs border_zinc_100
+@docs border_zinc_200
+@docs border_zinc_300
+@docs border_zinc_400
+@docs border_zinc_500
+@docs border_zinc_600
+@docs border_zinc_700
+@docs border_zinc_800
+@docs border_zinc_900
+@docs border_neutral_50
+@docs border_neutral_100
+@docs border_neutral_200
+@docs border_neutral_300
+@docs border_neutral_400
+@docs border_neutral_500
+@docs border_neutral_600
+@docs border_neutral_700
+@docs border_neutral_800
+@docs border_neutral_900
+@docs border_stone_50
+@docs border_stone_100
+@docs border_stone_200
+@docs border_stone_300
+@docs border_stone_400
+@docs border_stone_500
+@docs border_stone_600
+@docs border_stone_700
+@docs border_stone_800
+@docs border_stone_900
+@docs border_orange_50
+@docs border_orange_100
+@docs border_orange_200
+@docs border_orange_300
+@docs border_orange_400
+@docs border_orange_500
+@docs border_orange_600
+@docs border_orange_700
+@docs border_orange_800
+@docs border_orange_900
+@docs border_amber_50
+@docs border_amber_100
+@docs border_amber_200
+@docs border_amber_300
+@docs border_amber_400
+@docs border_amber_500
+@docs border_amber_600
+@docs border_amber_700
+@docs border_amber_800
+@docs border_amber_900
+@docs border_lime_50
+@docs border_lime_100
+@docs border_lime_200
+@docs border_lime_300
+@docs border_lime_400
+@docs border_lime_500
+@docs border_lime_600
+@docs border_lime_700
+@docs border_lime_800
+@docs border_lime_900
+@docs border_emerald_50
+@docs border_emerald_100
+@docs border_emerald_200
+@docs border_emerald_300
+@docs border_emerald_400
+@docs border_emerald_500
+@docs border_emerald_600
+@docs border_emerald_700
+@docs border_emerald_800
+@docs border_emerald_900
+@docs border_teal_50
+@docs border_teal_100
+@docs border_teal_200
+@docs border_teal_300
+@docs border_teal_400
+@docs border_teal_500
+@docs border_teal_600
+@docs border_teal_700
+@docs border_teal_800
+@docs border_teal_900
+@docs border_cyan_50
+@docs border_cyan_100
+@docs border_cyan_200
+@docs border_cyan_300
+@docs border_cyan_400
+@docs border_cyan_500
+@docs border_cyan_600
+@docs border_cyan_700
+@docs border_cyan_800
+@docs border_cyan_900
+@docs border_sky_50
+@docs border_sky_100
+@docs border_sky_200
+@docs border_sky_300
+@docs border_sky_400
+@docs border_sky_500
+@docs border_sky_600
+@docs border_sky_700
+@docs border_sky_800
+@docs border_sky_900
+@docs border_violet_50
+@docs border_violet_100
+@docs border_violet_200
+@docs border_violet_300
+@docs border_violet_400
+@docs border_violet_500
+@docs border_violet_600
+@docs border_violet_700
+@docs border_violet_800
+@docs border_violet_900
+@docs border_fuchsia_50
+@docs border_fuchsia_100
+@docs border_fuchsia_200
+@docs border_fuchsia_300
+@docs border_fuchsia_400
+@docs border_fuchsia_500
+@docs border_fuchsia_600
+@docs border_fuchsia_700
+@docs border_fuchsia_800
+@docs border_fuchsia_900
+@docs border_rose_50
+@docs border_rose_100
+@docs border_rose_200
+@docs border_rose_300
+@docs border_rose_400
+@docs border_rose_500
+@docs border_rose_600
+@docs border_rose_700
+@docs border_rose_800
+@docs border_rose_900
+@docs divide_slate_50
+@docs divide_slate_100
+@docs divide_slate_200
+@docs divide_slate_300
+@docs divide_slate_400
+@docs divide_slate_500
+@docs divide_slate_600
+@docs divide_slate_700
+@docs divide_slate_800
+@docs divide_slate_900
+@docs divide_zinc_50
+@docs divide_zinc_100
+@docs divide_zinc_200
+@docs divide_zinc_300
+@docs divide_zinc_400
+@docs divide_zinc_500
+@docs divide_zinc_600
+@docs divide_zinc_700
+@docs divide_zinc_800
+@docs divide_zinc_900
+@docs divide_neutral_50
+@docs divide_neutral_100
+@docs divide_neutral_200
+@docs divide_neutral_300
+@docs divide_neutral_400
+@docs divide_neutral_500
+@docs divide_neutral_600
+@docs divide_neutral_700
+@docs divide_neutral_800
+@docs divide_neutral_900
+@docs divide_stone_50
+@docs divide_stone_100
+@docs divide_stone_200
+@docs divide_stone_300
+@docs divide_stone_400
+@docs divide_stone_500
+@docs divide_stone_600
+@docs divide_stone_700
+@docs divide_stone_800
+@docs divide_stone_900
+@docs divide_orange_50
+@docs divide_orange_100
+@docs divide_orange_200
+@docs divide_orange_300
+@docs divide_orange_400
+@docs divide_orange_500
+@docs divide_orange_600
+@docs divide_orange_700
+@docs divide_orange_800
+@docs divide_orange_900
+@docs divide_amber_50
+@docs divide_amber_100
+@docs divide_amber_200
+@docs divide_amber_300
+@docs divide_amber_400
+@docs divide_amber_500
+@docs divide_amber_600
+@docs divide_amber_700
+@docs divide_amber_800
+@docs divide_amber_900
+@docs divide_lime_50
+@docs divide_lime_100
+@docs divide_lime_200
+@docs divide_lime_300
+@docs divide_lime_400
+@docs divide_lime_500
+@docs divide_lime_600
+@docs divide_lime_700
+@docs divide_lime_800
+@docs divide_lime_900
+@docs divide_emerald_50
+@docs divide_emerald_100
+@docs divide_emerald_200
+@docs divide_emerald_300
+@docs divide_emerald_400
+@docs divide_emerald_500
+@docs divide_emerald_600
+@docs divide_emerald_700
+@docs divide_emerald_800
+@docs divide_emerald_900
+@docs divide_teal_50
+@docs divide_teal_100
+@docs divide_teal_200
+@docs divide_teal_300
+@docs divide_teal_400
+@docs divide_teal_500
+@docs divide_teal_600
+@docs divide_teal_700
+@docs divide_teal_800
+@docs divide_teal_900
+@docs divide_cyan_50
+@docs divide_cyan_100
+@docs divide_cyan_200
+@docs divide_cyan_300
+@docs divide_cyan_400
+@docs divide_cyan_500
+@docs divide_cyan_600
+@docs divide_cyan_700
+@docs divide_cyan_800
+@docs divide_cyan_900
+@docs divide_sky_50
+@docs divide_sky_100
+@docs divide_sky_200
+@docs divide_sky_300
+@docs divide_sky_400
+@docs divide_sky_500
+@docs divide_sky_600
+@docs divide_sky_700
+@docs divide_sky_800
+@docs divide_sky_900
+@docs divide_violet_50
+@docs divide_violet_100
+@docs divide_violet_200
+@docs divide_violet_300
+@docs divide_violet_400
+@docs divide_violet_500
+@docs divide_violet_600
+@docs divide_violet_700
+@docs divide_violet_800
+@docs divide_violet_900
+@docs divide_fuchsia_50
+@docs divide_fuchsia_100
+@docs divide_fuchsia_200
+@docs divide_fuchsia_300
+@docs divide_fuchsia_400
+@docs divide_fuchsia_500
+@docs divide_fuchsia_600
+@docs divide_fuchsia_700
+@docs divide_fuchsia_800
+@docs divide_fuchsia_900
+@docs divide_rose_50
+@docs divide_rose_100
+@docs divide_rose_200
+@docs divide_rose_300
+@docs divide_rose_400
+@docs divide_rose_500
+@docs divide_rose_600
+@docs divide_rose_700
+@docs divide_rose_800
+@docs divide_rose_900
 
 -}
 
@@ -7783,7 +8623,6 @@ globalStyles =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 absolute : Css.Style
 absolute =
     Css.property "position" "absolute"
@@ -7794,7 +8633,6 @@ absolute =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_baseline : Css.Style
 align_baseline =
     Css.property "vertical-align" "baseline"
@@ -7805,7 +8643,6 @@ align_baseline =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_bottom : Css.Style
 align_bottom =
     Css.property "vertical-align" "bottom"
@@ -7816,7 +8653,6 @@ align_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_middle : Css.Style
 align_middle =
     Css.property "vertical-align" "middle"
@@ -7827,7 +8663,6 @@ align_middle =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_text_bottom : Css.Style
 align_text_bottom =
     Css.property "vertical-align" "text-bottom"
@@ -7838,7 +8673,6 @@ align_text_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_text_top : Css.Style
 align_text_top =
     Css.property "vertical-align" "text-top"
@@ -7849,7 +8683,6 @@ align_text_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 align_top : Css.Style
 align_top =
     Css.property "vertical-align" "top"
@@ -7860,7 +8693,6 @@ align_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 animate_bounce : Css.Style
 animate_bounce =
     Css.batch
@@ -7906,7 +8738,6 @@ animate_bounce =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 animate_none : Css.Style
 animate_none =
     Css.batch
@@ -7920,7 +8751,6 @@ animate_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 animate_ping : Css.Style
 animate_ping =
     Css.batch
@@ -7952,7 +8782,6 @@ animate_ping =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 animate_pulse : Css.Style
 animate_pulse =
     Css.batch
@@ -7982,7 +8811,6 @@ animate_pulse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 animate_spin : Css.Style
 animate_spin =
     Css.batch
@@ -8012,7 +8840,6 @@ animate_spin =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 antialiased : Css.Style
 antialiased =
     Css.batch
@@ -8026,7 +8853,6 @@ antialiased =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 appearance_none : Css.Style
 appearance_none =
     Css.batch
@@ -8041,7 +8867,6 @@ appearance_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_1 : Css.Style
 aspect_h_1 =
     Css.property "--tw-aspect-h" "1"
@@ -8052,7 +8877,6 @@ aspect_h_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_10 : Css.Style
 aspect_h_10 =
     Css.property "--tw-aspect-h" "10"
@@ -8063,7 +8887,6 @@ aspect_h_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_11 : Css.Style
 aspect_h_11 =
     Css.property "--tw-aspect-h" "11"
@@ -8074,7 +8897,6 @@ aspect_h_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_12 : Css.Style
 aspect_h_12 =
     Css.property "--tw-aspect-h" "12"
@@ -8085,7 +8907,6 @@ aspect_h_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_13 : Css.Style
 aspect_h_13 =
     Css.property "--tw-aspect-h" "13"
@@ -8096,7 +8917,6 @@ aspect_h_13 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_14 : Css.Style
 aspect_h_14 =
     Css.property "--tw-aspect-h" "14"
@@ -8107,7 +8927,6 @@ aspect_h_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_15 : Css.Style
 aspect_h_15 =
     Css.property "--tw-aspect-h" "15"
@@ -8118,7 +8937,6 @@ aspect_h_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_16 : Css.Style
 aspect_h_16 =
     Css.property "--tw-aspect-h" "16"
@@ -8129,7 +8947,6 @@ aspect_h_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_2 : Css.Style
 aspect_h_2 =
     Css.property "--tw-aspect-h" "2"
@@ -8140,7 +8957,6 @@ aspect_h_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_3 : Css.Style
 aspect_h_3 =
     Css.property "--tw-aspect-h" "3"
@@ -8151,7 +8967,6 @@ aspect_h_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_4 : Css.Style
 aspect_h_4 =
     Css.property "--tw-aspect-h" "4"
@@ -8162,7 +8977,6 @@ aspect_h_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_5 : Css.Style
 aspect_h_5 =
     Css.property "--tw-aspect-h" "5"
@@ -8173,7 +8987,6 @@ aspect_h_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_6 : Css.Style
 aspect_h_6 =
     Css.property "--tw-aspect-h" "6"
@@ -8184,7 +8997,6 @@ aspect_h_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_7 : Css.Style
 aspect_h_7 =
     Css.property "--tw-aspect-h" "7"
@@ -8195,7 +9007,6 @@ aspect_h_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_8 : Css.Style
 aspect_h_8 =
     Css.property "--tw-aspect-h" "8"
@@ -8206,7 +9017,6 @@ aspect_h_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_h_9 : Css.Style
 aspect_h_9 =
     Css.property "--tw-aspect-h" "9"
@@ -8217,7 +9027,6 @@ aspect_h_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_none : Css.Style
 aspect_none =
     Css.batch
@@ -8242,7 +9051,6 @@ aspect_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_1 : Css.Style
 aspect_w_1 =
     Css.batch
@@ -8268,7 +9076,6 @@ aspect_w_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_10 : Css.Style
 aspect_w_10 =
     Css.batch
@@ -8294,7 +9101,6 @@ aspect_w_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_11 : Css.Style
 aspect_w_11 =
     Css.batch
@@ -8320,7 +9126,6 @@ aspect_w_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_12 : Css.Style
 aspect_w_12 =
     Css.batch
@@ -8346,7 +9151,6 @@ aspect_w_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_13 : Css.Style
 aspect_w_13 =
     Css.batch
@@ -8372,7 +9176,6 @@ aspect_w_13 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_14 : Css.Style
 aspect_w_14 =
     Css.batch
@@ -8398,7 +9201,6 @@ aspect_w_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_15 : Css.Style
 aspect_w_15 =
     Css.batch
@@ -8424,7 +9226,6 @@ aspect_w_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_16 : Css.Style
 aspect_w_16 =
     Css.batch
@@ -8450,7 +9251,6 @@ aspect_w_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_2 : Css.Style
 aspect_w_2 =
     Css.batch
@@ -8476,7 +9276,6 @@ aspect_w_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_3 : Css.Style
 aspect_w_3 =
     Css.batch
@@ -8502,7 +9301,6 @@ aspect_w_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_4 : Css.Style
 aspect_w_4 =
     Css.batch
@@ -8528,7 +9326,6 @@ aspect_w_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_5 : Css.Style
 aspect_w_5 =
     Css.batch
@@ -8554,7 +9351,6 @@ aspect_w_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_6 : Css.Style
 aspect_w_6 =
     Css.batch
@@ -8580,7 +9376,6 @@ aspect_w_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_7 : Css.Style
 aspect_w_7 =
     Css.batch
@@ -8606,7 +9401,6 @@ aspect_w_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_8 : Css.Style
 aspect_w_8 =
     Css.batch
@@ -8632,7 +9426,6 @@ aspect_w_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 aspect_w_9 : Css.Style
 aspect_w_9 =
     Css.batch
@@ -8658,7 +9451,6 @@ aspect_w_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_cols_auto : Css.Style
 auto_cols_auto =
     Css.property "grid-auto-columns" "auto"
@@ -8669,7 +9461,6 @@ auto_cols_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_cols_fr : Css.Style
 auto_cols_fr =
     Css.property "grid-auto-columns" "minmax(0, 1fr)"
@@ -8680,7 +9471,6 @@ auto_cols_fr =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_cols_max : Css.Style
 auto_cols_max =
     Css.batch
@@ -8694,7 +9484,6 @@ auto_cols_max =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_cols_min : Css.Style
 auto_cols_min =
     Css.batch
@@ -8708,7 +9497,6 @@ auto_cols_min =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_rows_auto : Css.Style
 auto_rows_auto =
     Css.property "grid-auto-rows" "auto"
@@ -8719,7 +9507,6 @@ auto_rows_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_rows_fr : Css.Style
 auto_rows_fr =
     Css.property "grid-auto-rows" "minmax(0, 1fr)"
@@ -8730,7 +9517,6 @@ auto_rows_fr =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_rows_max : Css.Style
 auto_rows_max =
     Css.batch
@@ -8744,7 +9530,6 @@ auto_rows_max =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 auto_rows_min : Css.Style
 auto_rows_min =
     Css.batch
@@ -8758,7 +9543,6 @@ auto_rows_min =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur : Css.Style
 backdrop_blur =
     Css.property "--tw-backdrop-blur" "blur(8px)"
@@ -8769,7 +9553,6 @@ backdrop_blur =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_0 : Css.Style
 backdrop_blur_0 =
     Css.property "--tw-backdrop-blur" "blur(0)"
@@ -8780,7 +9563,6 @@ backdrop_blur_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_2xl : Css.Style
 backdrop_blur_2xl =
     Css.property "--tw-backdrop-blur" "blur(40px)"
@@ -8791,7 +9573,6 @@ backdrop_blur_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_3xl : Css.Style
 backdrop_blur_3xl =
     Css.property "--tw-backdrop-blur" "blur(64px)"
@@ -8802,7 +9583,6 @@ backdrop_blur_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_lg : Css.Style
 backdrop_blur_lg =
     Css.property "--tw-backdrop-blur" "blur(16px)"
@@ -8813,7 +9593,6 @@ backdrop_blur_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_md : Css.Style
 backdrop_blur_md =
     Css.property "--tw-backdrop-blur" "blur(12px)"
@@ -8824,7 +9603,6 @@ backdrop_blur_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_sm : Css.Style
 backdrop_blur_sm =
     Css.property "--tw-backdrop-blur" "blur(4px)"
@@ -8835,7 +9613,6 @@ backdrop_blur_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_blur_xl : Css.Style
 backdrop_blur_xl =
     Css.property "--tw-backdrop-blur" "blur(24px)"
@@ -8846,7 +9623,6 @@ backdrop_blur_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_0 : Css.Style
 backdrop_brightness_0 =
     Css.property "--tw-backdrop-brightness" "brightness(0)"
@@ -8857,7 +9633,6 @@ backdrop_brightness_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_100 : Css.Style
 backdrop_brightness_100 =
     Css.property "--tw-backdrop-brightness" "brightness(1)"
@@ -8868,7 +9643,6 @@ backdrop_brightness_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_105 : Css.Style
 backdrop_brightness_105 =
     Css.property "--tw-backdrop-brightness" "brightness(1.05)"
@@ -8879,7 +9653,6 @@ backdrop_brightness_105 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_110 : Css.Style
 backdrop_brightness_110 =
     Css.property "--tw-backdrop-brightness" "brightness(1.1)"
@@ -8890,7 +9663,6 @@ backdrop_brightness_110 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_125 : Css.Style
 backdrop_brightness_125 =
     Css.property "--tw-backdrop-brightness" "brightness(1.25)"
@@ -8901,7 +9673,6 @@ backdrop_brightness_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_150 : Css.Style
 backdrop_brightness_150 =
     Css.property "--tw-backdrop-brightness" "brightness(1.5)"
@@ -8912,7 +9683,6 @@ backdrop_brightness_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_200 : Css.Style
 backdrop_brightness_200 =
     Css.property "--tw-backdrop-brightness" "brightness(2)"
@@ -8923,7 +9693,6 @@ backdrop_brightness_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_50 : Css.Style
 backdrop_brightness_50 =
     Css.property "--tw-backdrop-brightness" "brightness(.5)"
@@ -8934,7 +9703,6 @@ backdrop_brightness_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_75 : Css.Style
 backdrop_brightness_75 =
     Css.property "--tw-backdrop-brightness" "brightness(.75)"
@@ -8945,7 +9713,6 @@ backdrop_brightness_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_90 : Css.Style
 backdrop_brightness_90 =
     Css.property "--tw-backdrop-brightness" "brightness(.9)"
@@ -8956,7 +9723,6 @@ backdrop_brightness_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_brightness_95 : Css.Style
 backdrop_brightness_95 =
     Css.property "--tw-backdrop-brightness" "brightness(.95)"
@@ -8967,7 +9733,6 @@ backdrop_brightness_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_0 : Css.Style
 backdrop_contrast_0 =
     Css.property "--tw-backdrop-contrast" "contrast(0)"
@@ -8978,7 +9743,6 @@ backdrop_contrast_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_100 : Css.Style
 backdrop_contrast_100 =
     Css.property "--tw-backdrop-contrast" "contrast(1)"
@@ -8989,7 +9753,6 @@ backdrop_contrast_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_125 : Css.Style
 backdrop_contrast_125 =
     Css.property "--tw-backdrop-contrast" "contrast(1.25)"
@@ -9000,7 +9763,6 @@ backdrop_contrast_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_150 : Css.Style
 backdrop_contrast_150 =
     Css.property "--tw-backdrop-contrast" "contrast(1.5)"
@@ -9011,7 +9773,6 @@ backdrop_contrast_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_200 : Css.Style
 backdrop_contrast_200 =
     Css.property "--tw-backdrop-contrast" "contrast(2)"
@@ -9022,7 +9783,6 @@ backdrop_contrast_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_50 : Css.Style
 backdrop_contrast_50 =
     Css.property "--tw-backdrop-contrast" "contrast(.5)"
@@ -9033,7 +9793,6 @@ backdrop_contrast_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_contrast_75 : Css.Style
 backdrop_contrast_75 =
     Css.property "--tw-backdrop-contrast" "contrast(.75)"
@@ -9044,7 +9803,6 @@ backdrop_contrast_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_filter : Css.Style
 backdrop_filter =
     Css.batch
@@ -9067,7 +9825,6 @@ backdrop_filter =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_filter_none : Css.Style
 backdrop_filter_none =
     Css.batch
@@ -9081,7 +9838,6 @@ backdrop_filter_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_grayscale : Css.Style
 backdrop_grayscale =
     Css.property "--tw-backdrop-grayscale" "grayscale(100%)"
@@ -9092,7 +9848,6 @@ backdrop_grayscale =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_grayscale_0 : Css.Style
 backdrop_grayscale_0 =
     Css.property "--tw-backdrop-grayscale" "grayscale(0)"
@@ -9103,7 +9858,6 @@ backdrop_grayscale_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_0 : Css.Style
 backdrop_hue_rotate_0 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(0deg)"
@@ -9114,7 +9868,6 @@ backdrop_hue_rotate_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_15 : Css.Style
 backdrop_hue_rotate_15 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(15deg)"
@@ -9125,7 +9878,6 @@ backdrop_hue_rotate_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_180 : Css.Style
 backdrop_hue_rotate_180 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(180deg)"
@@ -9136,7 +9888,6 @@ backdrop_hue_rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_30 : Css.Style
 backdrop_hue_rotate_30 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(30deg)"
@@ -9147,7 +9898,6 @@ backdrop_hue_rotate_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_60 : Css.Style
 backdrop_hue_rotate_60 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(60deg)"
@@ -9158,7 +9908,6 @@ backdrop_hue_rotate_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_hue_rotate_90 : Css.Style
 backdrop_hue_rotate_90 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(90deg)"
@@ -9169,7 +9918,6 @@ backdrop_hue_rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_invert : Css.Style
 backdrop_invert =
     Css.property "--tw-backdrop-invert" "invert(100%)"
@@ -9180,7 +9928,6 @@ backdrop_invert =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_invert_0 : Css.Style
 backdrop_invert_0 =
     Css.property "--tw-backdrop-invert" "invert(0)"
@@ -9191,7 +9938,6 @@ backdrop_invert_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_0 : Css.Style
 backdrop_opacity_0 =
     Css.property "--tw-backdrop-opacity" "opacity(0)"
@@ -9202,7 +9948,6 @@ backdrop_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_10 : Css.Style
 backdrop_opacity_10 =
     Css.property "--tw-backdrop-opacity" "opacity(0.1)"
@@ -9213,7 +9958,6 @@ backdrop_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_100 : Css.Style
 backdrop_opacity_100 =
     Css.property "--tw-backdrop-opacity" "opacity(1)"
@@ -9224,7 +9968,6 @@ backdrop_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_20 : Css.Style
 backdrop_opacity_20 =
     Css.property "--tw-backdrop-opacity" "opacity(0.2)"
@@ -9235,7 +9978,6 @@ backdrop_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_25 : Css.Style
 backdrop_opacity_25 =
     Css.property "--tw-backdrop-opacity" "opacity(0.25)"
@@ -9246,7 +9988,6 @@ backdrop_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_30 : Css.Style
 backdrop_opacity_30 =
     Css.property "--tw-backdrop-opacity" "opacity(0.3)"
@@ -9257,7 +9998,6 @@ backdrop_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_40 : Css.Style
 backdrop_opacity_40 =
     Css.property "--tw-backdrop-opacity" "opacity(0.4)"
@@ -9268,7 +10008,6 @@ backdrop_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_5 : Css.Style
 backdrop_opacity_5 =
     Css.property "--tw-backdrop-opacity" "opacity(0.05)"
@@ -9279,7 +10018,6 @@ backdrop_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_50 : Css.Style
 backdrop_opacity_50 =
     Css.property "--tw-backdrop-opacity" "opacity(0.5)"
@@ -9290,7 +10028,6 @@ backdrop_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_60 : Css.Style
 backdrop_opacity_60 =
     Css.property "--tw-backdrop-opacity" "opacity(0.6)"
@@ -9301,7 +10038,6 @@ backdrop_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_70 : Css.Style
 backdrop_opacity_70 =
     Css.property "--tw-backdrop-opacity" "opacity(0.7)"
@@ -9312,7 +10048,6 @@ backdrop_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_75 : Css.Style
 backdrop_opacity_75 =
     Css.property "--tw-backdrop-opacity" "opacity(0.75)"
@@ -9323,7 +10058,6 @@ backdrop_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_80 : Css.Style
 backdrop_opacity_80 =
     Css.property "--tw-backdrop-opacity" "opacity(0.8)"
@@ -9334,7 +10068,6 @@ backdrop_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_90 : Css.Style
 backdrop_opacity_90 =
     Css.property "--tw-backdrop-opacity" "opacity(0.9)"
@@ -9345,7 +10078,6 @@ backdrop_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_opacity_95 : Css.Style
 backdrop_opacity_95 =
     Css.property "--tw-backdrop-opacity" "opacity(0.95)"
@@ -9356,7 +10088,6 @@ backdrop_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_saturate_0 : Css.Style
 backdrop_saturate_0 =
     Css.property "--tw-backdrop-saturate" "saturate(0)"
@@ -9367,7 +10098,6 @@ backdrop_saturate_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_saturate_100 : Css.Style
 backdrop_saturate_100 =
     Css.property "--tw-backdrop-saturate" "saturate(1)"
@@ -9378,7 +10108,6 @@ backdrop_saturate_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_saturate_150 : Css.Style
 backdrop_saturate_150 =
     Css.property "--tw-backdrop-saturate" "saturate(1.5)"
@@ -9389,7 +10118,6 @@ backdrop_saturate_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_saturate_200 : Css.Style
 backdrop_saturate_200 =
     Css.property "--tw-backdrop-saturate" "saturate(2)"
@@ -9400,7 +10128,6 @@ backdrop_saturate_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_saturate_50 : Css.Style
 backdrop_saturate_50 =
     Css.property "--tw-backdrop-saturate" "saturate(.5)"
@@ -9411,7 +10138,6 @@ backdrop_saturate_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_sepia : Css.Style
 backdrop_sepia =
     Css.property "--tw-backdrop-sepia" "sepia(100%)"
@@ -9422,7 +10148,6 @@ backdrop_sepia =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 backdrop_sepia_0 : Css.Style
 backdrop_sepia_0 =
     Css.property "--tw-backdrop-sepia" "sepia(0)"
@@ -9433,7 +10158,6 @@ backdrop_sepia_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_auto : Css.Style
 bg_auto =
     Css.property "background-size" "auto"
@@ -9444,7 +10168,6 @@ bg_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_black : Css.Style
 bg_black =
     Css.batch
@@ -9458,7 +10181,6 @@ bg_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_color : Css.Style
 bg_blend_color =
     Css.property "background-blend-mode" "color"
@@ -9469,7 +10191,6 @@ bg_blend_color =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_color_burn : Css.Style
 bg_blend_color_burn =
     Css.property "background-blend-mode" "color-burn"
@@ -9480,7 +10201,6 @@ bg_blend_color_burn =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_color_dodge : Css.Style
 bg_blend_color_dodge =
     Css.property "background-blend-mode" "color-dodge"
@@ -9491,7 +10211,6 @@ bg_blend_color_dodge =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_darken : Css.Style
 bg_blend_darken =
     Css.property "background-blend-mode" "darken"
@@ -9502,7 +10221,6 @@ bg_blend_darken =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_difference : Css.Style
 bg_blend_difference =
     Css.property "background-blend-mode" "difference"
@@ -9513,7 +10231,6 @@ bg_blend_difference =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_exclusion : Css.Style
 bg_blend_exclusion =
     Css.property "background-blend-mode" "exclusion"
@@ -9524,7 +10241,6 @@ bg_blend_exclusion =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_hard_light : Css.Style
 bg_blend_hard_light =
     Css.property "background-blend-mode" "hard-light"
@@ -9535,7 +10251,6 @@ bg_blend_hard_light =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_hue : Css.Style
 bg_blend_hue =
     Css.property "background-blend-mode" "hue"
@@ -9546,7 +10261,6 @@ bg_blend_hue =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_lighten : Css.Style
 bg_blend_lighten =
     Css.property "background-blend-mode" "lighten"
@@ -9557,7 +10271,6 @@ bg_blend_lighten =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_luminosity : Css.Style
 bg_blend_luminosity =
     Css.property "background-blend-mode" "luminosity"
@@ -9568,7 +10281,6 @@ bg_blend_luminosity =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_multiply : Css.Style
 bg_blend_multiply =
     Css.property "background-blend-mode" "multiply"
@@ -9579,7 +10291,6 @@ bg_blend_multiply =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_normal : Css.Style
 bg_blend_normal =
     Css.property "background-blend-mode" "normal"
@@ -9590,7 +10301,6 @@ bg_blend_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_overlay : Css.Style
 bg_blend_overlay =
     Css.property "background-blend-mode" "overlay"
@@ -9601,7 +10311,6 @@ bg_blend_overlay =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_saturation : Css.Style
 bg_blend_saturation =
     Css.property "background-blend-mode" "saturation"
@@ -9612,7 +10321,6 @@ bg_blend_saturation =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_screen : Css.Style
 bg_blend_screen =
     Css.property "background-blend-mode" "screen"
@@ -9623,7 +10331,6 @@ bg_blend_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blend_soft_light : Css.Style
 bg_blend_soft_light =
     Css.property "background-blend-mode" "soft-light"
@@ -9634,7 +10341,6 @@ bg_blend_soft_light =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_100 : Css.Style
 bg_blue_100 =
     Css.batch
@@ -9648,7 +10354,6 @@ bg_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_200 : Css.Style
 bg_blue_200 =
     Css.batch
@@ -9662,7 +10367,6 @@ bg_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_300 : Css.Style
 bg_blue_300 =
     Css.batch
@@ -9676,7 +10380,6 @@ bg_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_400 : Css.Style
 bg_blue_400 =
     Css.batch
@@ -9690,7 +10393,6 @@ bg_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_50 : Css.Style
 bg_blue_50 =
     Css.batch
@@ -9704,7 +10406,6 @@ bg_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_500 : Css.Style
 bg_blue_500 =
     Css.batch
@@ -9718,7 +10419,6 @@ bg_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_600 : Css.Style
 bg_blue_600 =
     Css.batch
@@ -9732,7 +10432,6 @@ bg_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_700 : Css.Style
 bg_blue_700 =
     Css.batch
@@ -9746,7 +10445,6 @@ bg_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_800 : Css.Style
 bg_blue_800 =
     Css.batch
@@ -9760,7 +10458,6 @@ bg_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_blue_900 : Css.Style
 bg_blue_900 =
     Css.batch
@@ -9774,7 +10471,6 @@ bg_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_bottom : Css.Style
 bg_bottom =
     Css.property "background-position" "bottom"
@@ -9785,7 +10481,6 @@ bg_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_center : Css.Style
 bg_center =
     Css.property "background-position" "center"
@@ -9796,7 +10491,6 @@ bg_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_clip_border : Css.Style
 bg_clip_border =
     Css.property "background-clip" "border-box"
@@ -9807,7 +10501,6 @@ bg_clip_border =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_clip_content : Css.Style
 bg_clip_content =
     Css.property "background-clip" "content-box"
@@ -9818,7 +10511,6 @@ bg_clip_content =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_clip_padding : Css.Style
 bg_clip_padding =
     Css.property "background-clip" "padding-box"
@@ -9829,7 +10521,6 @@ bg_clip_padding =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_clip_text : Css.Style
 bg_clip_text =
     Css.batch
@@ -9843,7 +10534,6 @@ bg_clip_text =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_contain : Css.Style
 bg_contain =
     Css.property "background-size" "contain"
@@ -9854,7 +10544,6 @@ bg_contain =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_cover : Css.Style
 bg_cover =
     Css.property "background-size" "cover"
@@ -9865,7 +10554,6 @@ bg_cover =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_current : Css.Style
 bg_current =
     Css.property "background-color" "currentColor"
@@ -9876,7 +10564,6 @@ bg_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_fixed : Css.Style
 bg_fixed =
     Css.property "background-attachment" "fixed"
@@ -9887,7 +10574,6 @@ bg_fixed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_b : Css.Style
 bg_gradient_to_b =
     Css.property "background-image" "linear-gradient(to bottom, var(--tw-gradient-stops))"
@@ -9898,7 +10584,6 @@ bg_gradient_to_b =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_bl : Css.Style
 bg_gradient_to_bl =
     Css.property "background-image" "linear-gradient(to bottom left, var(--tw-gradient-stops))"
@@ -9909,7 +10594,6 @@ bg_gradient_to_bl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_br : Css.Style
 bg_gradient_to_br =
     Css.property "background-image" "linear-gradient(to bottom right, var(--tw-gradient-stops))"
@@ -9920,7 +10604,6 @@ bg_gradient_to_br =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_l : Css.Style
 bg_gradient_to_l =
     Css.property "background-image" "linear-gradient(to left, var(--tw-gradient-stops))"
@@ -9931,7 +10614,6 @@ bg_gradient_to_l =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_r : Css.Style
 bg_gradient_to_r =
     Css.property "background-image" "linear-gradient(to right, var(--tw-gradient-stops))"
@@ -9942,7 +10624,6 @@ bg_gradient_to_r =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_t : Css.Style
 bg_gradient_to_t =
     Css.property "background-image" "linear-gradient(to top, var(--tw-gradient-stops))"
@@ -9953,7 +10634,6 @@ bg_gradient_to_t =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_tl : Css.Style
 bg_gradient_to_tl =
     Css.property "background-image" "linear-gradient(to top left, var(--tw-gradient-stops))"
@@ -9964,7 +10644,6 @@ bg_gradient_to_tl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gradient_to_tr : Css.Style
 bg_gradient_to_tr =
     Css.property "background-image" "linear-gradient(to top right, var(--tw-gradient-stops))"
@@ -9975,7 +10654,6 @@ bg_gradient_to_tr =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_100 : Css.Style
 bg_gray_100 =
     Css.batch
@@ -9989,7 +10667,6 @@ bg_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_200 : Css.Style
 bg_gray_200 =
     Css.batch
@@ -10003,7 +10680,6 @@ bg_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_300 : Css.Style
 bg_gray_300 =
     Css.batch
@@ -10017,7 +10693,6 @@ bg_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_400 : Css.Style
 bg_gray_400 =
     Css.batch
@@ -10031,7 +10706,6 @@ bg_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_50 : Css.Style
 bg_gray_50 =
     Css.batch
@@ -10045,7 +10719,6 @@ bg_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_500 : Css.Style
 bg_gray_500 =
     Css.batch
@@ -10059,7 +10732,6 @@ bg_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_600 : Css.Style
 bg_gray_600 =
     Css.batch
@@ -10073,7 +10745,6 @@ bg_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_700 : Css.Style
 bg_gray_700 =
     Css.batch
@@ -10087,7 +10758,6 @@ bg_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_800 : Css.Style
 bg_gray_800 =
     Css.batch
@@ -10101,7 +10771,6 @@ bg_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_gray_900 : Css.Style
 bg_gray_900 =
     Css.batch
@@ -10115,7 +10784,6 @@ bg_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_100 : Css.Style
 bg_green_100 =
     Css.batch
@@ -10129,7 +10797,6 @@ bg_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_200 : Css.Style
 bg_green_200 =
     Css.batch
@@ -10143,7 +10810,6 @@ bg_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_300 : Css.Style
 bg_green_300 =
     Css.batch
@@ -10157,7 +10823,6 @@ bg_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_400 : Css.Style
 bg_green_400 =
     Css.batch
@@ -10171,7 +10836,6 @@ bg_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_50 : Css.Style
 bg_green_50 =
     Css.batch
@@ -10185,7 +10849,6 @@ bg_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_500 : Css.Style
 bg_green_500 =
     Css.batch
@@ -10199,7 +10862,6 @@ bg_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_600 : Css.Style
 bg_green_600 =
     Css.batch
@@ -10213,7 +10875,6 @@ bg_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_700 : Css.Style
 bg_green_700 =
     Css.batch
@@ -10227,7 +10888,6 @@ bg_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_800 : Css.Style
 bg_green_800 =
     Css.batch
@@ -10241,7 +10901,6 @@ bg_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_green_900 : Css.Style
 bg_green_900 =
     Css.batch
@@ -10255,7 +10914,6 @@ bg_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_100 : Css.Style
 bg_indigo_100 =
     Css.batch
@@ -10269,7 +10927,6 @@ bg_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_200 : Css.Style
 bg_indigo_200 =
     Css.batch
@@ -10283,7 +10940,6 @@ bg_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_300 : Css.Style
 bg_indigo_300 =
     Css.batch
@@ -10297,7 +10953,6 @@ bg_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_400 : Css.Style
 bg_indigo_400 =
     Css.batch
@@ -10311,7 +10966,6 @@ bg_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_50 : Css.Style
 bg_indigo_50 =
     Css.batch
@@ -10325,7 +10979,6 @@ bg_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_500 : Css.Style
 bg_indigo_500 =
     Css.batch
@@ -10339,7 +10992,6 @@ bg_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_600 : Css.Style
 bg_indigo_600 =
     Css.batch
@@ -10353,7 +11005,6 @@ bg_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_700 : Css.Style
 bg_indigo_700 =
     Css.batch
@@ -10367,7 +11018,6 @@ bg_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_800 : Css.Style
 bg_indigo_800 =
     Css.batch
@@ -10381,7 +11031,6 @@ bg_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_indigo_900 : Css.Style
 bg_indigo_900 =
     Css.batch
@@ -10395,7 +11044,6 @@ bg_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_left : Css.Style
 bg_left =
     Css.property "background-position" "left"
@@ -10406,7 +11054,6 @@ bg_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_left_bottom : Css.Style
 bg_left_bottom =
     Css.property "background-position" "left bottom"
@@ -10417,7 +11064,6 @@ bg_left_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_left_top : Css.Style
 bg_left_top =
     Css.property "background-position" "left top"
@@ -10428,7 +11074,6 @@ bg_left_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_local : Css.Style
 bg_local =
     Css.property "background-attachment" "local"
@@ -10439,7 +11084,6 @@ bg_local =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_no_repeat : Css.Style
 bg_no_repeat =
     Css.property "background-repeat" "no-repeat"
@@ -10450,7 +11094,6 @@ bg_no_repeat =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_none : Css.Style
 bg_none =
     Css.property "background-image" "none"
@@ -10461,7 +11104,6 @@ bg_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_0 : Css.Style
 bg_opacity_0 =
     Css.property "--tw-bg-opacity" "0"
@@ -10472,7 +11114,6 @@ bg_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_10 : Css.Style
 bg_opacity_10 =
     Css.property "--tw-bg-opacity" "0.1"
@@ -10483,7 +11124,6 @@ bg_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_100 : Css.Style
 bg_opacity_100 =
     Css.property "--tw-bg-opacity" "1"
@@ -10494,7 +11134,6 @@ bg_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_20 : Css.Style
 bg_opacity_20 =
     Css.property "--tw-bg-opacity" "0.2"
@@ -10505,7 +11144,6 @@ bg_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_25 : Css.Style
 bg_opacity_25 =
     Css.property "--tw-bg-opacity" "0.25"
@@ -10516,7 +11154,6 @@ bg_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_30 : Css.Style
 bg_opacity_30 =
     Css.property "--tw-bg-opacity" "0.3"
@@ -10527,7 +11164,6 @@ bg_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_40 : Css.Style
 bg_opacity_40 =
     Css.property "--tw-bg-opacity" "0.4"
@@ -10538,7 +11174,6 @@ bg_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_5 : Css.Style
 bg_opacity_5 =
     Css.property "--tw-bg-opacity" "0.05"
@@ -10549,7 +11184,6 @@ bg_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_50 : Css.Style
 bg_opacity_50 =
     Css.property "--tw-bg-opacity" "0.5"
@@ -10560,7 +11194,6 @@ bg_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_60 : Css.Style
 bg_opacity_60 =
     Css.property "--tw-bg-opacity" "0.6"
@@ -10571,7 +11204,6 @@ bg_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_70 : Css.Style
 bg_opacity_70 =
     Css.property "--tw-bg-opacity" "0.7"
@@ -10582,7 +11214,6 @@ bg_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_75 : Css.Style
 bg_opacity_75 =
     Css.property "--tw-bg-opacity" "0.75"
@@ -10593,7 +11224,6 @@ bg_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_80 : Css.Style
 bg_opacity_80 =
     Css.property "--tw-bg-opacity" "0.8"
@@ -10604,7 +11234,6 @@ bg_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_90 : Css.Style
 bg_opacity_90 =
     Css.property "--tw-bg-opacity" "0.9"
@@ -10615,7 +11244,6 @@ bg_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_opacity_95 : Css.Style
 bg_opacity_95 =
     Css.property "--tw-bg-opacity" "0.95"
@@ -10626,7 +11254,6 @@ bg_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_100 : Css.Style
 bg_pink_100 =
     Css.batch
@@ -10640,7 +11267,6 @@ bg_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_200 : Css.Style
 bg_pink_200 =
     Css.batch
@@ -10654,7 +11280,6 @@ bg_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_300 : Css.Style
 bg_pink_300 =
     Css.batch
@@ -10668,7 +11293,6 @@ bg_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_400 : Css.Style
 bg_pink_400 =
     Css.batch
@@ -10682,7 +11306,6 @@ bg_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_50 : Css.Style
 bg_pink_50 =
     Css.batch
@@ -10696,7 +11319,6 @@ bg_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_500 : Css.Style
 bg_pink_500 =
     Css.batch
@@ -10710,7 +11332,6 @@ bg_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_600 : Css.Style
 bg_pink_600 =
     Css.batch
@@ -10724,7 +11345,6 @@ bg_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_700 : Css.Style
 bg_pink_700 =
     Css.batch
@@ -10738,7 +11358,6 @@ bg_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_800 : Css.Style
 bg_pink_800 =
     Css.batch
@@ -10752,7 +11371,6 @@ bg_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_pink_900 : Css.Style
 bg_pink_900 =
     Css.batch
@@ -10766,7 +11384,6 @@ bg_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_100 : Css.Style
 bg_purple_100 =
     Css.batch
@@ -10780,7 +11397,6 @@ bg_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_200 : Css.Style
 bg_purple_200 =
     Css.batch
@@ -10794,7 +11410,6 @@ bg_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_300 : Css.Style
 bg_purple_300 =
     Css.batch
@@ -10808,7 +11423,6 @@ bg_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_400 : Css.Style
 bg_purple_400 =
     Css.batch
@@ -10822,7 +11436,6 @@ bg_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_50 : Css.Style
 bg_purple_50 =
     Css.batch
@@ -10836,7 +11449,6 @@ bg_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_500 : Css.Style
 bg_purple_500 =
     Css.batch
@@ -10850,7 +11462,6 @@ bg_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_600 : Css.Style
 bg_purple_600 =
     Css.batch
@@ -10864,7 +11475,6 @@ bg_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_700 : Css.Style
 bg_purple_700 =
     Css.batch
@@ -10878,7 +11488,6 @@ bg_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_800 : Css.Style
 bg_purple_800 =
     Css.batch
@@ -10892,7 +11501,6 @@ bg_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_purple_900 : Css.Style
 bg_purple_900 =
     Css.batch
@@ -10906,7 +11514,6 @@ bg_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_100 : Css.Style
 bg_red_100 =
     Css.batch
@@ -10920,7 +11527,6 @@ bg_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_200 : Css.Style
 bg_red_200 =
     Css.batch
@@ -10934,7 +11540,6 @@ bg_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_300 : Css.Style
 bg_red_300 =
     Css.batch
@@ -10948,7 +11553,6 @@ bg_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_400 : Css.Style
 bg_red_400 =
     Css.batch
@@ -10962,7 +11566,6 @@ bg_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_50 : Css.Style
 bg_red_50 =
     Css.batch
@@ -10976,7 +11579,6 @@ bg_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_500 : Css.Style
 bg_red_500 =
     Css.batch
@@ -10990,7 +11592,6 @@ bg_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_600 : Css.Style
 bg_red_600 =
     Css.batch
@@ -11004,7 +11605,6 @@ bg_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_700 : Css.Style
 bg_red_700 =
     Css.batch
@@ -11018,7 +11618,6 @@ bg_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_800 : Css.Style
 bg_red_800 =
     Css.batch
@@ -11032,7 +11631,6 @@ bg_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_red_900 : Css.Style
 bg_red_900 =
     Css.batch
@@ -11046,7 +11644,6 @@ bg_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_repeat : Css.Style
 bg_repeat =
     Css.property "background-repeat" "repeat"
@@ -11057,7 +11654,6 @@ bg_repeat =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_repeat_round : Css.Style
 bg_repeat_round =
     Css.property "background-repeat" "round"
@@ -11068,7 +11664,6 @@ bg_repeat_round =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_repeat_space : Css.Style
 bg_repeat_space =
     Css.property "background-repeat" "space"
@@ -11079,7 +11674,6 @@ bg_repeat_space =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_repeat_x : Css.Style
 bg_repeat_x =
     Css.property "background-repeat" "repeat-x"
@@ -11090,7 +11684,6 @@ bg_repeat_x =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_repeat_y : Css.Style
 bg_repeat_y =
     Css.property "background-repeat" "repeat-y"
@@ -11101,7 +11694,6 @@ bg_repeat_y =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_right : Css.Style
 bg_right =
     Css.property "background-position" "right"
@@ -11112,7 +11704,6 @@ bg_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_right_bottom : Css.Style
 bg_right_bottom =
     Css.property "background-position" "right bottom"
@@ -11123,7 +11714,6 @@ bg_right_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_right_top : Css.Style
 bg_right_top =
     Css.property "background-position" "right top"
@@ -11134,7 +11724,6 @@ bg_right_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_scroll : Css.Style
 bg_scroll =
     Css.property "background-attachment" "scroll"
@@ -11145,7 +11734,6 @@ bg_scroll =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_top : Css.Style
 bg_top =
     Css.property "background-position" "top"
@@ -11156,7 +11744,6 @@ bg_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_transparent : Css.Style
 bg_transparent =
     Css.property "background-color" "transparent"
@@ -11167,7 +11754,6 @@ bg_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_white : Css.Style
 bg_white =
     Css.batch
@@ -11181,7 +11767,6 @@ bg_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_100 : Css.Style
 bg_yellow_100 =
     Css.batch
@@ -11195,7 +11780,6 @@ bg_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_200 : Css.Style
 bg_yellow_200 =
     Css.batch
@@ -11209,7 +11793,6 @@ bg_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_300 : Css.Style
 bg_yellow_300 =
     Css.batch
@@ -11223,7 +11806,6 @@ bg_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_400 : Css.Style
 bg_yellow_400 =
     Css.batch
@@ -11237,7 +11819,6 @@ bg_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_50 : Css.Style
 bg_yellow_50 =
     Css.batch
@@ -11251,7 +11832,6 @@ bg_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_500 : Css.Style
 bg_yellow_500 =
     Css.batch
@@ -11265,7 +11845,6 @@ bg_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_600 : Css.Style
 bg_yellow_600 =
     Css.batch
@@ -11279,7 +11858,6 @@ bg_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_700 : Css.Style
 bg_yellow_700 =
     Css.batch
@@ -11293,7 +11871,6 @@ bg_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_800 : Css.Style
 bg_yellow_800 =
     Css.batch
@@ -11307,7 +11884,6 @@ bg_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bg_yellow_900 : Css.Style
 bg_yellow_900 =
     Css.batch
@@ -11321,7 +11897,6 @@ bg_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 block : Css.Style
 block =
     Css.property "display" "block"
@@ -11332,7 +11907,6 @@ block =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur : Css.Style
 blur =
     Css.property "--tw-blur" "blur(8px)"
@@ -11343,7 +11917,6 @@ blur =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_0 : Css.Style
 blur_0 =
     Css.property "--tw-blur" "blur(0)"
@@ -11354,7 +11927,6 @@ blur_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_2xl : Css.Style
 blur_2xl =
     Css.property "--tw-blur" "blur(40px)"
@@ -11365,7 +11937,6 @@ blur_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_3xl : Css.Style
 blur_3xl =
     Css.property "--tw-blur" "blur(64px)"
@@ -11376,7 +11947,6 @@ blur_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_lg : Css.Style
 blur_lg =
     Css.property "--tw-blur" "blur(16px)"
@@ -11387,7 +11957,6 @@ blur_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_md : Css.Style
 blur_md =
     Css.property "--tw-blur" "blur(12px)"
@@ -11398,7 +11967,6 @@ blur_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_sm : Css.Style
 blur_sm =
     Css.property "--tw-blur" "blur(4px)"
@@ -11409,7 +11977,6 @@ blur_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 blur_xl : Css.Style
 blur_xl =
     Css.property "--tw-blur" "blur(24px)"
@@ -11420,7 +11987,6 @@ blur_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border : Css.Style
 border =
     Css.property "border-width" "1px"
@@ -11431,7 +11997,6 @@ border =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_0 : Css.Style
 border_0 =
     Css.property "border-width" "0px"
@@ -11442,7 +12007,6 @@ border_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_2 : Css.Style
 border_2 =
     Css.property "border-width" "2px"
@@ -11453,7 +12017,6 @@ border_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_4 : Css.Style
 border_4 =
     Css.property "border-width" "4px"
@@ -11464,7 +12027,6 @@ border_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_8 : Css.Style
 border_8 =
     Css.property "border-width" "8px"
@@ -11475,7 +12037,6 @@ border_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_b : Css.Style
 border_b =
     Css.property "border-bottom-width" "1px"
@@ -11486,7 +12047,6 @@ border_b =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_b_0 : Css.Style
 border_b_0 =
     Css.property "border-bottom-width" "0px"
@@ -11497,7 +12057,6 @@ border_b_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_b_2 : Css.Style
 border_b_2 =
     Css.property "border-bottom-width" "2px"
@@ -11508,7 +12067,6 @@ border_b_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_b_4 : Css.Style
 border_b_4 =
     Css.property "border-bottom-width" "4px"
@@ -11519,7 +12077,6 @@ border_b_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_b_8 : Css.Style
 border_b_8 =
     Css.property "border-bottom-width" "8px"
@@ -11530,7 +12087,6 @@ border_b_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_black : Css.Style
 border_black =
     Css.batch
@@ -11544,7 +12100,6 @@ border_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_100 : Css.Style
 border_blue_100 =
     Css.batch
@@ -11558,7 +12113,6 @@ border_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_200 : Css.Style
 border_blue_200 =
     Css.batch
@@ -11572,7 +12126,6 @@ border_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_300 : Css.Style
 border_blue_300 =
     Css.batch
@@ -11586,7 +12139,6 @@ border_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_400 : Css.Style
 border_blue_400 =
     Css.batch
@@ -11600,7 +12152,6 @@ border_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_50 : Css.Style
 border_blue_50 =
     Css.batch
@@ -11614,7 +12165,6 @@ border_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_500 : Css.Style
 border_blue_500 =
     Css.batch
@@ -11628,7 +12178,6 @@ border_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_600 : Css.Style
 border_blue_600 =
     Css.batch
@@ -11642,7 +12191,6 @@ border_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_700 : Css.Style
 border_blue_700 =
     Css.batch
@@ -11656,7 +12204,6 @@ border_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_800 : Css.Style
 border_blue_800 =
     Css.batch
@@ -11670,7 +12217,6 @@ border_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_blue_900 : Css.Style
 border_blue_900 =
     Css.batch
@@ -11684,7 +12230,6 @@ border_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_collapse : Css.Style
 border_collapse =
     Css.property "border-collapse" "collapse"
@@ -11695,7 +12240,6 @@ border_collapse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_current : Css.Style
 border_current =
     Css.property "border-color" "currentColor"
@@ -11706,7 +12250,6 @@ border_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_dashed : Css.Style
 border_dashed =
     Css.property "border-style" "dashed"
@@ -11717,7 +12260,6 @@ border_dashed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_dotted : Css.Style
 border_dotted =
     Css.property "border-style" "dotted"
@@ -11728,7 +12270,6 @@ border_dotted =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_double : Css.Style
 border_double =
     Css.property "border-style" "double"
@@ -11739,7 +12280,6 @@ border_double =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_100 : Css.Style
 border_gray_100 =
     Css.batch
@@ -11753,7 +12293,6 @@ border_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_200 : Css.Style
 border_gray_200 =
     Css.batch
@@ -11767,7 +12306,6 @@ border_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_300 : Css.Style
 border_gray_300 =
     Css.batch
@@ -11781,7 +12319,6 @@ border_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_400 : Css.Style
 border_gray_400 =
     Css.batch
@@ -11795,7 +12332,6 @@ border_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_50 : Css.Style
 border_gray_50 =
     Css.batch
@@ -11809,7 +12345,6 @@ border_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_500 : Css.Style
 border_gray_500 =
     Css.batch
@@ -11823,7 +12358,6 @@ border_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_600 : Css.Style
 border_gray_600 =
     Css.batch
@@ -11837,7 +12371,6 @@ border_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_700 : Css.Style
 border_gray_700 =
     Css.batch
@@ -11851,7 +12384,6 @@ border_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_800 : Css.Style
 border_gray_800 =
     Css.batch
@@ -11865,7 +12397,6 @@ border_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_gray_900 : Css.Style
 border_gray_900 =
     Css.batch
@@ -11879,7 +12410,6 @@ border_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_100 : Css.Style
 border_green_100 =
     Css.batch
@@ -11893,7 +12423,6 @@ border_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_200 : Css.Style
 border_green_200 =
     Css.batch
@@ -11907,7 +12436,6 @@ border_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_300 : Css.Style
 border_green_300 =
     Css.batch
@@ -11921,7 +12449,6 @@ border_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_400 : Css.Style
 border_green_400 =
     Css.batch
@@ -11935,7 +12462,6 @@ border_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_50 : Css.Style
 border_green_50 =
     Css.batch
@@ -11949,7 +12475,6 @@ border_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_500 : Css.Style
 border_green_500 =
     Css.batch
@@ -11963,7 +12488,6 @@ border_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_600 : Css.Style
 border_green_600 =
     Css.batch
@@ -11977,7 +12501,6 @@ border_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_700 : Css.Style
 border_green_700 =
     Css.batch
@@ -11991,7 +12514,6 @@ border_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_800 : Css.Style
 border_green_800 =
     Css.batch
@@ -12005,7 +12527,6 @@ border_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_green_900 : Css.Style
 border_green_900 =
     Css.batch
@@ -12019,7 +12540,6 @@ border_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_100 : Css.Style
 border_indigo_100 =
     Css.batch
@@ -12033,7 +12553,6 @@ border_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_200 : Css.Style
 border_indigo_200 =
     Css.batch
@@ -12047,7 +12566,6 @@ border_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_300 : Css.Style
 border_indigo_300 =
     Css.batch
@@ -12061,7 +12579,6 @@ border_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_400 : Css.Style
 border_indigo_400 =
     Css.batch
@@ -12075,7 +12592,6 @@ border_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_50 : Css.Style
 border_indigo_50 =
     Css.batch
@@ -12089,7 +12605,6 @@ border_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_500 : Css.Style
 border_indigo_500 =
     Css.batch
@@ -12103,7 +12618,6 @@ border_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_600 : Css.Style
 border_indigo_600 =
     Css.batch
@@ -12117,7 +12631,6 @@ border_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_700 : Css.Style
 border_indigo_700 =
     Css.batch
@@ -12131,7 +12644,6 @@ border_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_800 : Css.Style
 border_indigo_800 =
     Css.batch
@@ -12145,7 +12657,6 @@ border_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_indigo_900 : Css.Style
 border_indigo_900 =
     Css.batch
@@ -12159,7 +12670,6 @@ border_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_l : Css.Style
 border_l =
     Css.property "border-left-width" "1px"
@@ -12170,7 +12680,6 @@ border_l =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_l_0 : Css.Style
 border_l_0 =
     Css.property "border-left-width" "0px"
@@ -12181,7 +12690,6 @@ border_l_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_l_2 : Css.Style
 border_l_2 =
     Css.property "border-left-width" "2px"
@@ -12192,7 +12700,6 @@ border_l_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_l_4 : Css.Style
 border_l_4 =
     Css.property "border-left-width" "4px"
@@ -12203,7 +12710,6 @@ border_l_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_l_8 : Css.Style
 border_l_8 =
     Css.property "border-left-width" "8px"
@@ -12214,7 +12720,6 @@ border_l_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_none : Css.Style
 border_none =
     Css.property "border-style" "none"
@@ -12225,7 +12730,6 @@ border_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_0 : Css.Style
 border_opacity_0 =
     Css.property "--tw-border-opacity" "0"
@@ -12236,7 +12740,6 @@ border_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_10 : Css.Style
 border_opacity_10 =
     Css.property "--tw-border-opacity" "0.1"
@@ -12247,7 +12750,6 @@ border_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_100 : Css.Style
 border_opacity_100 =
     Css.property "--tw-border-opacity" "1"
@@ -12258,7 +12760,6 @@ border_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_20 : Css.Style
 border_opacity_20 =
     Css.property "--tw-border-opacity" "0.2"
@@ -12269,7 +12770,6 @@ border_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_25 : Css.Style
 border_opacity_25 =
     Css.property "--tw-border-opacity" "0.25"
@@ -12280,7 +12780,6 @@ border_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_30 : Css.Style
 border_opacity_30 =
     Css.property "--tw-border-opacity" "0.3"
@@ -12291,7 +12790,6 @@ border_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_40 : Css.Style
 border_opacity_40 =
     Css.property "--tw-border-opacity" "0.4"
@@ -12302,7 +12800,6 @@ border_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_5 : Css.Style
 border_opacity_5 =
     Css.property "--tw-border-opacity" "0.05"
@@ -12313,7 +12810,6 @@ border_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_50 : Css.Style
 border_opacity_50 =
     Css.property "--tw-border-opacity" "0.5"
@@ -12324,7 +12820,6 @@ border_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_60 : Css.Style
 border_opacity_60 =
     Css.property "--tw-border-opacity" "0.6"
@@ -12335,7 +12830,6 @@ border_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_70 : Css.Style
 border_opacity_70 =
     Css.property "--tw-border-opacity" "0.7"
@@ -12346,7 +12840,6 @@ border_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_75 : Css.Style
 border_opacity_75 =
     Css.property "--tw-border-opacity" "0.75"
@@ -12357,7 +12850,6 @@ border_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_80 : Css.Style
 border_opacity_80 =
     Css.property "--tw-border-opacity" "0.8"
@@ -12368,7 +12860,6 @@ border_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_90 : Css.Style
 border_opacity_90 =
     Css.property "--tw-border-opacity" "0.9"
@@ -12379,7 +12870,6 @@ border_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_opacity_95 : Css.Style
 border_opacity_95 =
     Css.property "--tw-border-opacity" "0.95"
@@ -12390,7 +12880,6 @@ border_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_100 : Css.Style
 border_pink_100 =
     Css.batch
@@ -12404,7 +12893,6 @@ border_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_200 : Css.Style
 border_pink_200 =
     Css.batch
@@ -12418,7 +12906,6 @@ border_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_300 : Css.Style
 border_pink_300 =
     Css.batch
@@ -12432,7 +12919,6 @@ border_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_400 : Css.Style
 border_pink_400 =
     Css.batch
@@ -12446,7 +12932,6 @@ border_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_50 : Css.Style
 border_pink_50 =
     Css.batch
@@ -12460,7 +12945,6 @@ border_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_500 : Css.Style
 border_pink_500 =
     Css.batch
@@ -12474,7 +12958,6 @@ border_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_600 : Css.Style
 border_pink_600 =
     Css.batch
@@ -12488,7 +12971,6 @@ border_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_700 : Css.Style
 border_pink_700 =
     Css.batch
@@ -12502,7 +12984,6 @@ border_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_800 : Css.Style
 border_pink_800 =
     Css.batch
@@ -12516,7 +12997,6 @@ border_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_pink_900 : Css.Style
 border_pink_900 =
     Css.batch
@@ -12530,7 +13010,6 @@ border_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_100 : Css.Style
 border_purple_100 =
     Css.batch
@@ -12544,7 +13023,6 @@ border_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_200 : Css.Style
 border_purple_200 =
     Css.batch
@@ -12558,7 +13036,6 @@ border_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_300 : Css.Style
 border_purple_300 =
     Css.batch
@@ -12572,7 +13049,6 @@ border_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_400 : Css.Style
 border_purple_400 =
     Css.batch
@@ -12586,7 +13062,6 @@ border_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_50 : Css.Style
 border_purple_50 =
     Css.batch
@@ -12600,7 +13075,6 @@ border_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_500 : Css.Style
 border_purple_500 =
     Css.batch
@@ -12614,7 +13088,6 @@ border_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_600 : Css.Style
 border_purple_600 =
     Css.batch
@@ -12628,7 +13101,6 @@ border_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_700 : Css.Style
 border_purple_700 =
     Css.batch
@@ -12642,7 +13114,6 @@ border_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_800 : Css.Style
 border_purple_800 =
     Css.batch
@@ -12656,7 +13127,6 @@ border_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_purple_900 : Css.Style
 border_purple_900 =
     Css.batch
@@ -12670,7 +13140,6 @@ border_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_r : Css.Style
 border_r =
     Css.property "border-right-width" "1px"
@@ -12681,7 +13150,6 @@ border_r =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_r_0 : Css.Style
 border_r_0 =
     Css.property "border-right-width" "0px"
@@ -12692,7 +13160,6 @@ border_r_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_r_2 : Css.Style
 border_r_2 =
     Css.property "border-right-width" "2px"
@@ -12703,7 +13170,6 @@ border_r_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_r_4 : Css.Style
 border_r_4 =
     Css.property "border-right-width" "4px"
@@ -12714,7 +13180,6 @@ border_r_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_r_8 : Css.Style
 border_r_8 =
     Css.property "border-right-width" "8px"
@@ -12725,7 +13190,6 @@ border_r_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_100 : Css.Style
 border_red_100 =
     Css.batch
@@ -12739,7 +13203,6 @@ border_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_200 : Css.Style
 border_red_200 =
     Css.batch
@@ -12753,7 +13216,6 @@ border_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_300 : Css.Style
 border_red_300 =
     Css.batch
@@ -12767,7 +13229,6 @@ border_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_400 : Css.Style
 border_red_400 =
     Css.batch
@@ -12781,7 +13242,6 @@ border_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_50 : Css.Style
 border_red_50 =
     Css.batch
@@ -12795,7 +13255,6 @@ border_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_500 : Css.Style
 border_red_500 =
     Css.batch
@@ -12809,7 +13268,6 @@ border_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_600 : Css.Style
 border_red_600 =
     Css.batch
@@ -12823,7 +13281,6 @@ border_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_700 : Css.Style
 border_red_700 =
     Css.batch
@@ -12837,7 +13294,6 @@ border_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_800 : Css.Style
 border_red_800 =
     Css.batch
@@ -12851,7 +13307,6 @@ border_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_red_900 : Css.Style
 border_red_900 =
     Css.batch
@@ -12865,7 +13320,6 @@ border_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_separate : Css.Style
 border_separate =
     Css.property "border-collapse" "separate"
@@ -12876,7 +13330,6 @@ border_separate =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_solid : Css.Style
 border_solid =
     Css.property "border-style" "solid"
@@ -12887,7 +13340,6 @@ border_solid =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_t : Css.Style
 border_t =
     Css.property "border-top-width" "1px"
@@ -12898,7 +13350,6 @@ border_t =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_t_0 : Css.Style
 border_t_0 =
     Css.property "border-top-width" "0px"
@@ -12909,7 +13360,6 @@ border_t_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_t_2 : Css.Style
 border_t_2 =
     Css.property "border-top-width" "2px"
@@ -12920,7 +13370,6 @@ border_t_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_t_4 : Css.Style
 border_t_4 =
     Css.property "border-top-width" "4px"
@@ -12931,7 +13380,6 @@ border_t_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_t_8 : Css.Style
 border_t_8 =
     Css.property "border-top-width" "8px"
@@ -12942,7 +13390,6 @@ border_t_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_transparent : Css.Style
 border_transparent =
     Css.property "border-color" "transparent"
@@ -12953,7 +13400,6 @@ border_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_white : Css.Style
 border_white =
     Css.batch
@@ -12967,7 +13413,6 @@ border_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_100 : Css.Style
 border_yellow_100 =
     Css.batch
@@ -12981,7 +13426,6 @@ border_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_200 : Css.Style
 border_yellow_200 =
     Css.batch
@@ -12995,7 +13439,6 @@ border_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_300 : Css.Style
 border_yellow_300 =
     Css.batch
@@ -13009,7 +13452,6 @@ border_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_400 : Css.Style
 border_yellow_400 =
     Css.batch
@@ -13023,7 +13465,6 @@ border_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_50 : Css.Style
 border_yellow_50 =
     Css.batch
@@ -13037,7 +13478,6 @@ border_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_500 : Css.Style
 border_yellow_500 =
     Css.batch
@@ -13051,7 +13491,6 @@ border_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_600 : Css.Style
 border_yellow_600 =
     Css.batch
@@ -13065,7 +13504,6 @@ border_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_700 : Css.Style
 border_yellow_700 =
     Css.batch
@@ -13079,7 +13517,6 @@ border_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_800 : Css.Style
 border_yellow_800 =
     Css.batch
@@ -13093,7 +13530,6 @@ border_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 border_yellow_900 : Css.Style
 border_yellow_900 =
     Css.batch
@@ -13107,7 +13543,6 @@ border_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_0 : Css.Style
 bottom_0 =
     Css.property "bottom" "0px"
@@ -13118,7 +13553,6 @@ bottom_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_0_dot_5 : Css.Style
 bottom_0_dot_5 =
     Css.property "bottom" "0.125rem"
@@ -13129,7 +13563,6 @@ bottom_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_1 : Css.Style
 bottom_1 =
     Css.property "bottom" "0.25rem"
@@ -13140,7 +13573,6 @@ bottom_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_10 : Css.Style
 bottom_10 =
     Css.property "bottom" "2.5rem"
@@ -13151,7 +13583,6 @@ bottom_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_11 : Css.Style
 bottom_11 =
     Css.property "bottom" "2.75rem"
@@ -13162,7 +13593,6 @@ bottom_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_12 : Css.Style
 bottom_12 =
     Css.property "bottom" "3rem"
@@ -13173,7 +13603,6 @@ bottom_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_14 : Css.Style
 bottom_14 =
     Css.property "bottom" "3.5rem"
@@ -13184,7 +13613,6 @@ bottom_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_16 : Css.Style
 bottom_16 =
     Css.property "bottom" "4rem"
@@ -13195,7 +13623,6 @@ bottom_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_1_dot_5 : Css.Style
 bottom_1_dot_5 =
     Css.property "bottom" "0.375rem"
@@ -13206,7 +13633,6 @@ bottom_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_1over2 : Css.Style
 bottom_1over2 =
     Css.property "bottom" "50%"
@@ -13217,7 +13643,6 @@ bottom_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_1over3 : Css.Style
 bottom_1over3 =
     Css.property "bottom" "33.333333%"
@@ -13228,7 +13653,6 @@ bottom_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_1over4 : Css.Style
 bottom_1over4 =
     Css.property "bottom" "25%"
@@ -13239,7 +13663,6 @@ bottom_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_2 : Css.Style
 bottom_2 =
     Css.property "bottom" "0.5rem"
@@ -13250,7 +13673,6 @@ bottom_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_20 : Css.Style
 bottom_20 =
     Css.property "bottom" "5rem"
@@ -13261,7 +13683,6 @@ bottom_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_24 : Css.Style
 bottom_24 =
     Css.property "bottom" "6rem"
@@ -13272,7 +13693,6 @@ bottom_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_28 : Css.Style
 bottom_28 =
     Css.property "bottom" "7rem"
@@ -13283,7 +13703,6 @@ bottom_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_2_dot_5 : Css.Style
 bottom_2_dot_5 =
     Css.property "bottom" "0.625rem"
@@ -13294,7 +13713,6 @@ bottom_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_2over3 : Css.Style
 bottom_2over3 =
     Css.property "bottom" "66.666667%"
@@ -13305,7 +13723,6 @@ bottom_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_2over4 : Css.Style
 bottom_2over4 =
     Css.property "bottom" "50%"
@@ -13316,7 +13733,6 @@ bottom_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_3 : Css.Style
 bottom_3 =
     Css.property "bottom" "0.75rem"
@@ -13327,7 +13743,6 @@ bottom_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_32 : Css.Style
 bottom_32 =
     Css.property "bottom" "8rem"
@@ -13338,7 +13753,6 @@ bottom_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_36 : Css.Style
 bottom_36 =
     Css.property "bottom" "9rem"
@@ -13349,7 +13763,6 @@ bottom_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_3_dot_5 : Css.Style
 bottom_3_dot_5 =
     Css.property "bottom" "0.875rem"
@@ -13360,7 +13773,6 @@ bottom_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_3over4 : Css.Style
 bottom_3over4 =
     Css.property "bottom" "75%"
@@ -13371,7 +13783,6 @@ bottom_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_4 : Css.Style
 bottom_4 =
     Css.property "bottom" "1rem"
@@ -13382,7 +13793,6 @@ bottom_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_40 : Css.Style
 bottom_40 =
     Css.property "bottom" "10rem"
@@ -13393,7 +13803,6 @@ bottom_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_44 : Css.Style
 bottom_44 =
     Css.property "bottom" "11rem"
@@ -13404,7 +13813,6 @@ bottom_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_48 : Css.Style
 bottom_48 =
     Css.property "bottom" "12rem"
@@ -13415,7 +13823,6 @@ bottom_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_5 : Css.Style
 bottom_5 =
     Css.property "bottom" "1.25rem"
@@ -13426,7 +13833,6 @@ bottom_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_52 : Css.Style
 bottom_52 =
     Css.property "bottom" "13rem"
@@ -13437,7 +13843,6 @@ bottom_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_56 : Css.Style
 bottom_56 =
     Css.property "bottom" "14rem"
@@ -13448,7 +13853,6 @@ bottom_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_6 : Css.Style
 bottom_6 =
     Css.property "bottom" "1.5rem"
@@ -13459,7 +13863,6 @@ bottom_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_60 : Css.Style
 bottom_60 =
     Css.property "bottom" "15rem"
@@ -13470,7 +13873,6 @@ bottom_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_64 : Css.Style
 bottom_64 =
     Css.property "bottom" "16rem"
@@ -13481,7 +13883,6 @@ bottom_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_7 : Css.Style
 bottom_7 =
     Css.property "bottom" "1.75rem"
@@ -13492,7 +13893,6 @@ bottom_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_72 : Css.Style
 bottom_72 =
     Css.property "bottom" "18rem"
@@ -13503,7 +13903,6 @@ bottom_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_8 : Css.Style
 bottom_8 =
     Css.property "bottom" "2rem"
@@ -13514,7 +13913,6 @@ bottom_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_80 : Css.Style
 bottom_80 =
     Css.property "bottom" "20rem"
@@ -13525,7 +13923,6 @@ bottom_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_9 : Css.Style
 bottom_9 =
     Css.property "bottom" "2.25rem"
@@ -13536,7 +13933,6 @@ bottom_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_96 : Css.Style
 bottom_96 =
     Css.property "bottom" "24rem"
@@ -13547,7 +13943,6 @@ bottom_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_auto : Css.Style
 bottom_auto =
     Css.property "bottom" "auto"
@@ -13558,7 +13953,6 @@ bottom_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_full : Css.Style
 bottom_full =
     Css.property "bottom" "100%"
@@ -13569,7 +13963,6 @@ bottom_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 bottom_px : Css.Style
 bottom_px =
     Css.property "bottom" "1px"
@@ -13580,7 +13973,6 @@ bottom_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 box_border : Css.Style
 box_border =
     Css.property "box-sizing" "border-box"
@@ -13591,7 +13983,6 @@ box_border =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 box_content : Css.Style
 box_content =
     Css.property "box-sizing" "content-box"
@@ -13602,7 +13993,6 @@ box_content =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 break_all : Css.Style
 break_all =
     Css.property "word-break" "break-all"
@@ -13613,7 +14003,6 @@ break_all =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 break_normal : Css.Style
 break_normal =
     Css.batch
@@ -13627,7 +14016,6 @@ break_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 break_words : Css.Style
 break_words =
     Css.property "overflow-wrap" "break-word"
@@ -13638,7 +14026,6 @@ break_words =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_0 : Css.Style
 brightness_0 =
     Css.property "--tw-brightness" "brightness(0)"
@@ -13649,7 +14036,6 @@ brightness_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_100 : Css.Style
 brightness_100 =
     Css.property "--tw-brightness" "brightness(1)"
@@ -13660,7 +14046,6 @@ brightness_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_105 : Css.Style
 brightness_105 =
     Css.property "--tw-brightness" "brightness(1.05)"
@@ -13671,7 +14056,6 @@ brightness_105 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_110 : Css.Style
 brightness_110 =
     Css.property "--tw-brightness" "brightness(1.1)"
@@ -13682,7 +14066,6 @@ brightness_110 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_125 : Css.Style
 brightness_125 =
     Css.property "--tw-brightness" "brightness(1.25)"
@@ -13693,7 +14076,6 @@ brightness_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_150 : Css.Style
 brightness_150 =
     Css.property "--tw-brightness" "brightness(1.5)"
@@ -13704,7 +14086,6 @@ brightness_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_200 : Css.Style
 brightness_200 =
     Css.property "--tw-brightness" "brightness(2)"
@@ -13715,7 +14096,6 @@ brightness_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_50 : Css.Style
 brightness_50 =
     Css.property "--tw-brightness" "brightness(.5)"
@@ -13726,7 +14106,6 @@ brightness_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_75 : Css.Style
 brightness_75 =
     Css.property "--tw-brightness" "brightness(.75)"
@@ -13737,7 +14116,6 @@ brightness_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_90 : Css.Style
 brightness_90 =
     Css.property "--tw-brightness" "brightness(.9)"
@@ -13748,7 +14126,6 @@ brightness_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 brightness_95 : Css.Style
 brightness_95 =
     Css.property "--tw-brightness" "brightness(.95)"
@@ -13759,7 +14136,6 @@ brightness_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 capitalize : Css.Style
 capitalize =
     Css.property "text-transform" "capitalize"
@@ -13770,7 +14146,6 @@ capitalize =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 clear_both : Css.Style
 clear_both =
     Css.property "clear" "both"
@@ -13781,7 +14156,6 @@ clear_both =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 clear_left : Css.Style
 clear_left =
     Css.property "clear" "left"
@@ -13792,7 +14166,6 @@ clear_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 clear_none : Css.Style
 clear_none =
     Css.property "clear" "none"
@@ -13803,7 +14176,6 @@ clear_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 clear_right : Css.Style
 clear_right =
     Css.property "clear" "right"
@@ -13814,7 +14186,6 @@ clear_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_auto : Css.Style
 col_auto =
     Css.property "grid-column" "auto"
@@ -13825,7 +14196,6 @@ col_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_1 : Css.Style
 col_end_1 =
     Css.property "grid-column-end" "1"
@@ -13836,7 +14206,6 @@ col_end_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_10 : Css.Style
 col_end_10 =
     Css.property "grid-column-end" "10"
@@ -13847,7 +14216,6 @@ col_end_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_11 : Css.Style
 col_end_11 =
     Css.property "grid-column-end" "11"
@@ -13858,7 +14226,6 @@ col_end_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_12 : Css.Style
 col_end_12 =
     Css.property "grid-column-end" "12"
@@ -13869,7 +14236,6 @@ col_end_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_13 : Css.Style
 col_end_13 =
     Css.property "grid-column-end" "13"
@@ -13880,7 +14246,6 @@ col_end_13 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_2 : Css.Style
 col_end_2 =
     Css.property "grid-column-end" "2"
@@ -13891,7 +14256,6 @@ col_end_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_3 : Css.Style
 col_end_3 =
     Css.property "grid-column-end" "3"
@@ -13902,7 +14266,6 @@ col_end_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_4 : Css.Style
 col_end_4 =
     Css.property "grid-column-end" "4"
@@ -13913,7 +14276,6 @@ col_end_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_5 : Css.Style
 col_end_5 =
     Css.property "grid-column-end" "5"
@@ -13924,7 +14286,6 @@ col_end_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_6 : Css.Style
 col_end_6 =
     Css.property "grid-column-end" "6"
@@ -13935,7 +14296,6 @@ col_end_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_7 : Css.Style
 col_end_7 =
     Css.property "grid-column-end" "7"
@@ -13946,7 +14306,6 @@ col_end_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_8 : Css.Style
 col_end_8 =
     Css.property "grid-column-end" "8"
@@ -13957,7 +14316,6 @@ col_end_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_9 : Css.Style
 col_end_9 =
     Css.property "grid-column-end" "9"
@@ -13968,7 +14326,6 @@ col_end_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_end_auto : Css.Style
 col_end_auto =
     Css.property "grid-column-end" "auto"
@@ -13979,7 +14336,6 @@ col_end_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_1 : Css.Style
 col_span_1 =
     Css.property "grid-column" "span 1 / span 1"
@@ -13990,7 +14346,6 @@ col_span_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_10 : Css.Style
 col_span_10 =
     Css.property "grid-column" "span 10 / span 10"
@@ -14001,7 +14356,6 @@ col_span_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_11 : Css.Style
 col_span_11 =
     Css.property "grid-column" "span 11 / span 11"
@@ -14012,7 +14366,6 @@ col_span_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_12 : Css.Style
 col_span_12 =
     Css.property "grid-column" "span 12 / span 12"
@@ -14023,7 +14376,6 @@ col_span_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_2 : Css.Style
 col_span_2 =
     Css.property "grid-column" "span 2 / span 2"
@@ -14034,7 +14386,6 @@ col_span_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_3 : Css.Style
 col_span_3 =
     Css.property "grid-column" "span 3 / span 3"
@@ -14045,7 +14396,6 @@ col_span_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_4 : Css.Style
 col_span_4 =
     Css.property "grid-column" "span 4 / span 4"
@@ -14056,7 +14406,6 @@ col_span_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_5 : Css.Style
 col_span_5 =
     Css.property "grid-column" "span 5 / span 5"
@@ -14067,7 +14416,6 @@ col_span_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_6 : Css.Style
 col_span_6 =
     Css.property "grid-column" "span 6 / span 6"
@@ -14078,7 +14426,6 @@ col_span_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_7 : Css.Style
 col_span_7 =
     Css.property "grid-column" "span 7 / span 7"
@@ -14089,7 +14436,6 @@ col_span_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_8 : Css.Style
 col_span_8 =
     Css.property "grid-column" "span 8 / span 8"
@@ -14100,7 +14446,6 @@ col_span_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_9 : Css.Style
 col_span_9 =
     Css.property "grid-column" "span 9 / span 9"
@@ -14111,7 +14456,6 @@ col_span_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_span_full : Css.Style
 col_span_full =
     Css.property "grid-column" "1 / -1"
@@ -14122,7 +14466,6 @@ col_span_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_1 : Css.Style
 col_start_1 =
     Css.property "grid-column-start" "1"
@@ -14133,7 +14476,6 @@ col_start_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_10 : Css.Style
 col_start_10 =
     Css.property "grid-column-start" "10"
@@ -14144,7 +14486,6 @@ col_start_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_11 : Css.Style
 col_start_11 =
     Css.property "grid-column-start" "11"
@@ -14155,7 +14496,6 @@ col_start_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_12 : Css.Style
 col_start_12 =
     Css.property "grid-column-start" "12"
@@ -14166,7 +14506,6 @@ col_start_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_13 : Css.Style
 col_start_13 =
     Css.property "grid-column-start" "13"
@@ -14177,7 +14516,6 @@ col_start_13 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_2 : Css.Style
 col_start_2 =
     Css.property "grid-column-start" "2"
@@ -14188,7 +14526,6 @@ col_start_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_3 : Css.Style
 col_start_3 =
     Css.property "grid-column-start" "3"
@@ -14199,7 +14536,6 @@ col_start_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_4 : Css.Style
 col_start_4 =
     Css.property "grid-column-start" "4"
@@ -14210,7 +14546,6 @@ col_start_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_5 : Css.Style
 col_start_5 =
     Css.property "grid-column-start" "5"
@@ -14221,7 +14556,6 @@ col_start_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_6 : Css.Style
 col_start_6 =
     Css.property "grid-column-start" "6"
@@ -14232,7 +14566,6 @@ col_start_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_7 : Css.Style
 col_start_7 =
     Css.property "grid-column-start" "7"
@@ -14243,7 +14576,6 @@ col_start_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_8 : Css.Style
 col_start_8 =
     Css.property "grid-column-start" "8"
@@ -14254,7 +14586,6 @@ col_start_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_9 : Css.Style
 col_start_9 =
     Css.property "grid-column-start" "9"
@@ -14265,7 +14596,6 @@ col_start_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 col_start_auto : Css.Style
 col_start_auto =
     Css.property "grid-column-start" "auto"
@@ -14276,7 +14606,6 @@ col_start_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 container : Css.Style
 container =
     Css.batch
@@ -14304,7 +14633,6 @@ container =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_around : Css.Style
 content_around =
     Css.property "align-content" "space-around"
@@ -14315,7 +14643,6 @@ content_around =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_between : Css.Style
 content_between =
     Css.property "align-content" "space-between"
@@ -14326,7 +14653,6 @@ content_between =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_center : Css.Style
 content_center =
     Css.property "align-content" "center"
@@ -14337,7 +14663,6 @@ content_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_end : Css.Style
 content_end =
     Css.property "align-content" "flex-end"
@@ -14348,7 +14673,6 @@ content_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_evenly : Css.Style
 content_evenly =
     Css.property "align-content" "space-evenly"
@@ -14359,7 +14683,6 @@ content_evenly =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 content_start : Css.Style
 content_start =
     Css.property "align-content" "flex-start"
@@ -14370,7 +14693,6 @@ content_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contents : Css.Style
 contents =
     Css.property "display" "contents"
@@ -14381,7 +14703,6 @@ contents =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_0 : Css.Style
 contrast_0 =
     Css.property "--tw-contrast" "contrast(0)"
@@ -14392,7 +14713,6 @@ contrast_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_100 : Css.Style
 contrast_100 =
     Css.property "--tw-contrast" "contrast(1)"
@@ -14403,7 +14723,6 @@ contrast_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_125 : Css.Style
 contrast_125 =
     Css.property "--tw-contrast" "contrast(1.25)"
@@ -14414,7 +14733,6 @@ contrast_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_150 : Css.Style
 contrast_150 =
     Css.property "--tw-contrast" "contrast(1.5)"
@@ -14425,7 +14743,6 @@ contrast_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_200 : Css.Style
 contrast_200 =
     Css.property "--tw-contrast" "contrast(2)"
@@ -14436,7 +14753,6 @@ contrast_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_50 : Css.Style
 contrast_50 =
     Css.property "--tw-contrast" "contrast(.5)"
@@ -14447,7 +14763,6 @@ contrast_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 contrast_75 : Css.Style
 contrast_75 =
     Css.property "--tw-contrast" "contrast(.75)"
@@ -14458,7 +14773,6 @@ contrast_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_auto : Css.Style
 cursor_auto =
     Css.property "cursor" "auto"
@@ -14469,7 +14783,6 @@ cursor_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_default : Css.Style
 cursor_default =
     Css.property "cursor" "default"
@@ -14480,7 +14793,6 @@ cursor_default =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_help : Css.Style
 cursor_help =
     Css.property "cursor" "help"
@@ -14491,7 +14803,6 @@ cursor_help =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_move : Css.Style
 cursor_move =
     Css.property "cursor" "move"
@@ -14502,7 +14813,6 @@ cursor_move =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_not_allowed : Css.Style
 cursor_not_allowed =
     Css.property "cursor" "not-allowed"
@@ -14513,7 +14823,6 @@ cursor_not_allowed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_pointer : Css.Style
 cursor_pointer =
     Css.property "cursor" "pointer"
@@ -14524,7 +14833,6 @@ cursor_pointer =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_text : Css.Style
 cursor_text =
     Css.property "cursor" "text"
@@ -14535,7 +14843,6 @@ cursor_text =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 cursor_wait : Css.Style
 cursor_wait =
     Css.property "cursor" "wait"
@@ -14546,7 +14853,6 @@ cursor_wait =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 decoration_clone : Css.Style
 decoration_clone =
     Css.batch
@@ -14560,7 +14866,6 @@ decoration_clone =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 decoration_slice : Css.Style
 decoration_slice =
     Css.batch
@@ -14574,7 +14879,6 @@ decoration_slice =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_100 : Css.Style
 delay_100 =
     Css.property "transition-delay" "100ms"
@@ -14585,7 +14889,6 @@ delay_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_1000 : Css.Style
 delay_1000 =
     Css.property "transition-delay" "1000ms"
@@ -14596,7 +14899,6 @@ delay_1000 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_150 : Css.Style
 delay_150 =
     Css.property "transition-delay" "150ms"
@@ -14607,7 +14909,6 @@ delay_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_200 : Css.Style
 delay_200 =
     Css.property "transition-delay" "200ms"
@@ -14618,7 +14919,6 @@ delay_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_300 : Css.Style
 delay_300 =
     Css.property "transition-delay" "300ms"
@@ -14629,7 +14929,6 @@ delay_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_500 : Css.Style
 delay_500 =
     Css.property "transition-delay" "500ms"
@@ -14640,7 +14939,6 @@ delay_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_700 : Css.Style
 delay_700 =
     Css.property "transition-delay" "700ms"
@@ -14651,7 +14949,6 @@ delay_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 delay_75 : Css.Style
 delay_75 =
     Css.property "transition-delay" "75ms"
@@ -14662,7 +14959,6 @@ delay_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 diagonal_fractions : Css.Style
 diagonal_fractions =
     Css.batch
@@ -14681,7 +14977,6 @@ diagonal_fractions =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_black : Css.Style
 divide_black =
     Css.batch
@@ -14699,7 +14994,6 @@ divide_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_100 : Css.Style
 divide_blue_100 =
     Css.batch
@@ -14717,7 +15011,6 @@ divide_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_200 : Css.Style
 divide_blue_200 =
     Css.batch
@@ -14735,7 +15028,6 @@ divide_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_300 : Css.Style
 divide_blue_300 =
     Css.batch
@@ -14753,7 +15045,6 @@ divide_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_400 : Css.Style
 divide_blue_400 =
     Css.batch
@@ -14771,7 +15062,6 @@ divide_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_50 : Css.Style
 divide_blue_50 =
     Css.batch
@@ -14789,7 +15079,6 @@ divide_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_500 : Css.Style
 divide_blue_500 =
     Css.batch
@@ -14807,7 +15096,6 @@ divide_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_600 : Css.Style
 divide_blue_600 =
     Css.batch
@@ -14825,7 +15113,6 @@ divide_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_700 : Css.Style
 divide_blue_700 =
     Css.batch
@@ -14843,7 +15130,6 @@ divide_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_800 : Css.Style
 divide_blue_800 =
     Css.batch
@@ -14861,7 +15147,6 @@ divide_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_blue_900 : Css.Style
 divide_blue_900 =
     Css.batch
@@ -14879,7 +15164,6 @@ divide_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_current : Css.Style
 divide_current =
     Css.batch
@@ -14896,7 +15180,6 @@ divide_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_dashed : Css.Style
 divide_dashed =
     Css.batch
@@ -14913,7 +15196,6 @@ divide_dashed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_dotted : Css.Style
 divide_dotted =
     Css.batch
@@ -14930,7 +15212,6 @@ divide_dotted =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_double : Css.Style
 divide_double =
     Css.batch
@@ -14947,7 +15228,6 @@ divide_double =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_100 : Css.Style
 divide_gray_100 =
     Css.batch
@@ -14965,7 +15245,6 @@ divide_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_200 : Css.Style
 divide_gray_200 =
     Css.batch
@@ -14983,7 +15262,6 @@ divide_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_300 : Css.Style
 divide_gray_300 =
     Css.batch
@@ -15001,7 +15279,6 @@ divide_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_400 : Css.Style
 divide_gray_400 =
     Css.batch
@@ -15019,7 +15296,6 @@ divide_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_50 : Css.Style
 divide_gray_50 =
     Css.batch
@@ -15037,7 +15313,6 @@ divide_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_500 : Css.Style
 divide_gray_500 =
     Css.batch
@@ -15055,7 +15330,6 @@ divide_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_600 : Css.Style
 divide_gray_600 =
     Css.batch
@@ -15073,7 +15347,6 @@ divide_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_700 : Css.Style
 divide_gray_700 =
     Css.batch
@@ -15091,7 +15364,6 @@ divide_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_800 : Css.Style
 divide_gray_800 =
     Css.batch
@@ -15109,7 +15381,6 @@ divide_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_gray_900 : Css.Style
 divide_gray_900 =
     Css.batch
@@ -15127,7 +15398,6 @@ divide_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_100 : Css.Style
 divide_green_100 =
     Css.batch
@@ -15145,7 +15415,6 @@ divide_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_200 : Css.Style
 divide_green_200 =
     Css.batch
@@ -15163,7 +15432,6 @@ divide_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_300 : Css.Style
 divide_green_300 =
     Css.batch
@@ -15181,7 +15449,6 @@ divide_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_400 : Css.Style
 divide_green_400 =
     Css.batch
@@ -15199,7 +15466,6 @@ divide_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_50 : Css.Style
 divide_green_50 =
     Css.batch
@@ -15217,7 +15483,6 @@ divide_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_500 : Css.Style
 divide_green_500 =
     Css.batch
@@ -15235,7 +15500,6 @@ divide_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_600 : Css.Style
 divide_green_600 =
     Css.batch
@@ -15253,7 +15517,6 @@ divide_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_700 : Css.Style
 divide_green_700 =
     Css.batch
@@ -15271,7 +15534,6 @@ divide_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_800 : Css.Style
 divide_green_800 =
     Css.batch
@@ -15289,7 +15551,6 @@ divide_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_green_900 : Css.Style
 divide_green_900 =
     Css.batch
@@ -15307,7 +15568,6 @@ divide_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_100 : Css.Style
 divide_indigo_100 =
     Css.batch
@@ -15325,7 +15585,6 @@ divide_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_200 : Css.Style
 divide_indigo_200 =
     Css.batch
@@ -15343,7 +15602,6 @@ divide_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_300 : Css.Style
 divide_indigo_300 =
     Css.batch
@@ -15361,7 +15619,6 @@ divide_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_400 : Css.Style
 divide_indigo_400 =
     Css.batch
@@ -15379,7 +15636,6 @@ divide_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_50 : Css.Style
 divide_indigo_50 =
     Css.batch
@@ -15397,7 +15653,6 @@ divide_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_500 : Css.Style
 divide_indigo_500 =
     Css.batch
@@ -15415,7 +15670,6 @@ divide_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_600 : Css.Style
 divide_indigo_600 =
     Css.batch
@@ -15433,7 +15687,6 @@ divide_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_700 : Css.Style
 divide_indigo_700 =
     Css.batch
@@ -15451,7 +15704,6 @@ divide_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_800 : Css.Style
 divide_indigo_800 =
     Css.batch
@@ -15469,7 +15721,6 @@ divide_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_indigo_900 : Css.Style
 divide_indigo_900 =
     Css.batch
@@ -15487,7 +15738,6 @@ divide_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_none : Css.Style
 divide_none =
     Css.batch
@@ -15504,7 +15754,6 @@ divide_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_0 : Css.Style
 divide_opacity_0 =
     Css.batch
@@ -15521,7 +15770,6 @@ divide_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_10 : Css.Style
 divide_opacity_10 =
     Css.batch
@@ -15538,7 +15786,6 @@ divide_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_100 : Css.Style
 divide_opacity_100 =
     Css.batch
@@ -15555,7 +15802,6 @@ divide_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_20 : Css.Style
 divide_opacity_20 =
     Css.batch
@@ -15572,7 +15818,6 @@ divide_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_25 : Css.Style
 divide_opacity_25 =
     Css.batch
@@ -15589,7 +15834,6 @@ divide_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_30 : Css.Style
 divide_opacity_30 =
     Css.batch
@@ -15606,7 +15850,6 @@ divide_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_40 : Css.Style
 divide_opacity_40 =
     Css.batch
@@ -15623,7 +15866,6 @@ divide_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_5 : Css.Style
 divide_opacity_5 =
     Css.batch
@@ -15640,7 +15882,6 @@ divide_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_50 : Css.Style
 divide_opacity_50 =
     Css.batch
@@ -15657,7 +15898,6 @@ divide_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_60 : Css.Style
 divide_opacity_60 =
     Css.batch
@@ -15674,7 +15914,6 @@ divide_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_70 : Css.Style
 divide_opacity_70 =
     Css.batch
@@ -15691,7 +15930,6 @@ divide_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_75 : Css.Style
 divide_opacity_75 =
     Css.batch
@@ -15708,7 +15946,6 @@ divide_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_80 : Css.Style
 divide_opacity_80 =
     Css.batch
@@ -15725,7 +15962,6 @@ divide_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_90 : Css.Style
 divide_opacity_90 =
     Css.batch
@@ -15742,7 +15978,6 @@ divide_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_opacity_95 : Css.Style
 divide_opacity_95 =
     Css.batch
@@ -15759,7 +15994,6 @@ divide_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_100 : Css.Style
 divide_pink_100 =
     Css.batch
@@ -15777,7 +16011,6 @@ divide_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_200 : Css.Style
 divide_pink_200 =
     Css.batch
@@ -15795,7 +16028,6 @@ divide_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_300 : Css.Style
 divide_pink_300 =
     Css.batch
@@ -15813,7 +16045,6 @@ divide_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_400 : Css.Style
 divide_pink_400 =
     Css.batch
@@ -15831,7 +16062,6 @@ divide_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_50 : Css.Style
 divide_pink_50 =
     Css.batch
@@ -15849,7 +16079,6 @@ divide_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_500 : Css.Style
 divide_pink_500 =
     Css.batch
@@ -15867,7 +16096,6 @@ divide_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_600 : Css.Style
 divide_pink_600 =
     Css.batch
@@ -15885,7 +16113,6 @@ divide_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_700 : Css.Style
 divide_pink_700 =
     Css.batch
@@ -15903,7 +16130,6 @@ divide_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_800 : Css.Style
 divide_pink_800 =
     Css.batch
@@ -15921,7 +16147,6 @@ divide_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_pink_900 : Css.Style
 divide_pink_900 =
     Css.batch
@@ -15939,7 +16164,6 @@ divide_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_100 : Css.Style
 divide_purple_100 =
     Css.batch
@@ -15957,7 +16181,6 @@ divide_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_200 : Css.Style
 divide_purple_200 =
     Css.batch
@@ -15975,7 +16198,6 @@ divide_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_300 : Css.Style
 divide_purple_300 =
     Css.batch
@@ -15993,7 +16215,6 @@ divide_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_400 : Css.Style
 divide_purple_400 =
     Css.batch
@@ -16011,7 +16232,6 @@ divide_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_50 : Css.Style
 divide_purple_50 =
     Css.batch
@@ -16029,7 +16249,6 @@ divide_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_500 : Css.Style
 divide_purple_500 =
     Css.batch
@@ -16047,7 +16266,6 @@ divide_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_600 : Css.Style
 divide_purple_600 =
     Css.batch
@@ -16065,7 +16283,6 @@ divide_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_700 : Css.Style
 divide_purple_700 =
     Css.batch
@@ -16083,7 +16300,6 @@ divide_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_800 : Css.Style
 divide_purple_800 =
     Css.batch
@@ -16101,7 +16317,6 @@ divide_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_purple_900 : Css.Style
 divide_purple_900 =
     Css.batch
@@ -16119,7 +16334,6 @@ divide_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_100 : Css.Style
 divide_red_100 =
     Css.batch
@@ -16137,7 +16351,6 @@ divide_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_200 : Css.Style
 divide_red_200 =
     Css.batch
@@ -16155,7 +16368,6 @@ divide_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_300 : Css.Style
 divide_red_300 =
     Css.batch
@@ -16173,7 +16385,6 @@ divide_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_400 : Css.Style
 divide_red_400 =
     Css.batch
@@ -16191,7 +16402,6 @@ divide_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_50 : Css.Style
 divide_red_50 =
     Css.batch
@@ -16209,7 +16419,6 @@ divide_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_500 : Css.Style
 divide_red_500 =
     Css.batch
@@ -16227,7 +16436,6 @@ divide_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_600 : Css.Style
 divide_red_600 =
     Css.batch
@@ -16245,7 +16453,6 @@ divide_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_700 : Css.Style
 divide_red_700 =
     Css.batch
@@ -16263,7 +16470,6 @@ divide_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_800 : Css.Style
 divide_red_800 =
     Css.batch
@@ -16281,7 +16487,6 @@ divide_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_red_900 : Css.Style
 divide_red_900 =
     Css.batch
@@ -16299,7 +16504,6 @@ divide_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_solid : Css.Style
 divide_solid =
     Css.batch
@@ -16316,7 +16520,6 @@ divide_solid =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_transparent : Css.Style
 divide_transparent =
     Css.batch
@@ -16333,7 +16536,6 @@ divide_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_white : Css.Style
 divide_white =
     Css.batch
@@ -16351,7 +16553,6 @@ divide_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x : Css.Style
 divide_x =
     Css.batch
@@ -16370,7 +16571,6 @@ divide_x =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x_0 : Css.Style
 divide_x_0 =
     Css.batch
@@ -16389,7 +16589,6 @@ divide_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x_2 : Css.Style
 divide_x_2 =
     Css.batch
@@ -16408,7 +16607,6 @@ divide_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x_4 : Css.Style
 divide_x_4 =
     Css.batch
@@ -16427,7 +16625,6 @@ divide_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x_8 : Css.Style
 divide_x_8 =
     Css.batch
@@ -16446,7 +16643,6 @@ divide_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_x_reverse : Css.Style
 divide_x_reverse =
     Css.batch
@@ -16463,7 +16659,6 @@ divide_x_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y : Css.Style
 divide_y =
     Css.batch
@@ -16482,7 +16677,6 @@ divide_y =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y_0 : Css.Style
 divide_y_0 =
     Css.batch
@@ -16501,7 +16695,6 @@ divide_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y_2 : Css.Style
 divide_y_2 =
     Css.batch
@@ -16520,7 +16713,6 @@ divide_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y_4 : Css.Style
 divide_y_4 =
     Css.batch
@@ -16539,7 +16731,6 @@ divide_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y_8 : Css.Style
 divide_y_8 =
     Css.batch
@@ -16558,7 +16749,6 @@ divide_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_y_reverse : Css.Style
 divide_y_reverse =
     Css.batch
@@ -16575,7 +16765,6 @@ divide_y_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_100 : Css.Style
 divide_yellow_100 =
     Css.batch
@@ -16593,7 +16782,6 @@ divide_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_200 : Css.Style
 divide_yellow_200 =
     Css.batch
@@ -16611,7 +16799,6 @@ divide_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_300 : Css.Style
 divide_yellow_300 =
     Css.batch
@@ -16629,7 +16816,6 @@ divide_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_400 : Css.Style
 divide_yellow_400 =
     Css.batch
@@ -16647,7 +16833,6 @@ divide_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_50 : Css.Style
 divide_yellow_50 =
     Css.batch
@@ -16665,7 +16850,6 @@ divide_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_500 : Css.Style
 divide_yellow_500 =
     Css.batch
@@ -16683,7 +16867,6 @@ divide_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_600 : Css.Style
 divide_yellow_600 =
     Css.batch
@@ -16701,7 +16884,6 @@ divide_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_700 : Css.Style
 divide_yellow_700 =
     Css.batch
@@ -16719,7 +16901,6 @@ divide_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_800 : Css.Style
 divide_yellow_800 =
     Css.batch
@@ -16737,7 +16918,6 @@ divide_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 divide_yellow_900 : Css.Style
 divide_yellow_900 =
     Css.batch
@@ -16755,7 +16935,6 @@ divide_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow : Css.Style
 drop_shadow =
     Css.property "--tw-drop-shadow" "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.06))"
@@ -16766,7 +16945,6 @@ drop_shadow =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_2xl : Css.Style
 drop_shadow_2xl =
     Css.property "--tw-drop-shadow" "drop-shadow(0 25px 25px rgba(0, 0, 0, 0.15))"
@@ -16777,7 +16955,6 @@ drop_shadow_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_lg : Css.Style
 drop_shadow_lg =
     Css.property "--tw-drop-shadow" "drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1))"
@@ -16788,7 +16965,6 @@ drop_shadow_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_md : Css.Style
 drop_shadow_md =
     Css.property "--tw-drop-shadow" "drop-shadow(0 4px 3px rgba(0, 0, 0, 0.07)) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.06))"
@@ -16799,7 +16975,6 @@ drop_shadow_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_none : Css.Style
 drop_shadow_none =
     Css.property "--tw-drop-shadow" "drop-shadow(0 0 #0000)"
@@ -16810,7 +16985,6 @@ drop_shadow_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_sm : Css.Style
 drop_shadow_sm =
     Css.property "--tw-drop-shadow" "drop-shadow(0 1px 1px rgba(0,0,0,0.05))"
@@ -16821,7 +16995,6 @@ drop_shadow_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 drop_shadow_xl : Css.Style
 drop_shadow_xl =
     Css.property "--tw-drop-shadow" "drop-shadow(0 20px 13px rgba(0, 0, 0, 0.03)) drop-shadow(0 8px 5px rgba(0, 0, 0, 0.08))"
@@ -16832,7 +17005,6 @@ drop_shadow_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_100 : Css.Style
 duration_100 =
     Css.property "transition-duration" "100ms"
@@ -16843,7 +17015,6 @@ duration_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_1000 : Css.Style
 duration_1000 =
     Css.property "transition-duration" "1000ms"
@@ -16854,7 +17025,6 @@ duration_1000 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_150 : Css.Style
 duration_150 =
     Css.property "transition-duration" "150ms"
@@ -16865,7 +17035,6 @@ duration_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_200 : Css.Style
 duration_200 =
     Css.property "transition-duration" "200ms"
@@ -16876,7 +17045,6 @@ duration_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_300 : Css.Style
 duration_300 =
     Css.property "transition-duration" "300ms"
@@ -16887,7 +17055,6 @@ duration_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_500 : Css.Style
 duration_500 =
     Css.property "transition-duration" "500ms"
@@ -16898,7 +17065,6 @@ duration_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_700 : Css.Style
 duration_700 =
     Css.property "transition-duration" "700ms"
@@ -16909,7 +17075,6 @@ duration_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 duration_75 : Css.Style
 duration_75 =
     Css.property "transition-duration" "75ms"
@@ -16920,7 +17085,6 @@ duration_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ease_in : Css.Style
 ease_in =
     Css.property "transition-timing-function" "cubic-bezier(0.4, 0, 1, 1)"
@@ -16931,7 +17095,6 @@ ease_in =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ease_in_out : Css.Style
 ease_in_out =
     Css.property "transition-timing-function" "cubic-bezier(0.4, 0, 0.2, 1)"
@@ -16942,7 +17105,6 @@ ease_in_out =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ease_linear : Css.Style
 ease_linear =
     Css.property "transition-timing-function" "linear"
@@ -16953,7 +17115,6 @@ ease_linear =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ease_out : Css.Style
 ease_out =
     Css.property "transition-timing-function" "cubic-bezier(0, 0, 0.2, 1)"
@@ -16964,7 +17125,6 @@ ease_out =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 fill_current : Css.Style
 fill_current =
     Css.property "fill" "currentColor"
@@ -16975,7 +17135,6 @@ fill_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 filter : Css.Style
 filter =
     Css.batch
@@ -16997,7 +17156,6 @@ filter =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 filter_none : Css.Style
 filter_none =
     Css.property "filter" "none"
@@ -17008,7 +17166,6 @@ filter_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 fixed : Css.Style
 fixed =
     Css.property "position" "fixed"
@@ -17019,7 +17176,6 @@ fixed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex : Css.Style
 flex =
     Css.property "display" "flex"
@@ -17030,7 +17186,6 @@ flex =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_1 : Css.Style
 flex_1 =
     Css.property "flex" "1 1 0%"
@@ -17041,7 +17196,6 @@ flex_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_auto : Css.Style
 flex_auto =
     Css.property "flex" "1 1 auto"
@@ -17052,7 +17206,6 @@ flex_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_col : Css.Style
 flex_col =
     Css.property "flex-direction" "column"
@@ -17063,7 +17216,6 @@ flex_col =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_col_reverse : Css.Style
 flex_col_reverse =
     Css.property "flex-direction" "column-reverse"
@@ -17074,7 +17226,6 @@ flex_col_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_grow : Css.Style
 flex_grow =
     Css.property "flex-grow" "1"
@@ -17085,7 +17236,6 @@ flex_grow =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_grow_0 : Css.Style
 flex_grow_0 =
     Css.property "flex-grow" "0"
@@ -17096,7 +17246,6 @@ flex_grow_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_initial : Css.Style
 flex_initial =
     Css.property "flex" "0 1 auto"
@@ -17107,7 +17256,6 @@ flex_initial =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_none : Css.Style
 flex_none =
     Css.property "flex" "none"
@@ -17118,7 +17266,6 @@ flex_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_nowrap : Css.Style
 flex_nowrap =
     Css.property "flex-wrap" "nowrap"
@@ -17129,7 +17276,6 @@ flex_nowrap =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_row : Css.Style
 flex_row =
     Css.property "flex-direction" "row"
@@ -17140,7 +17286,6 @@ flex_row =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_row_reverse : Css.Style
 flex_row_reverse =
     Css.property "flex-direction" "row-reverse"
@@ -17151,7 +17296,6 @@ flex_row_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_shrink : Css.Style
 flex_shrink =
     Css.property "flex-shrink" "1"
@@ -17162,7 +17306,6 @@ flex_shrink =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_shrink_0 : Css.Style
 flex_shrink_0 =
     Css.property "flex-shrink" "0"
@@ -17173,7 +17316,6 @@ flex_shrink_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_wrap : Css.Style
 flex_wrap =
     Css.property "flex-wrap" "wrap"
@@ -17184,7 +17326,6 @@ flex_wrap =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flex_wrap_reverse : Css.Style
 flex_wrap_reverse =
     Css.property "flex-wrap" "wrap-reverse"
@@ -17195,7 +17336,6 @@ flex_wrap_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 float_left : Css.Style
 float_left =
     Css.property "float" "left"
@@ -17206,7 +17346,6 @@ float_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 float_none : Css.Style
 float_none =
     Css.property "float" "none"
@@ -17217,7 +17356,6 @@ float_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 float_right : Css.Style
 float_right =
     Css.property "float" "right"
@@ -17228,7 +17366,6 @@ float_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 flow_root : Css.Style
 flow_root =
     Css.property "display" "flow-root"
@@ -17239,7 +17376,6 @@ flow_root =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_black : Css.Style
 font_black =
     Css.property "font-weight" "900"
@@ -17250,7 +17386,6 @@ font_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_bold : Css.Style
 font_bold =
     Css.property "font-weight" "700"
@@ -17261,7 +17396,6 @@ font_bold =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_extrabold : Css.Style
 font_extrabold =
     Css.property "font-weight" "800"
@@ -17272,7 +17406,6 @@ font_extrabold =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_extralight : Css.Style
 font_extralight =
     Css.property "font-weight" "200"
@@ -17283,7 +17416,6 @@ font_extralight =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_light : Css.Style
 font_light =
     Css.property "font-weight" "300"
@@ -17294,7 +17426,6 @@ font_light =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_medium : Css.Style
 font_medium =
     Css.property "font-weight" "500"
@@ -17305,7 +17436,6 @@ font_medium =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_mono : Css.Style
 font_mono =
     Css.property "font-family" "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
@@ -17316,7 +17446,6 @@ font_mono =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_normal : Css.Style
 font_normal =
     Css.property "font-weight" "400"
@@ -17327,7 +17456,6 @@ font_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_sans : Css.Style
 font_sans =
     Css.property "font-family" "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""
@@ -17338,7 +17466,6 @@ font_sans =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_semibold : Css.Style
 font_semibold =
     Css.property "font-weight" "600"
@@ -17349,7 +17476,6 @@ font_semibold =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_serif : Css.Style
 font_serif =
     Css.property "font-family" "ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif"
@@ -17360,7 +17486,6 @@ font_serif =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 font_thin : Css.Style
 font_thin =
     Css.property "font-weight" "100"
@@ -17371,7 +17496,6 @@ font_thin =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_checkbox : Css.Style
 form_checkbox =
     Css.batch
@@ -17455,7 +17579,6 @@ form_checkbox =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_input : Css.Style
 form_input =
     Css.batch
@@ -17510,7 +17633,6 @@ form_input =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_multiselect : Css.Style
 form_multiselect =
     Css.batch
@@ -17547,7 +17669,6 @@ form_multiselect =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_radio : Css.Style
 form_radio =
     Css.batch
@@ -17611,7 +17732,6 @@ form_radio =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_select : Css.Style
 form_select =
     Css.batch
@@ -17655,7 +17775,6 @@ form_select =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 form_textarea : Css.Style
 form_textarea =
     Css.batch
@@ -17704,7 +17823,6 @@ form_textarea =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_black : Css.Style
 from_black =
     Css.batch
@@ -17718,7 +17836,6 @@ from_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_100 : Css.Style
 from_blue_100 =
     Css.batch
@@ -17732,7 +17849,6 @@ from_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_200 : Css.Style
 from_blue_200 =
     Css.batch
@@ -17746,7 +17862,6 @@ from_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_300 : Css.Style
 from_blue_300 =
     Css.batch
@@ -17760,7 +17875,6 @@ from_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_400 : Css.Style
 from_blue_400 =
     Css.batch
@@ -17774,7 +17888,6 @@ from_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_50 : Css.Style
 from_blue_50 =
     Css.batch
@@ -17788,7 +17901,6 @@ from_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_500 : Css.Style
 from_blue_500 =
     Css.batch
@@ -17802,7 +17914,6 @@ from_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_600 : Css.Style
 from_blue_600 =
     Css.batch
@@ -17816,7 +17927,6 @@ from_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_700 : Css.Style
 from_blue_700 =
     Css.batch
@@ -17830,7 +17940,6 @@ from_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_800 : Css.Style
 from_blue_800 =
     Css.batch
@@ -17844,7 +17953,6 @@ from_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_blue_900 : Css.Style
 from_blue_900 =
     Css.batch
@@ -17858,7 +17966,6 @@ from_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_current : Css.Style
 from_current =
     Css.batch
@@ -17872,7 +17979,6 @@ from_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_100 : Css.Style
 from_gray_100 =
     Css.batch
@@ -17886,7 +17992,6 @@ from_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_200 : Css.Style
 from_gray_200 =
     Css.batch
@@ -17900,7 +18005,6 @@ from_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_300 : Css.Style
 from_gray_300 =
     Css.batch
@@ -17914,7 +18018,6 @@ from_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_400 : Css.Style
 from_gray_400 =
     Css.batch
@@ -17928,7 +18031,6 @@ from_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_50 : Css.Style
 from_gray_50 =
     Css.batch
@@ -17942,7 +18044,6 @@ from_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_500 : Css.Style
 from_gray_500 =
     Css.batch
@@ -17956,7 +18057,6 @@ from_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_600 : Css.Style
 from_gray_600 =
     Css.batch
@@ -17970,7 +18070,6 @@ from_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_700 : Css.Style
 from_gray_700 =
     Css.batch
@@ -17984,7 +18083,6 @@ from_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_800 : Css.Style
 from_gray_800 =
     Css.batch
@@ -17998,7 +18096,6 @@ from_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_gray_900 : Css.Style
 from_gray_900 =
     Css.batch
@@ -18012,7 +18109,6 @@ from_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_100 : Css.Style
 from_green_100 =
     Css.batch
@@ -18026,7 +18122,6 @@ from_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_200 : Css.Style
 from_green_200 =
     Css.batch
@@ -18040,7 +18135,6 @@ from_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_300 : Css.Style
 from_green_300 =
     Css.batch
@@ -18054,7 +18148,6 @@ from_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_400 : Css.Style
 from_green_400 =
     Css.batch
@@ -18068,7 +18161,6 @@ from_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_50 : Css.Style
 from_green_50 =
     Css.batch
@@ -18082,7 +18174,6 @@ from_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_500 : Css.Style
 from_green_500 =
     Css.batch
@@ -18096,7 +18187,6 @@ from_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_600 : Css.Style
 from_green_600 =
     Css.batch
@@ -18110,7 +18200,6 @@ from_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_700 : Css.Style
 from_green_700 =
     Css.batch
@@ -18124,7 +18213,6 @@ from_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_800 : Css.Style
 from_green_800 =
     Css.batch
@@ -18138,7 +18226,6 @@ from_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_green_900 : Css.Style
 from_green_900 =
     Css.batch
@@ -18152,7 +18239,6 @@ from_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_100 : Css.Style
 from_indigo_100 =
     Css.batch
@@ -18166,7 +18252,6 @@ from_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_200 : Css.Style
 from_indigo_200 =
     Css.batch
@@ -18180,7 +18265,6 @@ from_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_300 : Css.Style
 from_indigo_300 =
     Css.batch
@@ -18194,7 +18278,6 @@ from_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_400 : Css.Style
 from_indigo_400 =
     Css.batch
@@ -18208,7 +18291,6 @@ from_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_50 : Css.Style
 from_indigo_50 =
     Css.batch
@@ -18222,7 +18304,6 @@ from_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_500 : Css.Style
 from_indigo_500 =
     Css.batch
@@ -18236,7 +18317,6 @@ from_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_600 : Css.Style
 from_indigo_600 =
     Css.batch
@@ -18250,7 +18330,6 @@ from_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_700 : Css.Style
 from_indigo_700 =
     Css.batch
@@ -18264,7 +18343,6 @@ from_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_800 : Css.Style
 from_indigo_800 =
     Css.batch
@@ -18278,7 +18356,6 @@ from_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_indigo_900 : Css.Style
 from_indigo_900 =
     Css.batch
@@ -18292,7 +18369,6 @@ from_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_100 : Css.Style
 from_pink_100 =
     Css.batch
@@ -18306,7 +18382,6 @@ from_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_200 : Css.Style
 from_pink_200 =
     Css.batch
@@ -18320,7 +18395,6 @@ from_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_300 : Css.Style
 from_pink_300 =
     Css.batch
@@ -18334,7 +18408,6 @@ from_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_400 : Css.Style
 from_pink_400 =
     Css.batch
@@ -18348,7 +18421,6 @@ from_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_50 : Css.Style
 from_pink_50 =
     Css.batch
@@ -18362,7 +18434,6 @@ from_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_500 : Css.Style
 from_pink_500 =
     Css.batch
@@ -18376,7 +18447,6 @@ from_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_600 : Css.Style
 from_pink_600 =
     Css.batch
@@ -18390,7 +18460,6 @@ from_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_700 : Css.Style
 from_pink_700 =
     Css.batch
@@ -18404,7 +18473,6 @@ from_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_800 : Css.Style
 from_pink_800 =
     Css.batch
@@ -18418,7 +18486,6 @@ from_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_pink_900 : Css.Style
 from_pink_900 =
     Css.batch
@@ -18432,7 +18499,6 @@ from_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_100 : Css.Style
 from_purple_100 =
     Css.batch
@@ -18446,7 +18512,6 @@ from_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_200 : Css.Style
 from_purple_200 =
     Css.batch
@@ -18460,7 +18525,6 @@ from_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_300 : Css.Style
 from_purple_300 =
     Css.batch
@@ -18474,7 +18538,6 @@ from_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_400 : Css.Style
 from_purple_400 =
     Css.batch
@@ -18488,7 +18551,6 @@ from_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_50 : Css.Style
 from_purple_50 =
     Css.batch
@@ -18502,7 +18564,6 @@ from_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_500 : Css.Style
 from_purple_500 =
     Css.batch
@@ -18516,7 +18577,6 @@ from_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_600 : Css.Style
 from_purple_600 =
     Css.batch
@@ -18530,7 +18590,6 @@ from_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_700 : Css.Style
 from_purple_700 =
     Css.batch
@@ -18544,7 +18603,6 @@ from_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_800 : Css.Style
 from_purple_800 =
     Css.batch
@@ -18558,7 +18616,6 @@ from_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_purple_900 : Css.Style
 from_purple_900 =
     Css.batch
@@ -18572,7 +18629,6 @@ from_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_100 : Css.Style
 from_red_100 =
     Css.batch
@@ -18586,7 +18642,6 @@ from_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_200 : Css.Style
 from_red_200 =
     Css.batch
@@ -18600,7 +18655,6 @@ from_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_300 : Css.Style
 from_red_300 =
     Css.batch
@@ -18614,7 +18668,6 @@ from_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_400 : Css.Style
 from_red_400 =
     Css.batch
@@ -18628,7 +18681,6 @@ from_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_50 : Css.Style
 from_red_50 =
     Css.batch
@@ -18642,7 +18694,6 @@ from_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_500 : Css.Style
 from_red_500 =
     Css.batch
@@ -18656,7 +18707,6 @@ from_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_600 : Css.Style
 from_red_600 =
     Css.batch
@@ -18670,7 +18720,6 @@ from_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_700 : Css.Style
 from_red_700 =
     Css.batch
@@ -18684,7 +18733,6 @@ from_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_800 : Css.Style
 from_red_800 =
     Css.batch
@@ -18698,7 +18746,6 @@ from_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_red_900 : Css.Style
 from_red_900 =
     Css.batch
@@ -18712,7 +18759,6 @@ from_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_transparent : Css.Style
 from_transparent =
     Css.batch
@@ -18726,7 +18772,6 @@ from_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_white : Css.Style
 from_white =
     Css.batch
@@ -18740,7 +18785,6 @@ from_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_100 : Css.Style
 from_yellow_100 =
     Css.batch
@@ -18754,7 +18798,6 @@ from_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_200 : Css.Style
 from_yellow_200 =
     Css.batch
@@ -18768,7 +18811,6 @@ from_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_300 : Css.Style
 from_yellow_300 =
     Css.batch
@@ -18782,7 +18824,6 @@ from_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_400 : Css.Style
 from_yellow_400 =
     Css.batch
@@ -18796,7 +18837,6 @@ from_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_50 : Css.Style
 from_yellow_50 =
     Css.batch
@@ -18810,7 +18850,6 @@ from_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_500 : Css.Style
 from_yellow_500 =
     Css.batch
@@ -18824,7 +18863,6 @@ from_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_600 : Css.Style
 from_yellow_600 =
     Css.batch
@@ -18838,7 +18876,6 @@ from_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_700 : Css.Style
 from_yellow_700 =
     Css.batch
@@ -18852,7 +18889,6 @@ from_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_800 : Css.Style
 from_yellow_800 =
     Css.batch
@@ -18866,7 +18902,6 @@ from_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 from_yellow_900 : Css.Style
 from_yellow_900 =
     Css.batch
@@ -18880,7 +18915,6 @@ from_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_0 : Css.Style
 gap_0 =
     Css.property "gap" "0px"
@@ -18891,7 +18925,6 @@ gap_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_0_dot_5 : Css.Style
 gap_0_dot_5 =
     Css.property "gap" "0.125rem"
@@ -18902,7 +18935,6 @@ gap_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_1 : Css.Style
 gap_1 =
     Css.property "gap" "0.25rem"
@@ -18913,7 +18945,6 @@ gap_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_10 : Css.Style
 gap_10 =
     Css.property "gap" "2.5rem"
@@ -18924,7 +18955,6 @@ gap_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_11 : Css.Style
 gap_11 =
     Css.property "gap" "2.75rem"
@@ -18935,7 +18965,6 @@ gap_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_12 : Css.Style
 gap_12 =
     Css.property "gap" "3rem"
@@ -18946,7 +18975,6 @@ gap_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_14 : Css.Style
 gap_14 =
     Css.property "gap" "3.5rem"
@@ -18957,7 +18985,6 @@ gap_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_16 : Css.Style
 gap_16 =
     Css.property "gap" "4rem"
@@ -18968,7 +18995,6 @@ gap_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_1_dot_5 : Css.Style
 gap_1_dot_5 =
     Css.property "gap" "0.375rem"
@@ -18979,7 +19005,6 @@ gap_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_2 : Css.Style
 gap_2 =
     Css.property "gap" "0.5rem"
@@ -18990,7 +19015,6 @@ gap_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_20 : Css.Style
 gap_20 =
     Css.property "gap" "5rem"
@@ -19001,7 +19025,6 @@ gap_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_24 : Css.Style
 gap_24 =
     Css.property "gap" "6rem"
@@ -19012,7 +19035,6 @@ gap_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_28 : Css.Style
 gap_28 =
     Css.property "gap" "7rem"
@@ -19023,7 +19045,6 @@ gap_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_2_dot_5 : Css.Style
 gap_2_dot_5 =
     Css.property "gap" "0.625rem"
@@ -19034,7 +19055,6 @@ gap_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_3 : Css.Style
 gap_3 =
     Css.property "gap" "0.75rem"
@@ -19045,7 +19065,6 @@ gap_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_32 : Css.Style
 gap_32 =
     Css.property "gap" "8rem"
@@ -19056,7 +19075,6 @@ gap_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_36 : Css.Style
 gap_36 =
     Css.property "gap" "9rem"
@@ -19067,7 +19085,6 @@ gap_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_3_dot_5 : Css.Style
 gap_3_dot_5 =
     Css.property "gap" "0.875rem"
@@ -19078,7 +19095,6 @@ gap_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_4 : Css.Style
 gap_4 =
     Css.property "gap" "1rem"
@@ -19089,7 +19105,6 @@ gap_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_40 : Css.Style
 gap_40 =
     Css.property "gap" "10rem"
@@ -19100,7 +19115,6 @@ gap_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_44 : Css.Style
 gap_44 =
     Css.property "gap" "11rem"
@@ -19111,7 +19125,6 @@ gap_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_48 : Css.Style
 gap_48 =
     Css.property "gap" "12rem"
@@ -19122,7 +19135,6 @@ gap_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_5 : Css.Style
 gap_5 =
     Css.property "gap" "1.25rem"
@@ -19133,7 +19145,6 @@ gap_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_52 : Css.Style
 gap_52 =
     Css.property "gap" "13rem"
@@ -19144,7 +19155,6 @@ gap_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_56 : Css.Style
 gap_56 =
     Css.property "gap" "14rem"
@@ -19155,7 +19165,6 @@ gap_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_6 : Css.Style
 gap_6 =
     Css.property "gap" "1.5rem"
@@ -19166,7 +19175,6 @@ gap_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_60 : Css.Style
 gap_60 =
     Css.property "gap" "15rem"
@@ -19177,7 +19185,6 @@ gap_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_64 : Css.Style
 gap_64 =
     Css.property "gap" "16rem"
@@ -19188,7 +19195,6 @@ gap_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_7 : Css.Style
 gap_7 =
     Css.property "gap" "1.75rem"
@@ -19199,7 +19205,6 @@ gap_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_72 : Css.Style
 gap_72 =
     Css.property "gap" "18rem"
@@ -19210,7 +19215,6 @@ gap_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_8 : Css.Style
 gap_8 =
     Css.property "gap" "2rem"
@@ -19221,7 +19225,6 @@ gap_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_80 : Css.Style
 gap_80 =
     Css.property "gap" "20rem"
@@ -19232,7 +19235,6 @@ gap_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_9 : Css.Style
 gap_9 =
     Css.property "gap" "2.25rem"
@@ -19243,7 +19245,6 @@ gap_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_96 : Css.Style
 gap_96 =
     Css.property "gap" "24rem"
@@ -19254,7 +19255,6 @@ gap_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_px : Css.Style
 gap_px =
     Css.property "gap" "1px"
@@ -19265,7 +19265,6 @@ gap_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_0 : Css.Style
 gap_x_0 =
     Css.batch
@@ -19279,7 +19278,6 @@ gap_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_0_dot_5 : Css.Style
 gap_x_0_dot_5 =
     Css.batch
@@ -19293,7 +19291,6 @@ gap_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_1 : Css.Style
 gap_x_1 =
     Css.batch
@@ -19307,7 +19304,6 @@ gap_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_10 : Css.Style
 gap_x_10 =
     Css.batch
@@ -19321,7 +19317,6 @@ gap_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_11 : Css.Style
 gap_x_11 =
     Css.batch
@@ -19335,7 +19330,6 @@ gap_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_12 : Css.Style
 gap_x_12 =
     Css.batch
@@ -19349,7 +19343,6 @@ gap_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_14 : Css.Style
 gap_x_14 =
     Css.batch
@@ -19363,7 +19356,6 @@ gap_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_16 : Css.Style
 gap_x_16 =
     Css.batch
@@ -19377,7 +19369,6 @@ gap_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_1_dot_5 : Css.Style
 gap_x_1_dot_5 =
     Css.batch
@@ -19391,7 +19382,6 @@ gap_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_2 : Css.Style
 gap_x_2 =
     Css.batch
@@ -19405,7 +19395,6 @@ gap_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_20 : Css.Style
 gap_x_20 =
     Css.batch
@@ -19419,7 +19408,6 @@ gap_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_24 : Css.Style
 gap_x_24 =
     Css.batch
@@ -19433,7 +19421,6 @@ gap_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_28 : Css.Style
 gap_x_28 =
     Css.batch
@@ -19447,7 +19434,6 @@ gap_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_2_dot_5 : Css.Style
 gap_x_2_dot_5 =
     Css.batch
@@ -19461,7 +19447,6 @@ gap_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_3 : Css.Style
 gap_x_3 =
     Css.batch
@@ -19475,7 +19460,6 @@ gap_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_32 : Css.Style
 gap_x_32 =
     Css.batch
@@ -19489,7 +19473,6 @@ gap_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_36 : Css.Style
 gap_x_36 =
     Css.batch
@@ -19503,7 +19486,6 @@ gap_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_3_dot_5 : Css.Style
 gap_x_3_dot_5 =
     Css.batch
@@ -19517,7 +19499,6 @@ gap_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_4 : Css.Style
 gap_x_4 =
     Css.batch
@@ -19531,7 +19512,6 @@ gap_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_40 : Css.Style
 gap_x_40 =
     Css.batch
@@ -19545,7 +19525,6 @@ gap_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_44 : Css.Style
 gap_x_44 =
     Css.batch
@@ -19559,7 +19538,6 @@ gap_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_48 : Css.Style
 gap_x_48 =
     Css.batch
@@ -19573,7 +19551,6 @@ gap_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_5 : Css.Style
 gap_x_5 =
     Css.batch
@@ -19587,7 +19564,6 @@ gap_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_52 : Css.Style
 gap_x_52 =
     Css.batch
@@ -19601,7 +19577,6 @@ gap_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_56 : Css.Style
 gap_x_56 =
     Css.batch
@@ -19615,7 +19590,6 @@ gap_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_6 : Css.Style
 gap_x_6 =
     Css.batch
@@ -19629,7 +19603,6 @@ gap_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_60 : Css.Style
 gap_x_60 =
     Css.batch
@@ -19643,7 +19616,6 @@ gap_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_64 : Css.Style
 gap_x_64 =
     Css.batch
@@ -19657,7 +19629,6 @@ gap_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_7 : Css.Style
 gap_x_7 =
     Css.batch
@@ -19671,7 +19642,6 @@ gap_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_72 : Css.Style
 gap_x_72 =
     Css.batch
@@ -19685,7 +19655,6 @@ gap_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_8 : Css.Style
 gap_x_8 =
     Css.batch
@@ -19699,7 +19668,6 @@ gap_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_80 : Css.Style
 gap_x_80 =
     Css.batch
@@ -19713,7 +19681,6 @@ gap_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_9 : Css.Style
 gap_x_9 =
     Css.batch
@@ -19727,7 +19694,6 @@ gap_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_96 : Css.Style
 gap_x_96 =
     Css.batch
@@ -19741,7 +19707,6 @@ gap_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_x_px : Css.Style
 gap_x_px =
     Css.batch
@@ -19755,7 +19720,6 @@ gap_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_0 : Css.Style
 gap_y_0 =
     Css.property "row-gap" "0px"
@@ -19766,7 +19730,6 @@ gap_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_0_dot_5 : Css.Style
 gap_y_0_dot_5 =
     Css.property "row-gap" "0.125rem"
@@ -19777,7 +19740,6 @@ gap_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_1 : Css.Style
 gap_y_1 =
     Css.property "row-gap" "0.25rem"
@@ -19788,7 +19750,6 @@ gap_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_10 : Css.Style
 gap_y_10 =
     Css.property "row-gap" "2.5rem"
@@ -19799,7 +19760,6 @@ gap_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_11 : Css.Style
 gap_y_11 =
     Css.property "row-gap" "2.75rem"
@@ -19810,7 +19770,6 @@ gap_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_12 : Css.Style
 gap_y_12 =
     Css.property "row-gap" "3rem"
@@ -19821,7 +19780,6 @@ gap_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_14 : Css.Style
 gap_y_14 =
     Css.property "row-gap" "3.5rem"
@@ -19832,7 +19790,6 @@ gap_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_16 : Css.Style
 gap_y_16 =
     Css.property "row-gap" "4rem"
@@ -19843,7 +19800,6 @@ gap_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_1_dot_5 : Css.Style
 gap_y_1_dot_5 =
     Css.property "row-gap" "0.375rem"
@@ -19854,7 +19810,6 @@ gap_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_2 : Css.Style
 gap_y_2 =
     Css.property "row-gap" "0.5rem"
@@ -19865,7 +19820,6 @@ gap_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_20 : Css.Style
 gap_y_20 =
     Css.property "row-gap" "5rem"
@@ -19876,7 +19830,6 @@ gap_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_24 : Css.Style
 gap_y_24 =
     Css.property "row-gap" "6rem"
@@ -19887,7 +19840,6 @@ gap_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_28 : Css.Style
 gap_y_28 =
     Css.property "row-gap" "7rem"
@@ -19898,7 +19850,6 @@ gap_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_2_dot_5 : Css.Style
 gap_y_2_dot_5 =
     Css.property "row-gap" "0.625rem"
@@ -19909,7 +19860,6 @@ gap_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_3 : Css.Style
 gap_y_3 =
     Css.property "row-gap" "0.75rem"
@@ -19920,7 +19870,6 @@ gap_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_32 : Css.Style
 gap_y_32 =
     Css.property "row-gap" "8rem"
@@ -19931,7 +19880,6 @@ gap_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_36 : Css.Style
 gap_y_36 =
     Css.property "row-gap" "9rem"
@@ -19942,7 +19890,6 @@ gap_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_3_dot_5 : Css.Style
 gap_y_3_dot_5 =
     Css.property "row-gap" "0.875rem"
@@ -19953,7 +19900,6 @@ gap_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_4 : Css.Style
 gap_y_4 =
     Css.property "row-gap" "1rem"
@@ -19964,7 +19910,6 @@ gap_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_40 : Css.Style
 gap_y_40 =
     Css.property "row-gap" "10rem"
@@ -19975,7 +19920,6 @@ gap_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_44 : Css.Style
 gap_y_44 =
     Css.property "row-gap" "11rem"
@@ -19986,7 +19930,6 @@ gap_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_48 : Css.Style
 gap_y_48 =
     Css.property "row-gap" "12rem"
@@ -19997,7 +19940,6 @@ gap_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_5 : Css.Style
 gap_y_5 =
     Css.property "row-gap" "1.25rem"
@@ -20008,7 +19950,6 @@ gap_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_52 : Css.Style
 gap_y_52 =
     Css.property "row-gap" "13rem"
@@ -20019,7 +19960,6 @@ gap_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_56 : Css.Style
 gap_y_56 =
     Css.property "row-gap" "14rem"
@@ -20030,7 +19970,6 @@ gap_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_6 : Css.Style
 gap_y_6 =
     Css.property "row-gap" "1.5rem"
@@ -20041,7 +19980,6 @@ gap_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_60 : Css.Style
 gap_y_60 =
     Css.property "row-gap" "15rem"
@@ -20052,7 +19990,6 @@ gap_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_64 : Css.Style
 gap_y_64 =
     Css.property "row-gap" "16rem"
@@ -20063,7 +20000,6 @@ gap_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_7 : Css.Style
 gap_y_7 =
     Css.property "row-gap" "1.75rem"
@@ -20074,7 +20010,6 @@ gap_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_72 : Css.Style
 gap_y_72 =
     Css.property "row-gap" "18rem"
@@ -20085,7 +20020,6 @@ gap_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_8 : Css.Style
 gap_y_8 =
     Css.property "row-gap" "2rem"
@@ -20096,7 +20030,6 @@ gap_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_80 : Css.Style
 gap_y_80 =
     Css.property "row-gap" "20rem"
@@ -20107,7 +20040,6 @@ gap_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_9 : Css.Style
 gap_y_9 =
     Css.property "row-gap" "2.25rem"
@@ -20118,7 +20050,6 @@ gap_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_96 : Css.Style
 gap_y_96 =
     Css.property "row-gap" "24rem"
@@ -20129,7 +20060,6 @@ gap_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 gap_y_px : Css.Style
 gap_y_px =
     Css.property "row-gap" "1px"
@@ -20140,7 +20070,6 @@ gap_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grayscale : Css.Style
 grayscale =
     Css.property "--tw-grayscale" "grayscale(100%)"
@@ -20151,7 +20080,6 @@ grayscale =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grayscale_0 : Css.Style
 grayscale_0 =
     Css.property "--tw-grayscale" "grayscale(0)"
@@ -20162,7 +20090,6 @@ grayscale_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid : Css.Style
 grid =
     Css.property "display" "grid"
@@ -20173,7 +20100,6 @@ grid =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_1 : Css.Style
 grid_cols_1 =
     Css.property "grid-template-columns" "repeat(1, minmax(0, 1fr))"
@@ -20184,7 +20110,6 @@ grid_cols_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_10 : Css.Style
 grid_cols_10 =
     Css.property "grid-template-columns" "repeat(10, minmax(0, 1fr))"
@@ -20195,7 +20120,6 @@ grid_cols_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_11 : Css.Style
 grid_cols_11 =
     Css.property "grid-template-columns" "repeat(11, minmax(0, 1fr))"
@@ -20206,7 +20130,6 @@ grid_cols_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_12 : Css.Style
 grid_cols_12 =
     Css.property "grid-template-columns" "repeat(12, minmax(0, 1fr))"
@@ -20217,7 +20140,6 @@ grid_cols_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_2 : Css.Style
 grid_cols_2 =
     Css.property "grid-template-columns" "repeat(2, minmax(0, 1fr))"
@@ -20228,7 +20150,6 @@ grid_cols_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_3 : Css.Style
 grid_cols_3 =
     Css.property "grid-template-columns" "repeat(3, minmax(0, 1fr))"
@@ -20239,7 +20160,6 @@ grid_cols_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_4 : Css.Style
 grid_cols_4 =
     Css.property "grid-template-columns" "repeat(4, minmax(0, 1fr))"
@@ -20250,7 +20170,6 @@ grid_cols_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_5 : Css.Style
 grid_cols_5 =
     Css.property "grid-template-columns" "repeat(5, minmax(0, 1fr))"
@@ -20261,7 +20180,6 @@ grid_cols_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_6 : Css.Style
 grid_cols_6 =
     Css.property "grid-template-columns" "repeat(6, minmax(0, 1fr))"
@@ -20272,7 +20190,6 @@ grid_cols_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_7 : Css.Style
 grid_cols_7 =
     Css.property "grid-template-columns" "repeat(7, minmax(0, 1fr))"
@@ -20283,7 +20200,6 @@ grid_cols_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_8 : Css.Style
 grid_cols_8 =
     Css.property "grid-template-columns" "repeat(8, minmax(0, 1fr))"
@@ -20294,7 +20210,6 @@ grid_cols_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_9 : Css.Style
 grid_cols_9 =
     Css.property "grid-template-columns" "repeat(9, minmax(0, 1fr))"
@@ -20305,7 +20220,6 @@ grid_cols_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_cols_none : Css.Style
 grid_cols_none =
     Css.property "grid-template-columns" "none"
@@ -20316,7 +20230,6 @@ grid_cols_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_flow_col : Css.Style
 grid_flow_col =
     Css.property "grid-auto-flow" "column"
@@ -20327,7 +20240,6 @@ grid_flow_col =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_flow_col_dense : Css.Style
 grid_flow_col_dense =
     Css.property "grid-auto-flow" "column dense"
@@ -20338,7 +20250,6 @@ grid_flow_col_dense =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_flow_row : Css.Style
 grid_flow_row =
     Css.property "grid-auto-flow" "row"
@@ -20349,7 +20260,6 @@ grid_flow_row =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_flow_row_dense : Css.Style
 grid_flow_row_dense =
     Css.property "grid-auto-flow" "row dense"
@@ -20360,7 +20270,6 @@ grid_flow_row_dense =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_1 : Css.Style
 grid_rows_1 =
     Css.property "grid-template-rows" "repeat(1, minmax(0, 1fr))"
@@ -20371,7 +20280,6 @@ grid_rows_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_2 : Css.Style
 grid_rows_2 =
     Css.property "grid-template-rows" "repeat(2, minmax(0, 1fr))"
@@ -20382,7 +20290,6 @@ grid_rows_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_3 : Css.Style
 grid_rows_3 =
     Css.property "grid-template-rows" "repeat(3, minmax(0, 1fr))"
@@ -20393,7 +20300,6 @@ grid_rows_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_4 : Css.Style
 grid_rows_4 =
     Css.property "grid-template-rows" "repeat(4, minmax(0, 1fr))"
@@ -20404,7 +20310,6 @@ grid_rows_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_5 : Css.Style
 grid_rows_5 =
     Css.property "grid-template-rows" "repeat(5, minmax(0, 1fr))"
@@ -20415,7 +20320,6 @@ grid_rows_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_6 : Css.Style
 grid_rows_6 =
     Css.property "grid-template-rows" "repeat(6, minmax(0, 1fr))"
@@ -20426,7 +20330,6 @@ grid_rows_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 grid_rows_none : Css.Style
 grid_rows_none =
     Css.property "grid-template-rows" "none"
@@ -20437,7 +20340,6 @@ grid_rows_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_0 : Css.Style
 h_0 =
     Css.property "height" "0px"
@@ -20448,7 +20350,6 @@ h_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_0_dot_5 : Css.Style
 h_0_dot_5 =
     Css.property "height" "0.125rem"
@@ -20459,7 +20360,6 @@ h_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1 : Css.Style
 h_1 =
     Css.property "height" "0.25rem"
@@ -20470,7 +20370,6 @@ h_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_10 : Css.Style
 h_10 =
     Css.property "height" "2.5rem"
@@ -20481,7 +20380,6 @@ h_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_11 : Css.Style
 h_11 =
     Css.property "height" "2.75rem"
@@ -20492,7 +20390,6 @@ h_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_12 : Css.Style
 h_12 =
     Css.property "height" "3rem"
@@ -20503,7 +20400,6 @@ h_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_14 : Css.Style
 h_14 =
     Css.property "height" "3.5rem"
@@ -20514,7 +20410,6 @@ h_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_16 : Css.Style
 h_16 =
     Css.property "height" "4rem"
@@ -20525,7 +20420,6 @@ h_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1_dot_5 : Css.Style
 h_1_dot_5 =
     Css.property "height" "0.375rem"
@@ -20536,7 +20430,6 @@ h_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1over2 : Css.Style
 h_1over2 =
     Css.property "height" "50%"
@@ -20547,7 +20440,6 @@ h_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1over3 : Css.Style
 h_1over3 =
     Css.property "height" "33.333333%"
@@ -20558,7 +20450,6 @@ h_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1over4 : Css.Style
 h_1over4 =
     Css.property "height" "25%"
@@ -20569,7 +20460,6 @@ h_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1over5 : Css.Style
 h_1over5 =
     Css.property "height" "20%"
@@ -20580,7 +20470,6 @@ h_1over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_1over6 : Css.Style
 h_1over6 =
     Css.property "height" "16.666667%"
@@ -20591,7 +20480,6 @@ h_1over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2 : Css.Style
 h_2 =
     Css.property "height" "0.5rem"
@@ -20602,7 +20490,6 @@ h_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_20 : Css.Style
 h_20 =
     Css.property "height" "5rem"
@@ -20613,7 +20500,6 @@ h_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_24 : Css.Style
 h_24 =
     Css.property "height" "6rem"
@@ -20624,7 +20510,6 @@ h_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_28 : Css.Style
 h_28 =
     Css.property "height" "7rem"
@@ -20635,7 +20520,6 @@ h_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2_dot_5 : Css.Style
 h_2_dot_5 =
     Css.property "height" "0.625rem"
@@ -20646,7 +20530,6 @@ h_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2over3 : Css.Style
 h_2over3 =
     Css.property "height" "66.666667%"
@@ -20657,7 +20540,6 @@ h_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2over4 : Css.Style
 h_2over4 =
     Css.property "height" "50%"
@@ -20668,7 +20550,6 @@ h_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2over5 : Css.Style
 h_2over5 =
     Css.property "height" "40%"
@@ -20679,7 +20560,6 @@ h_2over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_2over6 : Css.Style
 h_2over6 =
     Css.property "height" "33.333333%"
@@ -20690,7 +20570,6 @@ h_2over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_3 : Css.Style
 h_3 =
     Css.property "height" "0.75rem"
@@ -20701,7 +20580,6 @@ h_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_32 : Css.Style
 h_32 =
     Css.property "height" "8rem"
@@ -20712,7 +20590,6 @@ h_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_36 : Css.Style
 h_36 =
     Css.property "height" "9rem"
@@ -20723,7 +20600,6 @@ h_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_3_dot_5 : Css.Style
 h_3_dot_5 =
     Css.property "height" "0.875rem"
@@ -20734,7 +20610,6 @@ h_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_3over4 : Css.Style
 h_3over4 =
     Css.property "height" "75%"
@@ -20745,7 +20620,6 @@ h_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_3over5 : Css.Style
 h_3over5 =
     Css.property "height" "60%"
@@ -20756,7 +20630,6 @@ h_3over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_3over6 : Css.Style
 h_3over6 =
     Css.property "height" "50%"
@@ -20767,7 +20640,6 @@ h_3over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_4 : Css.Style
 h_4 =
     Css.property "height" "1rem"
@@ -20778,7 +20650,6 @@ h_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_40 : Css.Style
 h_40 =
     Css.property "height" "10rem"
@@ -20789,7 +20660,6 @@ h_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_44 : Css.Style
 h_44 =
     Css.property "height" "11rem"
@@ -20800,7 +20670,6 @@ h_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_48 : Css.Style
 h_48 =
     Css.property "height" "12rem"
@@ -20811,7 +20680,6 @@ h_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_4over5 : Css.Style
 h_4over5 =
     Css.property "height" "80%"
@@ -20822,7 +20690,6 @@ h_4over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_4over6 : Css.Style
 h_4over6 =
     Css.property "height" "66.666667%"
@@ -20833,7 +20700,6 @@ h_4over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_5 : Css.Style
 h_5 =
     Css.property "height" "1.25rem"
@@ -20844,7 +20710,6 @@ h_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_52 : Css.Style
 h_52 =
     Css.property "height" "13rem"
@@ -20855,7 +20720,6 @@ h_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_56 : Css.Style
 h_56 =
     Css.property "height" "14rem"
@@ -20866,7 +20730,6 @@ h_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_5over6 : Css.Style
 h_5over6 =
     Css.property "height" "83.333333%"
@@ -20877,7 +20740,6 @@ h_5over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_6 : Css.Style
 h_6 =
     Css.property "height" "1.5rem"
@@ -20888,7 +20750,6 @@ h_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_60 : Css.Style
 h_60 =
     Css.property "height" "15rem"
@@ -20899,7 +20760,6 @@ h_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_64 : Css.Style
 h_64 =
     Css.property "height" "16rem"
@@ -20910,7 +20770,6 @@ h_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_7 : Css.Style
 h_7 =
     Css.property "height" "1.75rem"
@@ -20921,7 +20780,6 @@ h_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_72 : Css.Style
 h_72 =
     Css.property "height" "18rem"
@@ -20932,7 +20790,6 @@ h_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_8 : Css.Style
 h_8 =
     Css.property "height" "2rem"
@@ -20943,7 +20800,6 @@ h_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_80 : Css.Style
 h_80 =
     Css.property "height" "20rem"
@@ -20954,7 +20810,6 @@ h_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_9 : Css.Style
 h_9 =
     Css.property "height" "2.25rem"
@@ -20965,7 +20820,6 @@ h_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_96 : Css.Style
 h_96 =
     Css.property "height" "24rem"
@@ -20976,7 +20830,6 @@ h_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_auto : Css.Style
 h_auto =
     Css.property "height" "auto"
@@ -20987,7 +20840,6 @@ h_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_full : Css.Style
 h_full =
     Css.property "height" "100%"
@@ -20998,7 +20850,6 @@ h_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_px : Css.Style
 h_px =
     Css.property "height" "1px"
@@ -21009,7 +20860,6 @@ h_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 h_screen : Css.Style
 h_screen =
     Css.property "height" "100vh"
@@ -21020,7 +20870,6 @@ h_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hidden : Css.Style
 hidden =
     Css.property "display" "none"
@@ -21031,7 +20880,6 @@ hidden =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_0 : Css.Style
 hue_rotate_0 =
     Css.property "--tw-hue-rotate" "hue-rotate(0deg)"
@@ -21042,7 +20890,6 @@ hue_rotate_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_15 : Css.Style
 hue_rotate_15 =
     Css.property "--tw-hue-rotate" "hue-rotate(15deg)"
@@ -21053,7 +20900,6 @@ hue_rotate_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_180 : Css.Style
 hue_rotate_180 =
     Css.property "--tw-hue-rotate" "hue-rotate(180deg)"
@@ -21064,7 +20910,6 @@ hue_rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_30 : Css.Style
 hue_rotate_30 =
     Css.property "--tw-hue-rotate" "hue-rotate(30deg)"
@@ -21075,7 +20920,6 @@ hue_rotate_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_60 : Css.Style
 hue_rotate_60 =
     Css.property "--tw-hue-rotate" "hue-rotate(60deg)"
@@ -21086,7 +20930,6 @@ hue_rotate_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 hue_rotate_90 : Css.Style
 hue_rotate_90 =
     Css.property "--tw-hue-rotate" "hue-rotate(90deg)"
@@ -21097,7 +20940,6 @@ hue_rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inline : Css.Style
 inline =
     Css.property "display" "inline"
@@ -21108,7 +20950,6 @@ inline =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inline_block : Css.Style
 inline_block =
     Css.property "display" "inline-block"
@@ -21119,7 +20960,6 @@ inline_block =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inline_flex : Css.Style
 inline_flex =
     Css.property "display" "inline-flex"
@@ -21130,7 +20970,6 @@ inline_flex =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inline_grid : Css.Style
 inline_grid =
     Css.property "display" "inline-grid"
@@ -21141,7 +20980,6 @@ inline_grid =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inline_table : Css.Style
 inline_table =
     Css.property "display" "inline-table"
@@ -21152,7 +20990,6 @@ inline_table =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_0 : Css.Style
 inset_0 =
     Css.batch
@@ -21168,7 +21005,6 @@ inset_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_0_dot_5 : Css.Style
 inset_0_dot_5 =
     Css.batch
@@ -21184,7 +21020,6 @@ inset_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_1 : Css.Style
 inset_1 =
     Css.batch
@@ -21200,7 +21035,6 @@ inset_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_10 : Css.Style
 inset_10 =
     Css.batch
@@ -21216,7 +21050,6 @@ inset_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_11 : Css.Style
 inset_11 =
     Css.batch
@@ -21232,7 +21065,6 @@ inset_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_12 : Css.Style
 inset_12 =
     Css.batch
@@ -21248,7 +21080,6 @@ inset_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_14 : Css.Style
 inset_14 =
     Css.batch
@@ -21264,7 +21095,6 @@ inset_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_16 : Css.Style
 inset_16 =
     Css.batch
@@ -21280,7 +21110,6 @@ inset_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_1_dot_5 : Css.Style
 inset_1_dot_5 =
     Css.batch
@@ -21296,7 +21125,6 @@ inset_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_1over2 : Css.Style
 inset_1over2 =
     Css.batch
@@ -21312,7 +21140,6 @@ inset_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_1over3 : Css.Style
 inset_1over3 =
     Css.batch
@@ -21328,7 +21155,6 @@ inset_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_1over4 : Css.Style
 inset_1over4 =
     Css.batch
@@ -21344,7 +21170,6 @@ inset_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_2 : Css.Style
 inset_2 =
     Css.batch
@@ -21360,7 +21185,6 @@ inset_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_20 : Css.Style
 inset_20 =
     Css.batch
@@ -21376,7 +21200,6 @@ inset_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_24 : Css.Style
 inset_24 =
     Css.batch
@@ -21392,7 +21215,6 @@ inset_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_28 : Css.Style
 inset_28 =
     Css.batch
@@ -21408,7 +21230,6 @@ inset_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_2_dot_5 : Css.Style
 inset_2_dot_5 =
     Css.batch
@@ -21424,7 +21245,6 @@ inset_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_2over3 : Css.Style
 inset_2over3 =
     Css.batch
@@ -21440,7 +21260,6 @@ inset_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_2over4 : Css.Style
 inset_2over4 =
     Css.batch
@@ -21456,7 +21275,6 @@ inset_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_3 : Css.Style
 inset_3 =
     Css.batch
@@ -21472,7 +21290,6 @@ inset_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_32 : Css.Style
 inset_32 =
     Css.batch
@@ -21488,7 +21305,6 @@ inset_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_36 : Css.Style
 inset_36 =
     Css.batch
@@ -21504,7 +21320,6 @@ inset_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_3_dot_5 : Css.Style
 inset_3_dot_5 =
     Css.batch
@@ -21520,7 +21335,6 @@ inset_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_3over4 : Css.Style
 inset_3over4 =
     Css.batch
@@ -21536,7 +21350,6 @@ inset_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_4 : Css.Style
 inset_4 =
     Css.batch
@@ -21552,7 +21365,6 @@ inset_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_40 : Css.Style
 inset_40 =
     Css.batch
@@ -21568,7 +21380,6 @@ inset_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_44 : Css.Style
 inset_44 =
     Css.batch
@@ -21584,7 +21395,6 @@ inset_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_48 : Css.Style
 inset_48 =
     Css.batch
@@ -21600,7 +21410,6 @@ inset_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_5 : Css.Style
 inset_5 =
     Css.batch
@@ -21616,7 +21425,6 @@ inset_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_52 : Css.Style
 inset_52 =
     Css.batch
@@ -21632,7 +21440,6 @@ inset_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_56 : Css.Style
 inset_56 =
     Css.batch
@@ -21648,7 +21455,6 @@ inset_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_6 : Css.Style
 inset_6 =
     Css.batch
@@ -21664,7 +21470,6 @@ inset_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_60 : Css.Style
 inset_60 =
     Css.batch
@@ -21680,7 +21485,6 @@ inset_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_64 : Css.Style
 inset_64 =
     Css.batch
@@ -21696,7 +21500,6 @@ inset_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_7 : Css.Style
 inset_7 =
     Css.batch
@@ -21712,7 +21515,6 @@ inset_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_72 : Css.Style
 inset_72 =
     Css.batch
@@ -21728,7 +21530,6 @@ inset_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_8 : Css.Style
 inset_8 =
     Css.batch
@@ -21744,7 +21545,6 @@ inset_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_80 : Css.Style
 inset_80 =
     Css.batch
@@ -21760,7 +21560,6 @@ inset_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_9 : Css.Style
 inset_9 =
     Css.batch
@@ -21776,7 +21575,6 @@ inset_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_96 : Css.Style
 inset_96 =
     Css.batch
@@ -21792,7 +21590,6 @@ inset_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_auto : Css.Style
 inset_auto =
     Css.batch
@@ -21808,7 +21605,6 @@ inset_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_full : Css.Style
 inset_full =
     Css.batch
@@ -21824,7 +21620,6 @@ inset_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_px : Css.Style
 inset_px =
     Css.batch
@@ -21840,7 +21635,6 @@ inset_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_0 : Css.Style
 inset_x_0 =
     Css.batch
@@ -21854,7 +21648,6 @@ inset_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_0_dot_5 : Css.Style
 inset_x_0_dot_5 =
     Css.batch
@@ -21868,7 +21661,6 @@ inset_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_1 : Css.Style
 inset_x_1 =
     Css.batch
@@ -21882,7 +21674,6 @@ inset_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_10 : Css.Style
 inset_x_10 =
     Css.batch
@@ -21896,7 +21687,6 @@ inset_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_11 : Css.Style
 inset_x_11 =
     Css.batch
@@ -21910,7 +21700,6 @@ inset_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_12 : Css.Style
 inset_x_12 =
     Css.batch
@@ -21924,7 +21713,6 @@ inset_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_14 : Css.Style
 inset_x_14 =
     Css.batch
@@ -21938,7 +21726,6 @@ inset_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_16 : Css.Style
 inset_x_16 =
     Css.batch
@@ -21952,7 +21739,6 @@ inset_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_1_dot_5 : Css.Style
 inset_x_1_dot_5 =
     Css.batch
@@ -21966,7 +21752,6 @@ inset_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_1over2 : Css.Style
 inset_x_1over2 =
     Css.batch
@@ -21980,7 +21765,6 @@ inset_x_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_1over3 : Css.Style
 inset_x_1over3 =
     Css.batch
@@ -21994,7 +21778,6 @@ inset_x_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_1over4 : Css.Style
 inset_x_1over4 =
     Css.batch
@@ -22008,7 +21791,6 @@ inset_x_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_2 : Css.Style
 inset_x_2 =
     Css.batch
@@ -22022,7 +21804,6 @@ inset_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_20 : Css.Style
 inset_x_20 =
     Css.batch
@@ -22036,7 +21817,6 @@ inset_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_24 : Css.Style
 inset_x_24 =
     Css.batch
@@ -22050,7 +21830,6 @@ inset_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_28 : Css.Style
 inset_x_28 =
     Css.batch
@@ -22064,7 +21843,6 @@ inset_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_2_dot_5 : Css.Style
 inset_x_2_dot_5 =
     Css.batch
@@ -22078,7 +21856,6 @@ inset_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_2over3 : Css.Style
 inset_x_2over3 =
     Css.batch
@@ -22092,7 +21869,6 @@ inset_x_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_2over4 : Css.Style
 inset_x_2over4 =
     Css.batch
@@ -22106,7 +21882,6 @@ inset_x_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_3 : Css.Style
 inset_x_3 =
     Css.batch
@@ -22120,7 +21895,6 @@ inset_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_32 : Css.Style
 inset_x_32 =
     Css.batch
@@ -22134,7 +21908,6 @@ inset_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_36 : Css.Style
 inset_x_36 =
     Css.batch
@@ -22148,7 +21921,6 @@ inset_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_3_dot_5 : Css.Style
 inset_x_3_dot_5 =
     Css.batch
@@ -22162,7 +21934,6 @@ inset_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_3over4 : Css.Style
 inset_x_3over4 =
     Css.batch
@@ -22176,7 +21947,6 @@ inset_x_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_4 : Css.Style
 inset_x_4 =
     Css.batch
@@ -22190,7 +21960,6 @@ inset_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_40 : Css.Style
 inset_x_40 =
     Css.batch
@@ -22204,7 +21973,6 @@ inset_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_44 : Css.Style
 inset_x_44 =
     Css.batch
@@ -22218,7 +21986,6 @@ inset_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_48 : Css.Style
 inset_x_48 =
     Css.batch
@@ -22232,7 +21999,6 @@ inset_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_5 : Css.Style
 inset_x_5 =
     Css.batch
@@ -22246,7 +22012,6 @@ inset_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_52 : Css.Style
 inset_x_52 =
     Css.batch
@@ -22260,7 +22025,6 @@ inset_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_56 : Css.Style
 inset_x_56 =
     Css.batch
@@ -22274,7 +22038,6 @@ inset_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_6 : Css.Style
 inset_x_6 =
     Css.batch
@@ -22288,7 +22051,6 @@ inset_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_60 : Css.Style
 inset_x_60 =
     Css.batch
@@ -22302,7 +22064,6 @@ inset_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_64 : Css.Style
 inset_x_64 =
     Css.batch
@@ -22316,7 +22077,6 @@ inset_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_7 : Css.Style
 inset_x_7 =
     Css.batch
@@ -22330,7 +22090,6 @@ inset_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_72 : Css.Style
 inset_x_72 =
     Css.batch
@@ -22344,7 +22103,6 @@ inset_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_8 : Css.Style
 inset_x_8 =
     Css.batch
@@ -22358,7 +22116,6 @@ inset_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_80 : Css.Style
 inset_x_80 =
     Css.batch
@@ -22372,7 +22129,6 @@ inset_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_9 : Css.Style
 inset_x_9 =
     Css.batch
@@ -22386,7 +22142,6 @@ inset_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_96 : Css.Style
 inset_x_96 =
     Css.batch
@@ -22400,7 +22155,6 @@ inset_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_auto : Css.Style
 inset_x_auto =
     Css.batch
@@ -22414,7 +22168,6 @@ inset_x_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_full : Css.Style
 inset_x_full =
     Css.batch
@@ -22428,7 +22181,6 @@ inset_x_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_x_px : Css.Style
 inset_x_px =
     Css.batch
@@ -22442,7 +22194,6 @@ inset_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_0 : Css.Style
 inset_y_0 =
     Css.batch
@@ -22456,7 +22207,6 @@ inset_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_0_dot_5 : Css.Style
 inset_y_0_dot_5 =
     Css.batch
@@ -22470,7 +22220,6 @@ inset_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_1 : Css.Style
 inset_y_1 =
     Css.batch
@@ -22484,7 +22233,6 @@ inset_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_10 : Css.Style
 inset_y_10 =
     Css.batch
@@ -22498,7 +22246,6 @@ inset_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_11 : Css.Style
 inset_y_11 =
     Css.batch
@@ -22512,7 +22259,6 @@ inset_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_12 : Css.Style
 inset_y_12 =
     Css.batch
@@ -22526,7 +22272,6 @@ inset_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_14 : Css.Style
 inset_y_14 =
     Css.batch
@@ -22540,7 +22285,6 @@ inset_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_16 : Css.Style
 inset_y_16 =
     Css.batch
@@ -22554,7 +22298,6 @@ inset_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_1_dot_5 : Css.Style
 inset_y_1_dot_5 =
     Css.batch
@@ -22568,7 +22311,6 @@ inset_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_1over2 : Css.Style
 inset_y_1over2 =
     Css.batch
@@ -22582,7 +22324,6 @@ inset_y_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_1over3 : Css.Style
 inset_y_1over3 =
     Css.batch
@@ -22596,7 +22337,6 @@ inset_y_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_1over4 : Css.Style
 inset_y_1over4 =
     Css.batch
@@ -22610,7 +22350,6 @@ inset_y_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_2 : Css.Style
 inset_y_2 =
     Css.batch
@@ -22624,7 +22363,6 @@ inset_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_20 : Css.Style
 inset_y_20 =
     Css.batch
@@ -22638,7 +22376,6 @@ inset_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_24 : Css.Style
 inset_y_24 =
     Css.batch
@@ -22652,7 +22389,6 @@ inset_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_28 : Css.Style
 inset_y_28 =
     Css.batch
@@ -22666,7 +22402,6 @@ inset_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_2_dot_5 : Css.Style
 inset_y_2_dot_5 =
     Css.batch
@@ -22680,7 +22415,6 @@ inset_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_2over3 : Css.Style
 inset_y_2over3 =
     Css.batch
@@ -22694,7 +22428,6 @@ inset_y_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_2over4 : Css.Style
 inset_y_2over4 =
     Css.batch
@@ -22708,7 +22441,6 @@ inset_y_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_3 : Css.Style
 inset_y_3 =
     Css.batch
@@ -22722,7 +22454,6 @@ inset_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_32 : Css.Style
 inset_y_32 =
     Css.batch
@@ -22736,7 +22467,6 @@ inset_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_36 : Css.Style
 inset_y_36 =
     Css.batch
@@ -22750,7 +22480,6 @@ inset_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_3_dot_5 : Css.Style
 inset_y_3_dot_5 =
     Css.batch
@@ -22764,7 +22493,6 @@ inset_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_3over4 : Css.Style
 inset_y_3over4 =
     Css.batch
@@ -22778,7 +22506,6 @@ inset_y_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_4 : Css.Style
 inset_y_4 =
     Css.batch
@@ -22792,7 +22519,6 @@ inset_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_40 : Css.Style
 inset_y_40 =
     Css.batch
@@ -22806,7 +22532,6 @@ inset_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_44 : Css.Style
 inset_y_44 =
     Css.batch
@@ -22820,7 +22545,6 @@ inset_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_48 : Css.Style
 inset_y_48 =
     Css.batch
@@ -22834,7 +22558,6 @@ inset_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_5 : Css.Style
 inset_y_5 =
     Css.batch
@@ -22848,7 +22571,6 @@ inset_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_52 : Css.Style
 inset_y_52 =
     Css.batch
@@ -22862,7 +22584,6 @@ inset_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_56 : Css.Style
 inset_y_56 =
     Css.batch
@@ -22876,7 +22597,6 @@ inset_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_6 : Css.Style
 inset_y_6 =
     Css.batch
@@ -22890,7 +22610,6 @@ inset_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_60 : Css.Style
 inset_y_60 =
     Css.batch
@@ -22904,7 +22623,6 @@ inset_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_64 : Css.Style
 inset_y_64 =
     Css.batch
@@ -22918,7 +22636,6 @@ inset_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_7 : Css.Style
 inset_y_7 =
     Css.batch
@@ -22932,7 +22649,6 @@ inset_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_72 : Css.Style
 inset_y_72 =
     Css.batch
@@ -22946,7 +22662,6 @@ inset_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_8 : Css.Style
 inset_y_8 =
     Css.batch
@@ -22960,7 +22675,6 @@ inset_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_80 : Css.Style
 inset_y_80 =
     Css.batch
@@ -22974,7 +22688,6 @@ inset_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_9 : Css.Style
 inset_y_9 =
     Css.batch
@@ -22988,7 +22701,6 @@ inset_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_96 : Css.Style
 inset_y_96 =
     Css.batch
@@ -23002,7 +22714,6 @@ inset_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_auto : Css.Style
 inset_y_auto =
     Css.batch
@@ -23016,7 +22727,6 @@ inset_y_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_full : Css.Style
 inset_y_full =
     Css.batch
@@ -23030,7 +22740,6 @@ inset_y_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 inset_y_px : Css.Style
 inset_y_px =
     Css.batch
@@ -23044,7 +22753,6 @@ inset_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 invert : Css.Style
 invert =
     Css.property "--tw-invert" "invert(100%)"
@@ -23055,7 +22763,6 @@ invert =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 invert_0 : Css.Style
 invert_0 =
     Css.property "--tw-invert" "invert(0)"
@@ -23066,7 +22773,6 @@ invert_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 invisible : Css.Style
 invisible =
     Css.property "visibility" "hidden"
@@ -23077,7 +22783,6 @@ invisible =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 isolate : Css.Style
 isolate =
     Css.property "isolation" "isolate"
@@ -23088,7 +22793,6 @@ isolate =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 isolation_auto : Css.Style
 isolation_auto =
     Css.property "isolation" "auto"
@@ -23099,7 +22803,6 @@ isolation_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 italic : Css.Style
 italic =
     Css.property "font-style" "italic"
@@ -23110,7 +22813,6 @@ italic =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 items_baseline : Css.Style
 items_baseline =
     Css.property "align-items" "baseline"
@@ -23121,7 +22823,6 @@ items_baseline =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 items_center : Css.Style
 items_center =
     Css.property "align-items" "center"
@@ -23132,7 +22833,6 @@ items_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 items_end : Css.Style
 items_end =
     Css.property "align-items" "flex-end"
@@ -23143,7 +22843,6 @@ items_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 items_start : Css.Style
 items_start =
     Css.property "align-items" "flex-start"
@@ -23154,7 +22853,6 @@ items_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 items_stretch : Css.Style
 items_stretch =
     Css.property "align-items" "stretch"
@@ -23165,7 +22863,6 @@ items_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_around : Css.Style
 justify_around =
     Css.property "justify-content" "space-around"
@@ -23176,7 +22873,6 @@ justify_around =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_between : Css.Style
 justify_between =
     Css.property "justify-content" "space-between"
@@ -23187,7 +22883,6 @@ justify_between =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_center : Css.Style
 justify_center =
     Css.property "justify-content" "center"
@@ -23198,7 +22893,6 @@ justify_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_end : Css.Style
 justify_end =
     Css.property "justify-content" "flex-end"
@@ -23209,7 +22903,6 @@ justify_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_evenly : Css.Style
 justify_evenly =
     Css.property "justify-content" "space-evenly"
@@ -23220,7 +22913,6 @@ justify_evenly =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_items_center : Css.Style
 justify_items_center =
     Css.property "justify-items" "center"
@@ -23231,7 +22923,6 @@ justify_items_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_items_end : Css.Style
 justify_items_end =
     Css.property "justify-items" "end"
@@ -23242,7 +22933,6 @@ justify_items_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_items_start : Css.Style
 justify_items_start =
     Css.property "justify-items" "start"
@@ -23253,7 +22943,6 @@ justify_items_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_items_stretch : Css.Style
 justify_items_stretch =
     Css.property "justify-items" "stretch"
@@ -23264,7 +22953,6 @@ justify_items_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_self_auto : Css.Style
 justify_self_auto =
     Css.property "justify-self" "auto"
@@ -23275,7 +22963,6 @@ justify_self_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_self_center : Css.Style
 justify_self_center =
     Css.property "justify-self" "center"
@@ -23286,7 +22973,6 @@ justify_self_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_self_end : Css.Style
 justify_self_end =
     Css.property "justify-self" "end"
@@ -23297,7 +22983,6 @@ justify_self_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_self_start : Css.Style
 justify_self_start =
     Css.property "justify-self" "start"
@@ -23308,7 +22993,6 @@ justify_self_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_self_stretch : Css.Style
 justify_self_stretch =
     Css.property "justify-self" "stretch"
@@ -23319,7 +23003,6 @@ justify_self_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 justify_start : Css.Style
 justify_start =
     Css.property "justify-content" "flex-start"
@@ -23330,7 +23013,6 @@ justify_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_10 : Css.Style
 leading_10 =
     Css.property "line-height" "2.5rem"
@@ -23341,7 +23023,6 @@ leading_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_3 : Css.Style
 leading_3 =
     Css.property "line-height" ".75rem"
@@ -23352,7 +23033,6 @@ leading_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_4 : Css.Style
 leading_4 =
     Css.property "line-height" "1rem"
@@ -23363,7 +23043,6 @@ leading_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_5 : Css.Style
 leading_5 =
     Css.property "line-height" "1.25rem"
@@ -23374,7 +23053,6 @@ leading_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_6 : Css.Style
 leading_6 =
     Css.property "line-height" "1.5rem"
@@ -23385,7 +23063,6 @@ leading_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_7 : Css.Style
 leading_7 =
     Css.property "line-height" "1.75rem"
@@ -23396,7 +23073,6 @@ leading_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_8 : Css.Style
 leading_8 =
     Css.property "line-height" "2rem"
@@ -23407,7 +23083,6 @@ leading_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_9 : Css.Style
 leading_9 =
     Css.property "line-height" "2.25rem"
@@ -23418,7 +23093,6 @@ leading_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_loose : Css.Style
 leading_loose =
     Css.property "line-height" "2"
@@ -23429,7 +23103,6 @@ leading_loose =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_none : Css.Style
 leading_none =
     Css.property "line-height" "1"
@@ -23440,7 +23113,6 @@ leading_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_normal : Css.Style
 leading_normal =
     Css.property "line-height" "1.5"
@@ -23451,7 +23123,6 @@ leading_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_relaxed : Css.Style
 leading_relaxed =
     Css.property "line-height" "1.625"
@@ -23462,7 +23133,6 @@ leading_relaxed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_snug : Css.Style
 leading_snug =
     Css.property "line-height" "1.375"
@@ -23473,7 +23143,6 @@ leading_snug =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 leading_tight : Css.Style
 leading_tight =
     Css.property "line-height" "1.25"
@@ -23484,7 +23153,6 @@ leading_tight =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_0 : Css.Style
 left_0 =
     Css.property "left" "0px"
@@ -23495,7 +23163,6 @@ left_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_0_dot_5 : Css.Style
 left_0_dot_5 =
     Css.property "left" "0.125rem"
@@ -23506,7 +23173,6 @@ left_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_1 : Css.Style
 left_1 =
     Css.property "left" "0.25rem"
@@ -23517,7 +23183,6 @@ left_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_10 : Css.Style
 left_10 =
     Css.property "left" "2.5rem"
@@ -23528,7 +23193,6 @@ left_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_11 : Css.Style
 left_11 =
     Css.property "left" "2.75rem"
@@ -23539,7 +23203,6 @@ left_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_12 : Css.Style
 left_12 =
     Css.property "left" "3rem"
@@ -23550,7 +23213,6 @@ left_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_14 : Css.Style
 left_14 =
     Css.property "left" "3.5rem"
@@ -23561,7 +23223,6 @@ left_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_16 : Css.Style
 left_16 =
     Css.property "left" "4rem"
@@ -23572,7 +23233,6 @@ left_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_1_dot_5 : Css.Style
 left_1_dot_5 =
     Css.property "left" "0.375rem"
@@ -23583,7 +23243,6 @@ left_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_1over2 : Css.Style
 left_1over2 =
     Css.property "left" "50%"
@@ -23594,7 +23253,6 @@ left_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_1over3 : Css.Style
 left_1over3 =
     Css.property "left" "33.333333%"
@@ -23605,7 +23263,6 @@ left_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_1over4 : Css.Style
 left_1over4 =
     Css.property "left" "25%"
@@ -23616,7 +23273,6 @@ left_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_2 : Css.Style
 left_2 =
     Css.property "left" "0.5rem"
@@ -23627,7 +23283,6 @@ left_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_20 : Css.Style
 left_20 =
     Css.property "left" "5rem"
@@ -23638,7 +23293,6 @@ left_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_24 : Css.Style
 left_24 =
     Css.property "left" "6rem"
@@ -23649,7 +23303,6 @@ left_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_28 : Css.Style
 left_28 =
     Css.property "left" "7rem"
@@ -23660,7 +23313,6 @@ left_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_2_dot_5 : Css.Style
 left_2_dot_5 =
     Css.property "left" "0.625rem"
@@ -23671,7 +23323,6 @@ left_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_2over3 : Css.Style
 left_2over3 =
     Css.property "left" "66.666667%"
@@ -23682,7 +23333,6 @@ left_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_2over4 : Css.Style
 left_2over4 =
     Css.property "left" "50%"
@@ -23693,7 +23343,6 @@ left_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_3 : Css.Style
 left_3 =
     Css.property "left" "0.75rem"
@@ -23704,7 +23353,6 @@ left_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_32 : Css.Style
 left_32 =
     Css.property "left" "8rem"
@@ -23715,7 +23363,6 @@ left_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_36 : Css.Style
 left_36 =
     Css.property "left" "9rem"
@@ -23726,7 +23373,6 @@ left_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_3_dot_5 : Css.Style
 left_3_dot_5 =
     Css.property "left" "0.875rem"
@@ -23737,7 +23383,6 @@ left_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_3over4 : Css.Style
 left_3over4 =
     Css.property "left" "75%"
@@ -23748,7 +23393,6 @@ left_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_4 : Css.Style
 left_4 =
     Css.property "left" "1rem"
@@ -23759,7 +23403,6 @@ left_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_40 : Css.Style
 left_40 =
     Css.property "left" "10rem"
@@ -23770,7 +23413,6 @@ left_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_44 : Css.Style
 left_44 =
     Css.property "left" "11rem"
@@ -23781,7 +23423,6 @@ left_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_48 : Css.Style
 left_48 =
     Css.property "left" "12rem"
@@ -23792,7 +23433,6 @@ left_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_5 : Css.Style
 left_5 =
     Css.property "left" "1.25rem"
@@ -23803,7 +23443,6 @@ left_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_52 : Css.Style
 left_52 =
     Css.property "left" "13rem"
@@ -23814,7 +23453,6 @@ left_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_56 : Css.Style
 left_56 =
     Css.property "left" "14rem"
@@ -23825,7 +23463,6 @@ left_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_6 : Css.Style
 left_6 =
     Css.property "left" "1.5rem"
@@ -23836,7 +23473,6 @@ left_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_60 : Css.Style
 left_60 =
     Css.property "left" "15rem"
@@ -23847,7 +23483,6 @@ left_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_64 : Css.Style
 left_64 =
     Css.property "left" "16rem"
@@ -23858,7 +23493,6 @@ left_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_7 : Css.Style
 left_7 =
     Css.property "left" "1.75rem"
@@ -23869,7 +23503,6 @@ left_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_72 : Css.Style
 left_72 =
     Css.property "left" "18rem"
@@ -23880,7 +23513,6 @@ left_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_8 : Css.Style
 left_8 =
     Css.property "left" "2rem"
@@ -23891,7 +23523,6 @@ left_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_80 : Css.Style
 left_80 =
     Css.property "left" "20rem"
@@ -23902,7 +23533,6 @@ left_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_9 : Css.Style
 left_9 =
     Css.property "left" "2.25rem"
@@ -23913,7 +23543,6 @@ left_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_96 : Css.Style
 left_96 =
     Css.property "left" "24rem"
@@ -23924,7 +23553,6 @@ left_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_auto : Css.Style
 left_auto =
     Css.property "left" "auto"
@@ -23935,7 +23563,6 @@ left_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_full : Css.Style
 left_full =
     Css.property "left" "100%"
@@ -23946,7 +23573,6 @@ left_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 left_px : Css.Style
 left_px =
     Css.property "left" "1px"
@@ -23957,7 +23583,6 @@ left_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 line_through : Css.Style
 line_through =
     Css.property "text-decoration" "line-through"
@@ -23968,7 +23593,6 @@ line_through =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 lining_nums : Css.Style
 lining_nums =
     Css.batch
@@ -23987,7 +23611,6 @@ lining_nums =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_decimal : Css.Style
 list_decimal =
     Css.property "list-style-type" "decimal"
@@ -23998,7 +23621,6 @@ list_decimal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_disc : Css.Style
 list_disc =
     Css.property "list-style-type" "disc"
@@ -24009,7 +23631,6 @@ list_disc =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_inside : Css.Style
 list_inside =
     Css.property "list-style-position" "inside"
@@ -24020,7 +23641,6 @@ list_inside =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_item : Css.Style
 list_item =
     Css.property "display" "list-item"
@@ -24031,7 +23651,6 @@ list_item =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_none : Css.Style
 list_none =
     Css.property "list-style-type" "none"
@@ -24042,7 +23661,6 @@ list_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 list_outside : Css.Style
 list_outside =
     Css.property "list-style-position" "outside"
@@ -24053,7 +23671,6 @@ list_outside =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 lowercase : Css.Style
 lowercase =
     Css.property "text-transform" "lowercase"
@@ -24064,7 +23681,6 @@ lowercase =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_0 : Css.Style
 m_0 =
     Css.property "margin" "0px"
@@ -24075,7 +23691,6 @@ m_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_0_dot_5 : Css.Style
 m_0_dot_5 =
     Css.property "margin" "0.125rem"
@@ -24086,7 +23701,6 @@ m_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_1 : Css.Style
 m_1 =
     Css.property "margin" "0.25rem"
@@ -24097,7 +23711,6 @@ m_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_10 : Css.Style
 m_10 =
     Css.property "margin" "2.5rem"
@@ -24108,7 +23721,6 @@ m_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_11 : Css.Style
 m_11 =
     Css.property "margin" "2.75rem"
@@ -24119,7 +23731,6 @@ m_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_12 : Css.Style
 m_12 =
     Css.property "margin" "3rem"
@@ -24130,7 +23741,6 @@ m_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_14 : Css.Style
 m_14 =
     Css.property "margin" "3.5rem"
@@ -24141,7 +23751,6 @@ m_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_16 : Css.Style
 m_16 =
     Css.property "margin" "4rem"
@@ -24152,7 +23761,6 @@ m_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_1_dot_5 : Css.Style
 m_1_dot_5 =
     Css.property "margin" "0.375rem"
@@ -24163,7 +23771,6 @@ m_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_2 : Css.Style
 m_2 =
     Css.property "margin" "0.5rem"
@@ -24174,7 +23781,6 @@ m_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_20 : Css.Style
 m_20 =
     Css.property "margin" "5rem"
@@ -24185,7 +23791,6 @@ m_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_24 : Css.Style
 m_24 =
     Css.property "margin" "6rem"
@@ -24196,7 +23801,6 @@ m_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_28 : Css.Style
 m_28 =
     Css.property "margin" "7rem"
@@ -24207,7 +23811,6 @@ m_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_2_dot_5 : Css.Style
 m_2_dot_5 =
     Css.property "margin" "0.625rem"
@@ -24218,7 +23821,6 @@ m_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_3 : Css.Style
 m_3 =
     Css.property "margin" "0.75rem"
@@ -24229,7 +23831,6 @@ m_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_32 : Css.Style
 m_32 =
     Css.property "margin" "8rem"
@@ -24240,7 +23841,6 @@ m_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_36 : Css.Style
 m_36 =
     Css.property "margin" "9rem"
@@ -24251,7 +23851,6 @@ m_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_3_dot_5 : Css.Style
 m_3_dot_5 =
     Css.property "margin" "0.875rem"
@@ -24262,7 +23861,6 @@ m_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_4 : Css.Style
 m_4 =
     Css.property "margin" "1rem"
@@ -24273,7 +23871,6 @@ m_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_40 : Css.Style
 m_40 =
     Css.property "margin" "10rem"
@@ -24284,7 +23881,6 @@ m_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_44 : Css.Style
 m_44 =
     Css.property "margin" "11rem"
@@ -24295,7 +23891,6 @@ m_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_48 : Css.Style
 m_48 =
     Css.property "margin" "12rem"
@@ -24306,7 +23901,6 @@ m_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_5 : Css.Style
 m_5 =
     Css.property "margin" "1.25rem"
@@ -24317,7 +23911,6 @@ m_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_52 : Css.Style
 m_52 =
     Css.property "margin" "13rem"
@@ -24328,7 +23921,6 @@ m_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_56 : Css.Style
 m_56 =
     Css.property "margin" "14rem"
@@ -24339,7 +23931,6 @@ m_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_6 : Css.Style
 m_6 =
     Css.property "margin" "1.5rem"
@@ -24350,7 +23941,6 @@ m_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_60 : Css.Style
 m_60 =
     Css.property "margin" "15rem"
@@ -24361,7 +23951,6 @@ m_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_64 : Css.Style
 m_64 =
     Css.property "margin" "16rem"
@@ -24372,7 +23961,6 @@ m_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_7 : Css.Style
 m_7 =
     Css.property "margin" "1.75rem"
@@ -24383,7 +23971,6 @@ m_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_72 : Css.Style
 m_72 =
     Css.property "margin" "18rem"
@@ -24394,7 +23981,6 @@ m_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_8 : Css.Style
 m_8 =
     Css.property "margin" "2rem"
@@ -24405,7 +23991,6 @@ m_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_80 : Css.Style
 m_80 =
     Css.property "margin" "20rem"
@@ -24416,7 +24001,6 @@ m_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_9 : Css.Style
 m_9 =
     Css.property "margin" "2.25rem"
@@ -24427,7 +24011,6 @@ m_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_96 : Css.Style
 m_96 =
     Css.property "margin" "24rem"
@@ -24438,7 +24021,6 @@ m_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_auto : Css.Style
 m_auto =
     Css.property "margin" "auto"
@@ -24449,7 +24031,6 @@ m_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 m_px : Css.Style
 m_px =
     Css.property "margin" "1px"
@@ -24460,7 +24041,6 @@ m_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_0 : Css.Style
 max_h_0 =
     Css.property "max-height" "0px"
@@ -24471,7 +24051,6 @@ max_h_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_0_dot_5 : Css.Style
 max_h_0_dot_5 =
     Css.property "max-height" "0.125rem"
@@ -24482,7 +24061,6 @@ max_h_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_1 : Css.Style
 max_h_1 =
     Css.property "max-height" "0.25rem"
@@ -24493,7 +24071,6 @@ max_h_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_10 : Css.Style
 max_h_10 =
     Css.property "max-height" "2.5rem"
@@ -24504,7 +24081,6 @@ max_h_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_11 : Css.Style
 max_h_11 =
     Css.property "max-height" "2.75rem"
@@ -24515,7 +24091,6 @@ max_h_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_12 : Css.Style
 max_h_12 =
     Css.property "max-height" "3rem"
@@ -24526,7 +24101,6 @@ max_h_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_14 : Css.Style
 max_h_14 =
     Css.property "max-height" "3.5rem"
@@ -24537,7 +24111,6 @@ max_h_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_16 : Css.Style
 max_h_16 =
     Css.property "max-height" "4rem"
@@ -24548,7 +24121,6 @@ max_h_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_1_dot_5 : Css.Style
 max_h_1_dot_5 =
     Css.property "max-height" "0.375rem"
@@ -24559,7 +24131,6 @@ max_h_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_2 : Css.Style
 max_h_2 =
     Css.property "max-height" "0.5rem"
@@ -24570,7 +24141,6 @@ max_h_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_20 : Css.Style
 max_h_20 =
     Css.property "max-height" "5rem"
@@ -24581,7 +24151,6 @@ max_h_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_24 : Css.Style
 max_h_24 =
     Css.property "max-height" "6rem"
@@ -24592,7 +24161,6 @@ max_h_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_28 : Css.Style
 max_h_28 =
     Css.property "max-height" "7rem"
@@ -24603,7 +24171,6 @@ max_h_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_2_dot_5 : Css.Style
 max_h_2_dot_5 =
     Css.property "max-height" "0.625rem"
@@ -24614,7 +24181,6 @@ max_h_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_3 : Css.Style
 max_h_3 =
     Css.property "max-height" "0.75rem"
@@ -24625,7 +24191,6 @@ max_h_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_32 : Css.Style
 max_h_32 =
     Css.property "max-height" "8rem"
@@ -24636,7 +24201,6 @@ max_h_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_36 : Css.Style
 max_h_36 =
     Css.property "max-height" "9rem"
@@ -24647,7 +24211,6 @@ max_h_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_3_dot_5 : Css.Style
 max_h_3_dot_5 =
     Css.property "max-height" "0.875rem"
@@ -24658,7 +24221,6 @@ max_h_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_4 : Css.Style
 max_h_4 =
     Css.property "max-height" "1rem"
@@ -24669,7 +24231,6 @@ max_h_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_40 : Css.Style
 max_h_40 =
     Css.property "max-height" "10rem"
@@ -24680,7 +24241,6 @@ max_h_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_44 : Css.Style
 max_h_44 =
     Css.property "max-height" "11rem"
@@ -24691,7 +24251,6 @@ max_h_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_48 : Css.Style
 max_h_48 =
     Css.property "max-height" "12rem"
@@ -24702,7 +24261,6 @@ max_h_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_5 : Css.Style
 max_h_5 =
     Css.property "max-height" "1.25rem"
@@ -24713,7 +24271,6 @@ max_h_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_52 : Css.Style
 max_h_52 =
     Css.property "max-height" "13rem"
@@ -24724,7 +24281,6 @@ max_h_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_56 : Css.Style
 max_h_56 =
     Css.property "max-height" "14rem"
@@ -24735,7 +24291,6 @@ max_h_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_6 : Css.Style
 max_h_6 =
     Css.property "max-height" "1.5rem"
@@ -24746,7 +24301,6 @@ max_h_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_60 : Css.Style
 max_h_60 =
     Css.property "max-height" "15rem"
@@ -24757,7 +24311,6 @@ max_h_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_64 : Css.Style
 max_h_64 =
     Css.property "max-height" "16rem"
@@ -24768,7 +24321,6 @@ max_h_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_7 : Css.Style
 max_h_7 =
     Css.property "max-height" "1.75rem"
@@ -24779,7 +24331,6 @@ max_h_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_72 : Css.Style
 max_h_72 =
     Css.property "max-height" "18rem"
@@ -24790,7 +24341,6 @@ max_h_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_8 : Css.Style
 max_h_8 =
     Css.property "max-height" "2rem"
@@ -24801,7 +24351,6 @@ max_h_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_80 : Css.Style
 max_h_80 =
     Css.property "max-height" "20rem"
@@ -24812,7 +24361,6 @@ max_h_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_9 : Css.Style
 max_h_9 =
     Css.property "max-height" "2.25rem"
@@ -24823,7 +24371,6 @@ max_h_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_96 : Css.Style
 max_h_96 =
     Css.property "max-height" "24rem"
@@ -24834,7 +24381,6 @@ max_h_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_full : Css.Style
 max_h_full =
     Css.property "max-height" "100%"
@@ -24845,7 +24391,6 @@ max_h_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_px : Css.Style
 max_h_px =
     Css.property "max-height" "1px"
@@ -24856,7 +24401,6 @@ max_h_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_h_screen : Css.Style
 max_h_screen =
     Css.property "max-height" "100vh"
@@ -24867,7 +24411,6 @@ max_h_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_0 : Css.Style
 max_w_0 =
     Css.property "max-width" "0rem"
@@ -24878,7 +24421,6 @@ max_w_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_2xl : Css.Style
 max_w_2xl =
     Css.property "max-width" "42rem"
@@ -24889,7 +24431,6 @@ max_w_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_3xl : Css.Style
 max_w_3xl =
     Css.property "max-width" "48rem"
@@ -24900,7 +24441,6 @@ max_w_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_4xl : Css.Style
 max_w_4xl =
     Css.property "max-width" "56rem"
@@ -24911,7 +24451,6 @@ max_w_4xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_5xl : Css.Style
 max_w_5xl =
     Css.property "max-width" "64rem"
@@ -24922,7 +24461,6 @@ max_w_5xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_6xl : Css.Style
 max_w_6xl =
     Css.property "max-width" "72rem"
@@ -24933,7 +24471,6 @@ max_w_6xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_7xl : Css.Style
 max_w_7xl =
     Css.property "max-width" "80rem"
@@ -24944,7 +24481,6 @@ max_w_7xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_full : Css.Style
 max_w_full =
     Css.property "max-width" "100%"
@@ -24955,7 +24491,6 @@ max_w_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_lg : Css.Style
 max_w_lg =
     Css.property "max-width" "32rem"
@@ -24966,7 +24501,6 @@ max_w_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_max : Css.Style
 max_w_max =
     Css.batch
@@ -24981,7 +24515,6 @@ max_w_max =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_md : Css.Style
 max_w_md =
     Css.property "max-width" "28rem"
@@ -24992,7 +24525,6 @@ max_w_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_min : Css.Style
 max_w_min =
     Css.batch
@@ -25007,7 +24539,6 @@ max_w_min =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_none : Css.Style
 max_w_none =
     Css.property "max-width" "none"
@@ -25018,7 +24549,6 @@ max_w_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_prose : Css.Style
 max_w_prose =
     Css.property "max-width" "65ch"
@@ -25029,7 +24559,6 @@ max_w_prose =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_screen_2xl : Css.Style
 max_w_screen_2xl =
     Css.property "max-width" "1536px"
@@ -25040,7 +24569,6 @@ max_w_screen_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_screen_lg : Css.Style
 max_w_screen_lg =
     Css.property "max-width" "1024px"
@@ -25051,7 +24579,6 @@ max_w_screen_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_screen_md : Css.Style
 max_w_screen_md =
     Css.property "max-width" "768px"
@@ -25062,7 +24589,6 @@ max_w_screen_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_screen_sm : Css.Style
 max_w_screen_sm =
     Css.property "max-width" "640px"
@@ -25073,7 +24599,6 @@ max_w_screen_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_screen_xl : Css.Style
 max_w_screen_xl =
     Css.property "max-width" "1280px"
@@ -25084,7 +24609,6 @@ max_w_screen_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_sm : Css.Style
 max_w_sm =
     Css.property "max-width" "24rem"
@@ -25095,7 +24619,6 @@ max_w_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_xl : Css.Style
 max_w_xl =
     Css.property "max-width" "36rem"
@@ -25106,7 +24629,6 @@ max_w_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 max_w_xs : Css.Style
 max_w_xs =
     Css.property "max-width" "20rem"
@@ -25117,7 +24639,6 @@ max_w_xs =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_0 : Css.Style
 mb_0 =
     Css.property "margin-bottom" "0px"
@@ -25128,7 +24649,6 @@ mb_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_0_dot_5 : Css.Style
 mb_0_dot_5 =
     Css.property "margin-bottom" "0.125rem"
@@ -25139,7 +24659,6 @@ mb_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_1 : Css.Style
 mb_1 =
     Css.property "margin-bottom" "0.25rem"
@@ -25150,7 +24669,6 @@ mb_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_10 : Css.Style
 mb_10 =
     Css.property "margin-bottom" "2.5rem"
@@ -25161,7 +24679,6 @@ mb_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_11 : Css.Style
 mb_11 =
     Css.property "margin-bottom" "2.75rem"
@@ -25172,7 +24689,6 @@ mb_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_12 : Css.Style
 mb_12 =
     Css.property "margin-bottom" "3rem"
@@ -25183,7 +24699,6 @@ mb_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_14 : Css.Style
 mb_14 =
     Css.property "margin-bottom" "3.5rem"
@@ -25194,7 +24709,6 @@ mb_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_16 : Css.Style
 mb_16 =
     Css.property "margin-bottom" "4rem"
@@ -25205,7 +24719,6 @@ mb_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_1_dot_5 : Css.Style
 mb_1_dot_5 =
     Css.property "margin-bottom" "0.375rem"
@@ -25216,7 +24729,6 @@ mb_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_2 : Css.Style
 mb_2 =
     Css.property "margin-bottom" "0.5rem"
@@ -25227,7 +24739,6 @@ mb_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_20 : Css.Style
 mb_20 =
     Css.property "margin-bottom" "5rem"
@@ -25238,7 +24749,6 @@ mb_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_24 : Css.Style
 mb_24 =
     Css.property "margin-bottom" "6rem"
@@ -25249,7 +24759,6 @@ mb_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_28 : Css.Style
 mb_28 =
     Css.property "margin-bottom" "7rem"
@@ -25260,7 +24769,6 @@ mb_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_2_dot_5 : Css.Style
 mb_2_dot_5 =
     Css.property "margin-bottom" "0.625rem"
@@ -25271,7 +24779,6 @@ mb_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_3 : Css.Style
 mb_3 =
     Css.property "margin-bottom" "0.75rem"
@@ -25282,7 +24789,6 @@ mb_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_32 : Css.Style
 mb_32 =
     Css.property "margin-bottom" "8rem"
@@ -25293,7 +24799,6 @@ mb_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_36 : Css.Style
 mb_36 =
     Css.property "margin-bottom" "9rem"
@@ -25304,7 +24809,6 @@ mb_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_3_dot_5 : Css.Style
 mb_3_dot_5 =
     Css.property "margin-bottom" "0.875rem"
@@ -25315,7 +24819,6 @@ mb_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_4 : Css.Style
 mb_4 =
     Css.property "margin-bottom" "1rem"
@@ -25326,7 +24829,6 @@ mb_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_40 : Css.Style
 mb_40 =
     Css.property "margin-bottom" "10rem"
@@ -25337,7 +24839,6 @@ mb_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_44 : Css.Style
 mb_44 =
     Css.property "margin-bottom" "11rem"
@@ -25348,7 +24849,6 @@ mb_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_48 : Css.Style
 mb_48 =
     Css.property "margin-bottom" "12rem"
@@ -25359,7 +24859,6 @@ mb_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_5 : Css.Style
 mb_5 =
     Css.property "margin-bottom" "1.25rem"
@@ -25370,7 +24869,6 @@ mb_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_52 : Css.Style
 mb_52 =
     Css.property "margin-bottom" "13rem"
@@ -25381,7 +24879,6 @@ mb_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_56 : Css.Style
 mb_56 =
     Css.property "margin-bottom" "14rem"
@@ -25392,7 +24889,6 @@ mb_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_6 : Css.Style
 mb_6 =
     Css.property "margin-bottom" "1.5rem"
@@ -25403,7 +24899,6 @@ mb_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_60 : Css.Style
 mb_60 =
     Css.property "margin-bottom" "15rem"
@@ -25414,7 +24909,6 @@ mb_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_64 : Css.Style
 mb_64 =
     Css.property "margin-bottom" "16rem"
@@ -25425,7 +24919,6 @@ mb_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_7 : Css.Style
 mb_7 =
     Css.property "margin-bottom" "1.75rem"
@@ -25436,7 +24929,6 @@ mb_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_72 : Css.Style
 mb_72 =
     Css.property "margin-bottom" "18rem"
@@ -25447,7 +24939,6 @@ mb_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_8 : Css.Style
 mb_8 =
     Css.property "margin-bottom" "2rem"
@@ -25458,7 +24949,6 @@ mb_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_80 : Css.Style
 mb_80 =
     Css.property "margin-bottom" "20rem"
@@ -25469,7 +24959,6 @@ mb_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_9 : Css.Style
 mb_9 =
     Css.property "margin-bottom" "2.25rem"
@@ -25480,7 +24969,6 @@ mb_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_96 : Css.Style
 mb_96 =
     Css.property "margin-bottom" "24rem"
@@ -25491,7 +24979,6 @@ mb_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_auto : Css.Style
 mb_auto =
     Css.property "margin-bottom" "auto"
@@ -25502,7 +24989,6 @@ mb_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mb_px : Css.Style
 mb_px =
     Css.property "margin-bottom" "1px"
@@ -25513,7 +24999,6 @@ mb_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_h_0 : Css.Style
 min_h_0 =
     Css.property "min-height" "0px"
@@ -25524,7 +25009,6 @@ min_h_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_h_full : Css.Style
 min_h_full =
     Css.property "min-height" "100%"
@@ -25535,7 +25019,6 @@ min_h_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_h_screen : Css.Style
 min_h_screen =
     Css.property "min-height" "100vh"
@@ -25546,7 +25029,6 @@ min_h_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_w_0 : Css.Style
 min_w_0 =
     Css.property "min-width" "0px"
@@ -25557,7 +25039,6 @@ min_w_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_w_full : Css.Style
 min_w_full =
     Css.property "min-width" "100%"
@@ -25568,7 +25049,6 @@ min_w_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_w_max : Css.Style
 min_w_max =
     Css.batch
@@ -25583,7 +25063,6 @@ min_w_max =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 min_w_min : Css.Style
 min_w_min =
     Css.batch
@@ -25598,7 +25077,6 @@ min_w_min =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_color : Css.Style
 mix_blend_color =
     Css.property "mix-blend-mode" "color"
@@ -25609,7 +25087,6 @@ mix_blend_color =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_color_burn : Css.Style
 mix_blend_color_burn =
     Css.property "mix-blend-mode" "color-burn"
@@ -25620,7 +25097,6 @@ mix_blend_color_burn =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_color_dodge : Css.Style
 mix_blend_color_dodge =
     Css.property "mix-blend-mode" "color-dodge"
@@ -25631,7 +25107,6 @@ mix_blend_color_dodge =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_darken : Css.Style
 mix_blend_darken =
     Css.property "mix-blend-mode" "darken"
@@ -25642,7 +25117,6 @@ mix_blend_darken =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_difference : Css.Style
 mix_blend_difference =
     Css.property "mix-blend-mode" "difference"
@@ -25653,7 +25127,6 @@ mix_blend_difference =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_exclusion : Css.Style
 mix_blend_exclusion =
     Css.property "mix-blend-mode" "exclusion"
@@ -25664,7 +25137,6 @@ mix_blend_exclusion =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_hard_light : Css.Style
 mix_blend_hard_light =
     Css.property "mix-blend-mode" "hard-light"
@@ -25675,7 +25147,6 @@ mix_blend_hard_light =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_hue : Css.Style
 mix_blend_hue =
     Css.property "mix-blend-mode" "hue"
@@ -25686,7 +25157,6 @@ mix_blend_hue =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_lighten : Css.Style
 mix_blend_lighten =
     Css.property "mix-blend-mode" "lighten"
@@ -25697,7 +25167,6 @@ mix_blend_lighten =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_luminosity : Css.Style
 mix_blend_luminosity =
     Css.property "mix-blend-mode" "luminosity"
@@ -25708,7 +25177,6 @@ mix_blend_luminosity =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_multiply : Css.Style
 mix_blend_multiply =
     Css.property "mix-blend-mode" "multiply"
@@ -25719,7 +25187,6 @@ mix_blend_multiply =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_normal : Css.Style
 mix_blend_normal =
     Css.property "mix-blend-mode" "normal"
@@ -25730,7 +25197,6 @@ mix_blend_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_overlay : Css.Style
 mix_blend_overlay =
     Css.property "mix-blend-mode" "overlay"
@@ -25741,7 +25207,6 @@ mix_blend_overlay =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_saturation : Css.Style
 mix_blend_saturation =
     Css.property "mix-blend-mode" "saturation"
@@ -25752,7 +25217,6 @@ mix_blend_saturation =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_screen : Css.Style
 mix_blend_screen =
     Css.property "mix-blend-mode" "screen"
@@ -25763,7 +25227,6 @@ mix_blend_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mix_blend_soft_light : Css.Style
 mix_blend_soft_light =
     Css.property "mix-blend-mode" "soft-light"
@@ -25774,7 +25237,6 @@ mix_blend_soft_light =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_0 : Css.Style
 ml_0 =
     Css.property "margin-left" "0px"
@@ -25785,7 +25247,6 @@ ml_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_0_dot_5 : Css.Style
 ml_0_dot_5 =
     Css.property "margin-left" "0.125rem"
@@ -25796,7 +25257,6 @@ ml_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_1 : Css.Style
 ml_1 =
     Css.property "margin-left" "0.25rem"
@@ -25807,7 +25267,6 @@ ml_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_10 : Css.Style
 ml_10 =
     Css.property "margin-left" "2.5rem"
@@ -25818,7 +25277,6 @@ ml_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_11 : Css.Style
 ml_11 =
     Css.property "margin-left" "2.75rem"
@@ -25829,7 +25287,6 @@ ml_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_12 : Css.Style
 ml_12 =
     Css.property "margin-left" "3rem"
@@ -25840,7 +25297,6 @@ ml_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_14 : Css.Style
 ml_14 =
     Css.property "margin-left" "3.5rem"
@@ -25851,7 +25307,6 @@ ml_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_16 : Css.Style
 ml_16 =
     Css.property "margin-left" "4rem"
@@ -25862,7 +25317,6 @@ ml_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_1_dot_5 : Css.Style
 ml_1_dot_5 =
     Css.property "margin-left" "0.375rem"
@@ -25873,7 +25327,6 @@ ml_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_2 : Css.Style
 ml_2 =
     Css.property "margin-left" "0.5rem"
@@ -25884,7 +25337,6 @@ ml_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_20 : Css.Style
 ml_20 =
     Css.property "margin-left" "5rem"
@@ -25895,7 +25347,6 @@ ml_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_24 : Css.Style
 ml_24 =
     Css.property "margin-left" "6rem"
@@ -25906,7 +25357,6 @@ ml_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_28 : Css.Style
 ml_28 =
     Css.property "margin-left" "7rem"
@@ -25917,7 +25367,6 @@ ml_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_2_dot_5 : Css.Style
 ml_2_dot_5 =
     Css.property "margin-left" "0.625rem"
@@ -25928,7 +25377,6 @@ ml_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_3 : Css.Style
 ml_3 =
     Css.property "margin-left" "0.75rem"
@@ -25939,7 +25387,6 @@ ml_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_32 : Css.Style
 ml_32 =
     Css.property "margin-left" "8rem"
@@ -25950,7 +25397,6 @@ ml_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_36 : Css.Style
 ml_36 =
     Css.property "margin-left" "9rem"
@@ -25961,7 +25407,6 @@ ml_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_3_dot_5 : Css.Style
 ml_3_dot_5 =
     Css.property "margin-left" "0.875rem"
@@ -25972,7 +25417,6 @@ ml_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_4 : Css.Style
 ml_4 =
     Css.property "margin-left" "1rem"
@@ -25983,7 +25427,6 @@ ml_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_40 : Css.Style
 ml_40 =
     Css.property "margin-left" "10rem"
@@ -25994,7 +25437,6 @@ ml_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_44 : Css.Style
 ml_44 =
     Css.property "margin-left" "11rem"
@@ -26005,7 +25447,6 @@ ml_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_48 : Css.Style
 ml_48 =
     Css.property "margin-left" "12rem"
@@ -26016,7 +25457,6 @@ ml_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_5 : Css.Style
 ml_5 =
     Css.property "margin-left" "1.25rem"
@@ -26027,7 +25467,6 @@ ml_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_52 : Css.Style
 ml_52 =
     Css.property "margin-left" "13rem"
@@ -26038,7 +25477,6 @@ ml_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_56 : Css.Style
 ml_56 =
     Css.property "margin-left" "14rem"
@@ -26049,7 +25487,6 @@ ml_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_6 : Css.Style
 ml_6 =
     Css.property "margin-left" "1.5rem"
@@ -26060,7 +25497,6 @@ ml_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_60 : Css.Style
 ml_60 =
     Css.property "margin-left" "15rem"
@@ -26071,7 +25507,6 @@ ml_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_64 : Css.Style
 ml_64 =
     Css.property "margin-left" "16rem"
@@ -26082,7 +25517,6 @@ ml_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_7 : Css.Style
 ml_7 =
     Css.property "margin-left" "1.75rem"
@@ -26093,7 +25527,6 @@ ml_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_72 : Css.Style
 ml_72 =
     Css.property "margin-left" "18rem"
@@ -26104,7 +25537,6 @@ ml_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_8 : Css.Style
 ml_8 =
     Css.property "margin-left" "2rem"
@@ -26115,7 +25547,6 @@ ml_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_80 : Css.Style
 ml_80 =
     Css.property "margin-left" "20rem"
@@ -26126,7 +25557,6 @@ ml_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_9 : Css.Style
 ml_9 =
     Css.property "margin-left" "2.25rem"
@@ -26137,7 +25567,6 @@ ml_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_96 : Css.Style
 ml_96 =
     Css.property "margin-left" "24rem"
@@ -26148,7 +25577,6 @@ ml_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_auto : Css.Style
 ml_auto =
     Css.property "margin-left" "auto"
@@ -26159,7 +25587,6 @@ ml_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ml_px : Css.Style
 ml_px =
     Css.property "margin-left" "1px"
@@ -26170,7 +25597,6 @@ ml_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_0 : Css.Style
 mr_0 =
     Css.property "margin-right" "0px"
@@ -26181,7 +25607,6 @@ mr_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_0_dot_5 : Css.Style
 mr_0_dot_5 =
     Css.property "margin-right" "0.125rem"
@@ -26192,7 +25617,6 @@ mr_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_1 : Css.Style
 mr_1 =
     Css.property "margin-right" "0.25rem"
@@ -26203,7 +25627,6 @@ mr_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_10 : Css.Style
 mr_10 =
     Css.property "margin-right" "2.5rem"
@@ -26214,7 +25637,6 @@ mr_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_11 : Css.Style
 mr_11 =
     Css.property "margin-right" "2.75rem"
@@ -26225,7 +25647,6 @@ mr_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_12 : Css.Style
 mr_12 =
     Css.property "margin-right" "3rem"
@@ -26236,7 +25657,6 @@ mr_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_14 : Css.Style
 mr_14 =
     Css.property "margin-right" "3.5rem"
@@ -26247,7 +25667,6 @@ mr_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_16 : Css.Style
 mr_16 =
     Css.property "margin-right" "4rem"
@@ -26258,7 +25677,6 @@ mr_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_1_dot_5 : Css.Style
 mr_1_dot_5 =
     Css.property "margin-right" "0.375rem"
@@ -26269,7 +25687,6 @@ mr_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_2 : Css.Style
 mr_2 =
     Css.property "margin-right" "0.5rem"
@@ -26280,7 +25697,6 @@ mr_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_20 : Css.Style
 mr_20 =
     Css.property "margin-right" "5rem"
@@ -26291,7 +25707,6 @@ mr_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_24 : Css.Style
 mr_24 =
     Css.property "margin-right" "6rem"
@@ -26302,7 +25717,6 @@ mr_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_28 : Css.Style
 mr_28 =
     Css.property "margin-right" "7rem"
@@ -26313,7 +25727,6 @@ mr_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_2_dot_5 : Css.Style
 mr_2_dot_5 =
     Css.property "margin-right" "0.625rem"
@@ -26324,7 +25737,6 @@ mr_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_3 : Css.Style
 mr_3 =
     Css.property "margin-right" "0.75rem"
@@ -26335,7 +25747,6 @@ mr_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_32 : Css.Style
 mr_32 =
     Css.property "margin-right" "8rem"
@@ -26346,7 +25757,6 @@ mr_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_36 : Css.Style
 mr_36 =
     Css.property "margin-right" "9rem"
@@ -26357,7 +25767,6 @@ mr_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_3_dot_5 : Css.Style
 mr_3_dot_5 =
     Css.property "margin-right" "0.875rem"
@@ -26368,7 +25777,6 @@ mr_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_4 : Css.Style
 mr_4 =
     Css.property "margin-right" "1rem"
@@ -26379,7 +25787,6 @@ mr_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_40 : Css.Style
 mr_40 =
     Css.property "margin-right" "10rem"
@@ -26390,7 +25797,6 @@ mr_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_44 : Css.Style
 mr_44 =
     Css.property "margin-right" "11rem"
@@ -26401,7 +25807,6 @@ mr_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_48 : Css.Style
 mr_48 =
     Css.property "margin-right" "12rem"
@@ -26412,7 +25817,6 @@ mr_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_5 : Css.Style
 mr_5 =
     Css.property "margin-right" "1.25rem"
@@ -26423,7 +25827,6 @@ mr_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_52 : Css.Style
 mr_52 =
     Css.property "margin-right" "13rem"
@@ -26434,7 +25837,6 @@ mr_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_56 : Css.Style
 mr_56 =
     Css.property "margin-right" "14rem"
@@ -26445,7 +25847,6 @@ mr_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_6 : Css.Style
 mr_6 =
     Css.property "margin-right" "1.5rem"
@@ -26456,7 +25857,6 @@ mr_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_60 : Css.Style
 mr_60 =
     Css.property "margin-right" "15rem"
@@ -26467,7 +25867,6 @@ mr_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_64 : Css.Style
 mr_64 =
     Css.property "margin-right" "16rem"
@@ -26478,7 +25877,6 @@ mr_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_7 : Css.Style
 mr_7 =
     Css.property "margin-right" "1.75rem"
@@ -26489,7 +25887,6 @@ mr_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_72 : Css.Style
 mr_72 =
     Css.property "margin-right" "18rem"
@@ -26500,7 +25897,6 @@ mr_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_8 : Css.Style
 mr_8 =
     Css.property "margin-right" "2rem"
@@ -26511,7 +25907,6 @@ mr_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_80 : Css.Style
 mr_80 =
     Css.property "margin-right" "20rem"
@@ -26522,7 +25917,6 @@ mr_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_9 : Css.Style
 mr_9 =
     Css.property "margin-right" "2.25rem"
@@ -26533,7 +25927,6 @@ mr_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_96 : Css.Style
 mr_96 =
     Css.property "margin-right" "24rem"
@@ -26544,7 +25937,6 @@ mr_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_auto : Css.Style
 mr_auto =
     Css.property "margin-right" "auto"
@@ -26555,7 +25947,6 @@ mr_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mr_px : Css.Style
 mr_px =
     Css.property "margin-right" "1px"
@@ -26566,7 +25957,6 @@ mr_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_0 : Css.Style
 mt_0 =
     Css.property "margin-top" "0px"
@@ -26577,7 +25967,6 @@ mt_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_0_dot_5 : Css.Style
 mt_0_dot_5 =
     Css.property "margin-top" "0.125rem"
@@ -26588,7 +25977,6 @@ mt_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_1 : Css.Style
 mt_1 =
     Css.property "margin-top" "0.25rem"
@@ -26599,7 +25987,6 @@ mt_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_10 : Css.Style
 mt_10 =
     Css.property "margin-top" "2.5rem"
@@ -26610,7 +25997,6 @@ mt_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_11 : Css.Style
 mt_11 =
     Css.property "margin-top" "2.75rem"
@@ -26621,7 +26007,6 @@ mt_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_12 : Css.Style
 mt_12 =
     Css.property "margin-top" "3rem"
@@ -26632,7 +26017,6 @@ mt_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_14 : Css.Style
 mt_14 =
     Css.property "margin-top" "3.5rem"
@@ -26643,7 +26027,6 @@ mt_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_16 : Css.Style
 mt_16 =
     Css.property "margin-top" "4rem"
@@ -26654,7 +26037,6 @@ mt_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_1_dot_5 : Css.Style
 mt_1_dot_5 =
     Css.property "margin-top" "0.375rem"
@@ -26665,7 +26047,6 @@ mt_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_2 : Css.Style
 mt_2 =
     Css.property "margin-top" "0.5rem"
@@ -26676,7 +26057,6 @@ mt_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_20 : Css.Style
 mt_20 =
     Css.property "margin-top" "5rem"
@@ -26687,7 +26067,6 @@ mt_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_24 : Css.Style
 mt_24 =
     Css.property "margin-top" "6rem"
@@ -26698,7 +26077,6 @@ mt_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_28 : Css.Style
 mt_28 =
     Css.property "margin-top" "7rem"
@@ -26709,7 +26087,6 @@ mt_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_2_dot_5 : Css.Style
 mt_2_dot_5 =
     Css.property "margin-top" "0.625rem"
@@ -26720,7 +26097,6 @@ mt_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_3 : Css.Style
 mt_3 =
     Css.property "margin-top" "0.75rem"
@@ -26731,7 +26107,6 @@ mt_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_32 : Css.Style
 mt_32 =
     Css.property "margin-top" "8rem"
@@ -26742,7 +26117,6 @@ mt_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_36 : Css.Style
 mt_36 =
     Css.property "margin-top" "9rem"
@@ -26753,7 +26127,6 @@ mt_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_3_dot_5 : Css.Style
 mt_3_dot_5 =
     Css.property "margin-top" "0.875rem"
@@ -26764,7 +26137,6 @@ mt_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_4 : Css.Style
 mt_4 =
     Css.property "margin-top" "1rem"
@@ -26775,7 +26147,6 @@ mt_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_40 : Css.Style
 mt_40 =
     Css.property "margin-top" "10rem"
@@ -26786,7 +26157,6 @@ mt_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_44 : Css.Style
 mt_44 =
     Css.property "margin-top" "11rem"
@@ -26797,7 +26167,6 @@ mt_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_48 : Css.Style
 mt_48 =
     Css.property "margin-top" "12rem"
@@ -26808,7 +26177,6 @@ mt_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_5 : Css.Style
 mt_5 =
     Css.property "margin-top" "1.25rem"
@@ -26819,7 +26187,6 @@ mt_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_52 : Css.Style
 mt_52 =
     Css.property "margin-top" "13rem"
@@ -26830,7 +26197,6 @@ mt_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_56 : Css.Style
 mt_56 =
     Css.property "margin-top" "14rem"
@@ -26841,7 +26207,6 @@ mt_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_6 : Css.Style
 mt_6 =
     Css.property "margin-top" "1.5rem"
@@ -26852,7 +26217,6 @@ mt_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_60 : Css.Style
 mt_60 =
     Css.property "margin-top" "15rem"
@@ -26863,7 +26227,6 @@ mt_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_64 : Css.Style
 mt_64 =
     Css.property "margin-top" "16rem"
@@ -26874,7 +26237,6 @@ mt_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_7 : Css.Style
 mt_7 =
     Css.property "margin-top" "1.75rem"
@@ -26885,7 +26247,6 @@ mt_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_72 : Css.Style
 mt_72 =
     Css.property "margin-top" "18rem"
@@ -26896,7 +26257,6 @@ mt_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_8 : Css.Style
 mt_8 =
     Css.property "margin-top" "2rem"
@@ -26907,7 +26267,6 @@ mt_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_80 : Css.Style
 mt_80 =
     Css.property "margin-top" "20rem"
@@ -26918,7 +26277,6 @@ mt_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_9 : Css.Style
 mt_9 =
     Css.property "margin-top" "2.25rem"
@@ -26929,7 +26287,6 @@ mt_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_96 : Css.Style
 mt_96 =
     Css.property "margin-top" "24rem"
@@ -26940,7 +26297,6 @@ mt_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_auto : Css.Style
 mt_auto =
     Css.property "margin-top" "auto"
@@ -26951,7 +26307,6 @@ mt_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mt_px : Css.Style
 mt_px =
     Css.property "margin-top" "1px"
@@ -26962,7 +26317,6 @@ mt_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_0 : Css.Style
 mx_0 =
     Css.batch
@@ -26976,7 +26330,6 @@ mx_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_0_dot_5 : Css.Style
 mx_0_dot_5 =
     Css.batch
@@ -26990,7 +26343,6 @@ mx_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_1 : Css.Style
 mx_1 =
     Css.batch
@@ -27004,7 +26356,6 @@ mx_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_10 : Css.Style
 mx_10 =
     Css.batch
@@ -27018,7 +26369,6 @@ mx_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_11 : Css.Style
 mx_11 =
     Css.batch
@@ -27032,7 +26382,6 @@ mx_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_12 : Css.Style
 mx_12 =
     Css.batch
@@ -27046,7 +26395,6 @@ mx_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_14 : Css.Style
 mx_14 =
     Css.batch
@@ -27060,7 +26408,6 @@ mx_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_16 : Css.Style
 mx_16 =
     Css.batch
@@ -27074,7 +26421,6 @@ mx_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_1_dot_5 : Css.Style
 mx_1_dot_5 =
     Css.batch
@@ -27088,7 +26434,6 @@ mx_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_2 : Css.Style
 mx_2 =
     Css.batch
@@ -27102,7 +26447,6 @@ mx_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_20 : Css.Style
 mx_20 =
     Css.batch
@@ -27116,7 +26460,6 @@ mx_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_24 : Css.Style
 mx_24 =
     Css.batch
@@ -27130,7 +26473,6 @@ mx_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_28 : Css.Style
 mx_28 =
     Css.batch
@@ -27144,7 +26486,6 @@ mx_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_2_dot_5 : Css.Style
 mx_2_dot_5 =
     Css.batch
@@ -27158,7 +26499,6 @@ mx_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_3 : Css.Style
 mx_3 =
     Css.batch
@@ -27172,7 +26512,6 @@ mx_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_32 : Css.Style
 mx_32 =
     Css.batch
@@ -27186,7 +26525,6 @@ mx_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_36 : Css.Style
 mx_36 =
     Css.batch
@@ -27200,7 +26538,6 @@ mx_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_3_dot_5 : Css.Style
 mx_3_dot_5 =
     Css.batch
@@ -27214,7 +26551,6 @@ mx_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_4 : Css.Style
 mx_4 =
     Css.batch
@@ -27228,7 +26564,6 @@ mx_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_40 : Css.Style
 mx_40 =
     Css.batch
@@ -27242,7 +26577,6 @@ mx_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_44 : Css.Style
 mx_44 =
     Css.batch
@@ -27256,7 +26590,6 @@ mx_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_48 : Css.Style
 mx_48 =
     Css.batch
@@ -27270,7 +26603,6 @@ mx_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_5 : Css.Style
 mx_5 =
     Css.batch
@@ -27284,7 +26616,6 @@ mx_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_52 : Css.Style
 mx_52 =
     Css.batch
@@ -27298,7 +26629,6 @@ mx_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_56 : Css.Style
 mx_56 =
     Css.batch
@@ -27312,7 +26642,6 @@ mx_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_6 : Css.Style
 mx_6 =
     Css.batch
@@ -27326,7 +26655,6 @@ mx_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_60 : Css.Style
 mx_60 =
     Css.batch
@@ -27340,7 +26668,6 @@ mx_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_64 : Css.Style
 mx_64 =
     Css.batch
@@ -27354,7 +26681,6 @@ mx_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_7 : Css.Style
 mx_7 =
     Css.batch
@@ -27368,7 +26694,6 @@ mx_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_72 : Css.Style
 mx_72 =
     Css.batch
@@ -27382,7 +26707,6 @@ mx_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_8 : Css.Style
 mx_8 =
     Css.batch
@@ -27396,7 +26720,6 @@ mx_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_80 : Css.Style
 mx_80 =
     Css.batch
@@ -27410,7 +26733,6 @@ mx_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_9 : Css.Style
 mx_9 =
     Css.batch
@@ -27424,7 +26746,6 @@ mx_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_96 : Css.Style
 mx_96 =
     Css.batch
@@ -27438,7 +26759,6 @@ mx_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_auto : Css.Style
 mx_auto =
     Css.batch
@@ -27452,7 +26772,6 @@ mx_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 mx_px : Css.Style
 mx_px =
     Css.batch
@@ -27466,7 +26785,6 @@ mx_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_0 : Css.Style
 my_0 =
     Css.batch
@@ -27480,7 +26798,6 @@ my_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_0_dot_5 : Css.Style
 my_0_dot_5 =
     Css.batch
@@ -27494,7 +26811,6 @@ my_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_1 : Css.Style
 my_1 =
     Css.batch
@@ -27508,7 +26824,6 @@ my_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_10 : Css.Style
 my_10 =
     Css.batch
@@ -27522,7 +26837,6 @@ my_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_11 : Css.Style
 my_11 =
     Css.batch
@@ -27536,7 +26850,6 @@ my_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_12 : Css.Style
 my_12 =
     Css.batch
@@ -27550,7 +26863,6 @@ my_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_14 : Css.Style
 my_14 =
     Css.batch
@@ -27564,7 +26876,6 @@ my_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_16 : Css.Style
 my_16 =
     Css.batch
@@ -27578,7 +26889,6 @@ my_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_1_dot_5 : Css.Style
 my_1_dot_5 =
     Css.batch
@@ -27592,7 +26902,6 @@ my_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_2 : Css.Style
 my_2 =
     Css.batch
@@ -27606,7 +26915,6 @@ my_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_20 : Css.Style
 my_20 =
     Css.batch
@@ -27620,7 +26928,6 @@ my_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_24 : Css.Style
 my_24 =
     Css.batch
@@ -27634,7 +26941,6 @@ my_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_28 : Css.Style
 my_28 =
     Css.batch
@@ -27648,7 +26954,6 @@ my_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_2_dot_5 : Css.Style
 my_2_dot_5 =
     Css.batch
@@ -27662,7 +26967,6 @@ my_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_3 : Css.Style
 my_3 =
     Css.batch
@@ -27676,7 +26980,6 @@ my_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_32 : Css.Style
 my_32 =
     Css.batch
@@ -27690,7 +26993,6 @@ my_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_36 : Css.Style
 my_36 =
     Css.batch
@@ -27704,7 +27006,6 @@ my_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_3_dot_5 : Css.Style
 my_3_dot_5 =
     Css.batch
@@ -27718,7 +27019,6 @@ my_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_4 : Css.Style
 my_4 =
     Css.batch
@@ -27732,7 +27032,6 @@ my_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_40 : Css.Style
 my_40 =
     Css.batch
@@ -27746,7 +27045,6 @@ my_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_44 : Css.Style
 my_44 =
     Css.batch
@@ -27760,7 +27058,6 @@ my_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_48 : Css.Style
 my_48 =
     Css.batch
@@ -27774,7 +27071,6 @@ my_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_5 : Css.Style
 my_5 =
     Css.batch
@@ -27788,7 +27084,6 @@ my_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_52 : Css.Style
 my_52 =
     Css.batch
@@ -27802,7 +27097,6 @@ my_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_56 : Css.Style
 my_56 =
     Css.batch
@@ -27816,7 +27110,6 @@ my_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_6 : Css.Style
 my_6 =
     Css.batch
@@ -27830,7 +27123,6 @@ my_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_60 : Css.Style
 my_60 =
     Css.batch
@@ -27844,7 +27136,6 @@ my_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_64 : Css.Style
 my_64 =
     Css.batch
@@ -27858,7 +27149,6 @@ my_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_7 : Css.Style
 my_7 =
     Css.batch
@@ -27872,7 +27162,6 @@ my_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_72 : Css.Style
 my_72 =
     Css.batch
@@ -27886,7 +27175,6 @@ my_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_8 : Css.Style
 my_8 =
     Css.batch
@@ -27900,7 +27188,6 @@ my_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_80 : Css.Style
 my_80 =
     Css.batch
@@ -27914,7 +27201,6 @@ my_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_9 : Css.Style
 my_9 =
     Css.batch
@@ -27928,7 +27214,6 @@ my_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_96 : Css.Style
 my_96 =
     Css.batch
@@ -27942,7 +27227,6 @@ my_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_auto : Css.Style
 my_auto =
     Css.batch
@@ -27956,7 +27240,6 @@ my_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 my_px : Css.Style
 my_px =
     Css.batch
@@ -27970,7 +27253,6 @@ my_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_backdrop_hue_rotate_15 : Css.Style
 neg_backdrop_hue_rotate_15 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(-15deg)"
@@ -27981,7 +27263,6 @@ neg_backdrop_hue_rotate_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_backdrop_hue_rotate_180 : Css.Style
 neg_backdrop_hue_rotate_180 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(-180deg)"
@@ -27992,7 +27273,6 @@ neg_backdrop_hue_rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_backdrop_hue_rotate_30 : Css.Style
 neg_backdrop_hue_rotate_30 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(-30deg)"
@@ -28003,7 +27283,6 @@ neg_backdrop_hue_rotate_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_backdrop_hue_rotate_60 : Css.Style
 neg_backdrop_hue_rotate_60 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(-60deg)"
@@ -28014,7 +27293,6 @@ neg_backdrop_hue_rotate_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_backdrop_hue_rotate_90 : Css.Style
 neg_backdrop_hue_rotate_90 =
     Css.property "--tw-backdrop-hue-rotate" "hue-rotate(-90deg)"
@@ -28025,7 +27303,6 @@ neg_backdrop_hue_rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_0 : Css.Style
 neg_bottom_0 =
     Css.property "bottom" "0px"
@@ -28036,7 +27313,6 @@ neg_bottom_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_0_dot_5 : Css.Style
 neg_bottom_0_dot_5 =
     Css.property "bottom" "-0.125rem"
@@ -28047,7 +27323,6 @@ neg_bottom_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_1 : Css.Style
 neg_bottom_1 =
     Css.property "bottom" "-0.25rem"
@@ -28058,7 +27333,6 @@ neg_bottom_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_10 : Css.Style
 neg_bottom_10 =
     Css.property "bottom" "-2.5rem"
@@ -28069,7 +27343,6 @@ neg_bottom_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_11 : Css.Style
 neg_bottom_11 =
     Css.property "bottom" "-2.75rem"
@@ -28080,7 +27353,6 @@ neg_bottom_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_12 : Css.Style
 neg_bottom_12 =
     Css.property "bottom" "-3rem"
@@ -28091,7 +27363,6 @@ neg_bottom_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_14 : Css.Style
 neg_bottom_14 =
     Css.property "bottom" "-3.5rem"
@@ -28102,7 +27373,6 @@ neg_bottom_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_16 : Css.Style
 neg_bottom_16 =
     Css.property "bottom" "-4rem"
@@ -28113,7 +27383,6 @@ neg_bottom_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_1_dot_5 : Css.Style
 neg_bottom_1_dot_5 =
     Css.property "bottom" "-0.375rem"
@@ -28124,7 +27393,6 @@ neg_bottom_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_1over2 : Css.Style
 neg_bottom_1over2 =
     Css.property "bottom" "-50%"
@@ -28135,7 +27403,6 @@ neg_bottom_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_1over3 : Css.Style
 neg_bottom_1over3 =
     Css.property "bottom" "-33.333333%"
@@ -28146,7 +27413,6 @@ neg_bottom_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_1over4 : Css.Style
 neg_bottom_1over4 =
     Css.property "bottom" "-25%"
@@ -28157,7 +27423,6 @@ neg_bottom_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_2 : Css.Style
 neg_bottom_2 =
     Css.property "bottom" "-0.5rem"
@@ -28168,7 +27433,6 @@ neg_bottom_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_20 : Css.Style
 neg_bottom_20 =
     Css.property "bottom" "-5rem"
@@ -28179,7 +27443,6 @@ neg_bottom_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_24 : Css.Style
 neg_bottom_24 =
     Css.property "bottom" "-6rem"
@@ -28190,7 +27453,6 @@ neg_bottom_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_28 : Css.Style
 neg_bottom_28 =
     Css.property "bottom" "-7rem"
@@ -28201,7 +27463,6 @@ neg_bottom_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_2_dot_5 : Css.Style
 neg_bottom_2_dot_5 =
     Css.property "bottom" "-0.625rem"
@@ -28212,7 +27473,6 @@ neg_bottom_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_2over3 : Css.Style
 neg_bottom_2over3 =
     Css.property "bottom" "-66.666667%"
@@ -28223,7 +27483,6 @@ neg_bottom_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_2over4 : Css.Style
 neg_bottom_2over4 =
     Css.property "bottom" "-50%"
@@ -28234,7 +27493,6 @@ neg_bottom_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_3 : Css.Style
 neg_bottom_3 =
     Css.property "bottom" "-0.75rem"
@@ -28245,7 +27503,6 @@ neg_bottom_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_32 : Css.Style
 neg_bottom_32 =
     Css.property "bottom" "-8rem"
@@ -28256,7 +27513,6 @@ neg_bottom_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_36 : Css.Style
 neg_bottom_36 =
     Css.property "bottom" "-9rem"
@@ -28267,7 +27523,6 @@ neg_bottom_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_3_dot_5 : Css.Style
 neg_bottom_3_dot_5 =
     Css.property "bottom" "-0.875rem"
@@ -28278,7 +27533,6 @@ neg_bottom_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_3over4 : Css.Style
 neg_bottom_3over4 =
     Css.property "bottom" "-75%"
@@ -28289,7 +27543,6 @@ neg_bottom_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_4 : Css.Style
 neg_bottom_4 =
     Css.property "bottom" "-1rem"
@@ -28300,7 +27553,6 @@ neg_bottom_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_40 : Css.Style
 neg_bottom_40 =
     Css.property "bottom" "-10rem"
@@ -28311,7 +27563,6 @@ neg_bottom_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_44 : Css.Style
 neg_bottom_44 =
     Css.property "bottom" "-11rem"
@@ -28322,7 +27573,6 @@ neg_bottom_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_48 : Css.Style
 neg_bottom_48 =
     Css.property "bottom" "-12rem"
@@ -28333,7 +27583,6 @@ neg_bottom_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_5 : Css.Style
 neg_bottom_5 =
     Css.property "bottom" "-1.25rem"
@@ -28344,7 +27593,6 @@ neg_bottom_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_52 : Css.Style
 neg_bottom_52 =
     Css.property "bottom" "-13rem"
@@ -28355,7 +27603,6 @@ neg_bottom_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_56 : Css.Style
 neg_bottom_56 =
     Css.property "bottom" "-14rem"
@@ -28366,7 +27613,6 @@ neg_bottom_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_6 : Css.Style
 neg_bottom_6 =
     Css.property "bottom" "-1.5rem"
@@ -28377,7 +27623,6 @@ neg_bottom_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_60 : Css.Style
 neg_bottom_60 =
     Css.property "bottom" "-15rem"
@@ -28388,7 +27633,6 @@ neg_bottom_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_64 : Css.Style
 neg_bottom_64 =
     Css.property "bottom" "-16rem"
@@ -28399,7 +27643,6 @@ neg_bottom_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_7 : Css.Style
 neg_bottom_7 =
     Css.property "bottom" "-1.75rem"
@@ -28410,7 +27653,6 @@ neg_bottom_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_72 : Css.Style
 neg_bottom_72 =
     Css.property "bottom" "-18rem"
@@ -28421,7 +27663,6 @@ neg_bottom_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_8 : Css.Style
 neg_bottom_8 =
     Css.property "bottom" "-2rem"
@@ -28432,7 +27673,6 @@ neg_bottom_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_80 : Css.Style
 neg_bottom_80 =
     Css.property "bottom" "-20rem"
@@ -28443,7 +27683,6 @@ neg_bottom_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_9 : Css.Style
 neg_bottom_9 =
     Css.property "bottom" "-2.25rem"
@@ -28454,7 +27693,6 @@ neg_bottom_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_96 : Css.Style
 neg_bottom_96 =
     Css.property "bottom" "-24rem"
@@ -28465,7 +27703,6 @@ neg_bottom_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_full : Css.Style
 neg_bottom_full =
     Css.property "bottom" "-100%"
@@ -28476,7 +27713,6 @@ neg_bottom_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_bottom_px : Css.Style
 neg_bottom_px =
     Css.property "bottom" "-1px"
@@ -28487,7 +27723,6 @@ neg_bottom_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_hue_rotate_15 : Css.Style
 neg_hue_rotate_15 =
     Css.property "--tw-hue-rotate" "hue-rotate(-15deg)"
@@ -28498,7 +27733,6 @@ neg_hue_rotate_15 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_hue_rotate_180 : Css.Style
 neg_hue_rotate_180 =
     Css.property "--tw-hue-rotate" "hue-rotate(-180deg)"
@@ -28509,7 +27743,6 @@ neg_hue_rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_hue_rotate_30 : Css.Style
 neg_hue_rotate_30 =
     Css.property "--tw-hue-rotate" "hue-rotate(-30deg)"
@@ -28520,7 +27753,6 @@ neg_hue_rotate_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_hue_rotate_60 : Css.Style
 neg_hue_rotate_60 =
     Css.property "--tw-hue-rotate" "hue-rotate(-60deg)"
@@ -28531,7 +27763,6 @@ neg_hue_rotate_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_hue_rotate_90 : Css.Style
 neg_hue_rotate_90 =
     Css.property "--tw-hue-rotate" "hue-rotate(-90deg)"
@@ -28542,7 +27773,6 @@ neg_hue_rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_0 : Css.Style
 neg_inset_0 =
     Css.batch
@@ -28558,7 +27788,6 @@ neg_inset_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_0_dot_5 : Css.Style
 neg_inset_0_dot_5 =
     Css.batch
@@ -28574,7 +27803,6 @@ neg_inset_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_1 : Css.Style
 neg_inset_1 =
     Css.batch
@@ -28590,7 +27818,6 @@ neg_inset_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_10 : Css.Style
 neg_inset_10 =
     Css.batch
@@ -28606,7 +27833,6 @@ neg_inset_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_11 : Css.Style
 neg_inset_11 =
     Css.batch
@@ -28622,7 +27848,6 @@ neg_inset_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_12 : Css.Style
 neg_inset_12 =
     Css.batch
@@ -28638,7 +27863,6 @@ neg_inset_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_14 : Css.Style
 neg_inset_14 =
     Css.batch
@@ -28654,7 +27878,6 @@ neg_inset_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_16 : Css.Style
 neg_inset_16 =
     Css.batch
@@ -28670,7 +27893,6 @@ neg_inset_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_1_dot_5 : Css.Style
 neg_inset_1_dot_5 =
     Css.batch
@@ -28686,7 +27908,6 @@ neg_inset_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_1over2 : Css.Style
 neg_inset_1over2 =
     Css.batch
@@ -28702,7 +27923,6 @@ neg_inset_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_1over3 : Css.Style
 neg_inset_1over3 =
     Css.batch
@@ -28718,7 +27938,6 @@ neg_inset_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_1over4 : Css.Style
 neg_inset_1over4 =
     Css.batch
@@ -28734,7 +27953,6 @@ neg_inset_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_2 : Css.Style
 neg_inset_2 =
     Css.batch
@@ -28750,7 +27968,6 @@ neg_inset_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_20 : Css.Style
 neg_inset_20 =
     Css.batch
@@ -28766,7 +27983,6 @@ neg_inset_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_24 : Css.Style
 neg_inset_24 =
     Css.batch
@@ -28782,7 +27998,6 @@ neg_inset_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_28 : Css.Style
 neg_inset_28 =
     Css.batch
@@ -28798,7 +28013,6 @@ neg_inset_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_2_dot_5 : Css.Style
 neg_inset_2_dot_5 =
     Css.batch
@@ -28814,7 +28028,6 @@ neg_inset_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_2over3 : Css.Style
 neg_inset_2over3 =
     Css.batch
@@ -28830,7 +28043,6 @@ neg_inset_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_2over4 : Css.Style
 neg_inset_2over4 =
     Css.batch
@@ -28846,7 +28058,6 @@ neg_inset_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_3 : Css.Style
 neg_inset_3 =
     Css.batch
@@ -28862,7 +28073,6 @@ neg_inset_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_32 : Css.Style
 neg_inset_32 =
     Css.batch
@@ -28878,7 +28088,6 @@ neg_inset_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_36 : Css.Style
 neg_inset_36 =
     Css.batch
@@ -28894,7 +28103,6 @@ neg_inset_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_3_dot_5 : Css.Style
 neg_inset_3_dot_5 =
     Css.batch
@@ -28910,7 +28118,6 @@ neg_inset_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_3over4 : Css.Style
 neg_inset_3over4 =
     Css.batch
@@ -28926,7 +28133,6 @@ neg_inset_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_4 : Css.Style
 neg_inset_4 =
     Css.batch
@@ -28942,7 +28148,6 @@ neg_inset_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_40 : Css.Style
 neg_inset_40 =
     Css.batch
@@ -28958,7 +28163,6 @@ neg_inset_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_44 : Css.Style
 neg_inset_44 =
     Css.batch
@@ -28974,7 +28178,6 @@ neg_inset_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_48 : Css.Style
 neg_inset_48 =
     Css.batch
@@ -28990,7 +28193,6 @@ neg_inset_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_5 : Css.Style
 neg_inset_5 =
     Css.batch
@@ -29006,7 +28208,6 @@ neg_inset_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_52 : Css.Style
 neg_inset_52 =
     Css.batch
@@ -29022,7 +28223,6 @@ neg_inset_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_56 : Css.Style
 neg_inset_56 =
     Css.batch
@@ -29038,7 +28238,6 @@ neg_inset_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_6 : Css.Style
 neg_inset_6 =
     Css.batch
@@ -29054,7 +28253,6 @@ neg_inset_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_60 : Css.Style
 neg_inset_60 =
     Css.batch
@@ -29070,7 +28268,6 @@ neg_inset_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_64 : Css.Style
 neg_inset_64 =
     Css.batch
@@ -29086,7 +28283,6 @@ neg_inset_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_7 : Css.Style
 neg_inset_7 =
     Css.batch
@@ -29102,7 +28298,6 @@ neg_inset_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_72 : Css.Style
 neg_inset_72 =
     Css.batch
@@ -29118,7 +28313,6 @@ neg_inset_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_8 : Css.Style
 neg_inset_8 =
     Css.batch
@@ -29134,7 +28328,6 @@ neg_inset_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_80 : Css.Style
 neg_inset_80 =
     Css.batch
@@ -29150,7 +28343,6 @@ neg_inset_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_9 : Css.Style
 neg_inset_9 =
     Css.batch
@@ -29166,7 +28358,6 @@ neg_inset_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_96 : Css.Style
 neg_inset_96 =
     Css.batch
@@ -29182,7 +28373,6 @@ neg_inset_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_full : Css.Style
 neg_inset_full =
     Css.batch
@@ -29198,7 +28388,6 @@ neg_inset_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_px : Css.Style
 neg_inset_px =
     Css.batch
@@ -29214,7 +28403,6 @@ neg_inset_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_0 : Css.Style
 neg_inset_x_0 =
     Css.batch
@@ -29228,7 +28416,6 @@ neg_inset_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_0_dot_5 : Css.Style
 neg_inset_x_0_dot_5 =
     Css.batch
@@ -29242,7 +28429,6 @@ neg_inset_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_1 : Css.Style
 neg_inset_x_1 =
     Css.batch
@@ -29256,7 +28442,6 @@ neg_inset_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_10 : Css.Style
 neg_inset_x_10 =
     Css.batch
@@ -29270,7 +28455,6 @@ neg_inset_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_11 : Css.Style
 neg_inset_x_11 =
     Css.batch
@@ -29284,7 +28468,6 @@ neg_inset_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_12 : Css.Style
 neg_inset_x_12 =
     Css.batch
@@ -29298,7 +28481,6 @@ neg_inset_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_14 : Css.Style
 neg_inset_x_14 =
     Css.batch
@@ -29312,7 +28494,6 @@ neg_inset_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_16 : Css.Style
 neg_inset_x_16 =
     Css.batch
@@ -29326,7 +28507,6 @@ neg_inset_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_1_dot_5 : Css.Style
 neg_inset_x_1_dot_5 =
     Css.batch
@@ -29340,7 +28520,6 @@ neg_inset_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_1over2 : Css.Style
 neg_inset_x_1over2 =
     Css.batch
@@ -29354,7 +28533,6 @@ neg_inset_x_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_1over3 : Css.Style
 neg_inset_x_1over3 =
     Css.batch
@@ -29368,7 +28546,6 @@ neg_inset_x_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_1over4 : Css.Style
 neg_inset_x_1over4 =
     Css.batch
@@ -29382,7 +28559,6 @@ neg_inset_x_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_2 : Css.Style
 neg_inset_x_2 =
     Css.batch
@@ -29396,7 +28572,6 @@ neg_inset_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_20 : Css.Style
 neg_inset_x_20 =
     Css.batch
@@ -29410,7 +28585,6 @@ neg_inset_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_24 : Css.Style
 neg_inset_x_24 =
     Css.batch
@@ -29424,7 +28598,6 @@ neg_inset_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_28 : Css.Style
 neg_inset_x_28 =
     Css.batch
@@ -29438,7 +28611,6 @@ neg_inset_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_2_dot_5 : Css.Style
 neg_inset_x_2_dot_5 =
     Css.batch
@@ -29452,7 +28624,6 @@ neg_inset_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_2over3 : Css.Style
 neg_inset_x_2over3 =
     Css.batch
@@ -29466,7 +28637,6 @@ neg_inset_x_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_2over4 : Css.Style
 neg_inset_x_2over4 =
     Css.batch
@@ -29480,7 +28650,6 @@ neg_inset_x_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_3 : Css.Style
 neg_inset_x_3 =
     Css.batch
@@ -29494,7 +28663,6 @@ neg_inset_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_32 : Css.Style
 neg_inset_x_32 =
     Css.batch
@@ -29508,7 +28676,6 @@ neg_inset_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_36 : Css.Style
 neg_inset_x_36 =
     Css.batch
@@ -29522,7 +28689,6 @@ neg_inset_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_3_dot_5 : Css.Style
 neg_inset_x_3_dot_5 =
     Css.batch
@@ -29536,7 +28702,6 @@ neg_inset_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_3over4 : Css.Style
 neg_inset_x_3over4 =
     Css.batch
@@ -29550,7 +28715,6 @@ neg_inset_x_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_4 : Css.Style
 neg_inset_x_4 =
     Css.batch
@@ -29564,7 +28728,6 @@ neg_inset_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_40 : Css.Style
 neg_inset_x_40 =
     Css.batch
@@ -29578,7 +28741,6 @@ neg_inset_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_44 : Css.Style
 neg_inset_x_44 =
     Css.batch
@@ -29592,7 +28754,6 @@ neg_inset_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_48 : Css.Style
 neg_inset_x_48 =
     Css.batch
@@ -29606,7 +28767,6 @@ neg_inset_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_5 : Css.Style
 neg_inset_x_5 =
     Css.batch
@@ -29620,7 +28780,6 @@ neg_inset_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_52 : Css.Style
 neg_inset_x_52 =
     Css.batch
@@ -29634,7 +28793,6 @@ neg_inset_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_56 : Css.Style
 neg_inset_x_56 =
     Css.batch
@@ -29648,7 +28806,6 @@ neg_inset_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_6 : Css.Style
 neg_inset_x_6 =
     Css.batch
@@ -29662,7 +28819,6 @@ neg_inset_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_60 : Css.Style
 neg_inset_x_60 =
     Css.batch
@@ -29676,7 +28832,6 @@ neg_inset_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_64 : Css.Style
 neg_inset_x_64 =
     Css.batch
@@ -29690,7 +28845,6 @@ neg_inset_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_7 : Css.Style
 neg_inset_x_7 =
     Css.batch
@@ -29704,7 +28858,6 @@ neg_inset_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_72 : Css.Style
 neg_inset_x_72 =
     Css.batch
@@ -29718,7 +28871,6 @@ neg_inset_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_8 : Css.Style
 neg_inset_x_8 =
     Css.batch
@@ -29732,7 +28884,6 @@ neg_inset_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_80 : Css.Style
 neg_inset_x_80 =
     Css.batch
@@ -29746,7 +28897,6 @@ neg_inset_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_9 : Css.Style
 neg_inset_x_9 =
     Css.batch
@@ -29760,7 +28910,6 @@ neg_inset_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_96 : Css.Style
 neg_inset_x_96 =
     Css.batch
@@ -29774,7 +28923,6 @@ neg_inset_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_full : Css.Style
 neg_inset_x_full =
     Css.batch
@@ -29788,7 +28936,6 @@ neg_inset_x_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_x_px : Css.Style
 neg_inset_x_px =
     Css.batch
@@ -29802,7 +28949,6 @@ neg_inset_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_0 : Css.Style
 neg_inset_y_0 =
     Css.batch
@@ -29816,7 +28962,6 @@ neg_inset_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_0_dot_5 : Css.Style
 neg_inset_y_0_dot_5 =
     Css.batch
@@ -29830,7 +28975,6 @@ neg_inset_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_1 : Css.Style
 neg_inset_y_1 =
     Css.batch
@@ -29844,7 +28988,6 @@ neg_inset_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_10 : Css.Style
 neg_inset_y_10 =
     Css.batch
@@ -29858,7 +29001,6 @@ neg_inset_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_11 : Css.Style
 neg_inset_y_11 =
     Css.batch
@@ -29872,7 +29014,6 @@ neg_inset_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_12 : Css.Style
 neg_inset_y_12 =
     Css.batch
@@ -29886,7 +29027,6 @@ neg_inset_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_14 : Css.Style
 neg_inset_y_14 =
     Css.batch
@@ -29900,7 +29040,6 @@ neg_inset_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_16 : Css.Style
 neg_inset_y_16 =
     Css.batch
@@ -29914,7 +29053,6 @@ neg_inset_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_1_dot_5 : Css.Style
 neg_inset_y_1_dot_5 =
     Css.batch
@@ -29928,7 +29066,6 @@ neg_inset_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_1over2 : Css.Style
 neg_inset_y_1over2 =
     Css.batch
@@ -29942,7 +29079,6 @@ neg_inset_y_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_1over3 : Css.Style
 neg_inset_y_1over3 =
     Css.batch
@@ -29956,7 +29092,6 @@ neg_inset_y_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_1over4 : Css.Style
 neg_inset_y_1over4 =
     Css.batch
@@ -29970,7 +29105,6 @@ neg_inset_y_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_2 : Css.Style
 neg_inset_y_2 =
     Css.batch
@@ -29984,7 +29118,6 @@ neg_inset_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_20 : Css.Style
 neg_inset_y_20 =
     Css.batch
@@ -29998,7 +29131,6 @@ neg_inset_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_24 : Css.Style
 neg_inset_y_24 =
     Css.batch
@@ -30012,7 +29144,6 @@ neg_inset_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_28 : Css.Style
 neg_inset_y_28 =
     Css.batch
@@ -30026,7 +29157,6 @@ neg_inset_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_2_dot_5 : Css.Style
 neg_inset_y_2_dot_5 =
     Css.batch
@@ -30040,7 +29170,6 @@ neg_inset_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_2over3 : Css.Style
 neg_inset_y_2over3 =
     Css.batch
@@ -30054,7 +29183,6 @@ neg_inset_y_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_2over4 : Css.Style
 neg_inset_y_2over4 =
     Css.batch
@@ -30068,7 +29196,6 @@ neg_inset_y_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_3 : Css.Style
 neg_inset_y_3 =
     Css.batch
@@ -30082,7 +29209,6 @@ neg_inset_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_32 : Css.Style
 neg_inset_y_32 =
     Css.batch
@@ -30096,7 +29222,6 @@ neg_inset_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_36 : Css.Style
 neg_inset_y_36 =
     Css.batch
@@ -30110,7 +29235,6 @@ neg_inset_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_3_dot_5 : Css.Style
 neg_inset_y_3_dot_5 =
     Css.batch
@@ -30124,7 +29248,6 @@ neg_inset_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_3over4 : Css.Style
 neg_inset_y_3over4 =
     Css.batch
@@ -30138,7 +29261,6 @@ neg_inset_y_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_4 : Css.Style
 neg_inset_y_4 =
     Css.batch
@@ -30152,7 +29274,6 @@ neg_inset_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_40 : Css.Style
 neg_inset_y_40 =
     Css.batch
@@ -30166,7 +29287,6 @@ neg_inset_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_44 : Css.Style
 neg_inset_y_44 =
     Css.batch
@@ -30180,7 +29300,6 @@ neg_inset_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_48 : Css.Style
 neg_inset_y_48 =
     Css.batch
@@ -30194,7 +29313,6 @@ neg_inset_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_5 : Css.Style
 neg_inset_y_5 =
     Css.batch
@@ -30208,7 +29326,6 @@ neg_inset_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_52 : Css.Style
 neg_inset_y_52 =
     Css.batch
@@ -30222,7 +29339,6 @@ neg_inset_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_56 : Css.Style
 neg_inset_y_56 =
     Css.batch
@@ -30236,7 +29352,6 @@ neg_inset_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_6 : Css.Style
 neg_inset_y_6 =
     Css.batch
@@ -30250,7 +29365,6 @@ neg_inset_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_60 : Css.Style
 neg_inset_y_60 =
     Css.batch
@@ -30264,7 +29378,6 @@ neg_inset_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_64 : Css.Style
 neg_inset_y_64 =
     Css.batch
@@ -30278,7 +29391,6 @@ neg_inset_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_7 : Css.Style
 neg_inset_y_7 =
     Css.batch
@@ -30292,7 +29404,6 @@ neg_inset_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_72 : Css.Style
 neg_inset_y_72 =
     Css.batch
@@ -30306,7 +29417,6 @@ neg_inset_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_8 : Css.Style
 neg_inset_y_8 =
     Css.batch
@@ -30320,7 +29430,6 @@ neg_inset_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_80 : Css.Style
 neg_inset_y_80 =
     Css.batch
@@ -30334,7 +29443,6 @@ neg_inset_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_9 : Css.Style
 neg_inset_y_9 =
     Css.batch
@@ -30348,7 +29456,6 @@ neg_inset_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_96 : Css.Style
 neg_inset_y_96 =
     Css.batch
@@ -30362,7 +29469,6 @@ neg_inset_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_full : Css.Style
 neg_inset_y_full =
     Css.batch
@@ -30376,7 +29482,6 @@ neg_inset_y_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_inset_y_px : Css.Style
 neg_inset_y_px =
     Css.batch
@@ -30390,7 +29495,6 @@ neg_inset_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_0 : Css.Style
 neg_left_0 =
     Css.property "left" "0px"
@@ -30401,7 +29505,6 @@ neg_left_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_0_dot_5 : Css.Style
 neg_left_0_dot_5 =
     Css.property "left" "-0.125rem"
@@ -30412,7 +29515,6 @@ neg_left_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_1 : Css.Style
 neg_left_1 =
     Css.property "left" "-0.25rem"
@@ -30423,7 +29525,6 @@ neg_left_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_10 : Css.Style
 neg_left_10 =
     Css.property "left" "-2.5rem"
@@ -30434,7 +29535,6 @@ neg_left_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_11 : Css.Style
 neg_left_11 =
     Css.property "left" "-2.75rem"
@@ -30445,7 +29545,6 @@ neg_left_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_12 : Css.Style
 neg_left_12 =
     Css.property "left" "-3rem"
@@ -30456,7 +29555,6 @@ neg_left_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_14 : Css.Style
 neg_left_14 =
     Css.property "left" "-3.5rem"
@@ -30467,7 +29565,6 @@ neg_left_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_16 : Css.Style
 neg_left_16 =
     Css.property "left" "-4rem"
@@ -30478,7 +29575,6 @@ neg_left_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_1_dot_5 : Css.Style
 neg_left_1_dot_5 =
     Css.property "left" "-0.375rem"
@@ -30489,7 +29585,6 @@ neg_left_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_1over2 : Css.Style
 neg_left_1over2 =
     Css.property "left" "-50%"
@@ -30500,7 +29595,6 @@ neg_left_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_1over3 : Css.Style
 neg_left_1over3 =
     Css.property "left" "-33.333333%"
@@ -30511,7 +29605,6 @@ neg_left_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_1over4 : Css.Style
 neg_left_1over4 =
     Css.property "left" "-25%"
@@ -30522,7 +29615,6 @@ neg_left_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_2 : Css.Style
 neg_left_2 =
     Css.property "left" "-0.5rem"
@@ -30533,7 +29625,6 @@ neg_left_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_20 : Css.Style
 neg_left_20 =
     Css.property "left" "-5rem"
@@ -30544,7 +29635,6 @@ neg_left_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_24 : Css.Style
 neg_left_24 =
     Css.property "left" "-6rem"
@@ -30555,7 +29645,6 @@ neg_left_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_28 : Css.Style
 neg_left_28 =
     Css.property "left" "-7rem"
@@ -30566,7 +29655,6 @@ neg_left_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_2_dot_5 : Css.Style
 neg_left_2_dot_5 =
     Css.property "left" "-0.625rem"
@@ -30577,7 +29665,6 @@ neg_left_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_2over3 : Css.Style
 neg_left_2over3 =
     Css.property "left" "-66.666667%"
@@ -30588,7 +29675,6 @@ neg_left_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_2over4 : Css.Style
 neg_left_2over4 =
     Css.property "left" "-50%"
@@ -30599,7 +29685,6 @@ neg_left_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_3 : Css.Style
 neg_left_3 =
     Css.property "left" "-0.75rem"
@@ -30610,7 +29695,6 @@ neg_left_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_32 : Css.Style
 neg_left_32 =
     Css.property "left" "-8rem"
@@ -30621,7 +29705,6 @@ neg_left_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_36 : Css.Style
 neg_left_36 =
     Css.property "left" "-9rem"
@@ -30632,7 +29715,6 @@ neg_left_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_3_dot_5 : Css.Style
 neg_left_3_dot_5 =
     Css.property "left" "-0.875rem"
@@ -30643,7 +29725,6 @@ neg_left_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_3over4 : Css.Style
 neg_left_3over4 =
     Css.property "left" "-75%"
@@ -30654,7 +29735,6 @@ neg_left_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_4 : Css.Style
 neg_left_4 =
     Css.property "left" "-1rem"
@@ -30665,7 +29745,6 @@ neg_left_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_40 : Css.Style
 neg_left_40 =
     Css.property "left" "-10rem"
@@ -30676,7 +29755,6 @@ neg_left_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_44 : Css.Style
 neg_left_44 =
     Css.property "left" "-11rem"
@@ -30687,7 +29765,6 @@ neg_left_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_48 : Css.Style
 neg_left_48 =
     Css.property "left" "-12rem"
@@ -30698,7 +29775,6 @@ neg_left_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_5 : Css.Style
 neg_left_5 =
     Css.property "left" "-1.25rem"
@@ -30709,7 +29785,6 @@ neg_left_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_52 : Css.Style
 neg_left_52 =
     Css.property "left" "-13rem"
@@ -30720,7 +29795,6 @@ neg_left_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_56 : Css.Style
 neg_left_56 =
     Css.property "left" "-14rem"
@@ -30731,7 +29805,6 @@ neg_left_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_6 : Css.Style
 neg_left_6 =
     Css.property "left" "-1.5rem"
@@ -30742,7 +29815,6 @@ neg_left_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_60 : Css.Style
 neg_left_60 =
     Css.property "left" "-15rem"
@@ -30753,7 +29825,6 @@ neg_left_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_64 : Css.Style
 neg_left_64 =
     Css.property "left" "-16rem"
@@ -30764,7 +29835,6 @@ neg_left_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_7 : Css.Style
 neg_left_7 =
     Css.property "left" "-1.75rem"
@@ -30775,7 +29845,6 @@ neg_left_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_72 : Css.Style
 neg_left_72 =
     Css.property "left" "-18rem"
@@ -30786,7 +29855,6 @@ neg_left_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_8 : Css.Style
 neg_left_8 =
     Css.property "left" "-2rem"
@@ -30797,7 +29865,6 @@ neg_left_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_80 : Css.Style
 neg_left_80 =
     Css.property "left" "-20rem"
@@ -30808,7 +29875,6 @@ neg_left_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_9 : Css.Style
 neg_left_9 =
     Css.property "left" "-2.25rem"
@@ -30819,7 +29885,6 @@ neg_left_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_96 : Css.Style
 neg_left_96 =
     Css.property "left" "-24rem"
@@ -30830,7 +29895,6 @@ neg_left_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_full : Css.Style
 neg_left_full =
     Css.property "left" "-100%"
@@ -30841,7 +29905,6 @@ neg_left_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_left_px : Css.Style
 neg_left_px =
     Css.property "left" "-1px"
@@ -30852,7 +29915,6 @@ neg_left_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_0 : Css.Style
 neg_m_0 =
     Css.property "margin" "0px"
@@ -30863,7 +29925,6 @@ neg_m_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_0_dot_5 : Css.Style
 neg_m_0_dot_5 =
     Css.property "margin" "-0.125rem"
@@ -30874,7 +29935,6 @@ neg_m_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_1 : Css.Style
 neg_m_1 =
     Css.property "margin" "-0.25rem"
@@ -30885,7 +29945,6 @@ neg_m_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_10 : Css.Style
 neg_m_10 =
     Css.property "margin" "-2.5rem"
@@ -30896,7 +29955,6 @@ neg_m_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_11 : Css.Style
 neg_m_11 =
     Css.property "margin" "-2.75rem"
@@ -30907,7 +29965,6 @@ neg_m_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_12 : Css.Style
 neg_m_12 =
     Css.property "margin" "-3rem"
@@ -30918,7 +29975,6 @@ neg_m_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_14 : Css.Style
 neg_m_14 =
     Css.property "margin" "-3.5rem"
@@ -30929,7 +29985,6 @@ neg_m_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_16 : Css.Style
 neg_m_16 =
     Css.property "margin" "-4rem"
@@ -30940,7 +29995,6 @@ neg_m_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_1_dot_5 : Css.Style
 neg_m_1_dot_5 =
     Css.property "margin" "-0.375rem"
@@ -30951,7 +30005,6 @@ neg_m_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_2 : Css.Style
 neg_m_2 =
     Css.property "margin" "-0.5rem"
@@ -30962,7 +30015,6 @@ neg_m_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_20 : Css.Style
 neg_m_20 =
     Css.property "margin" "-5rem"
@@ -30973,7 +30025,6 @@ neg_m_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_24 : Css.Style
 neg_m_24 =
     Css.property "margin" "-6rem"
@@ -30984,7 +30035,6 @@ neg_m_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_28 : Css.Style
 neg_m_28 =
     Css.property "margin" "-7rem"
@@ -30995,7 +30045,6 @@ neg_m_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_2_dot_5 : Css.Style
 neg_m_2_dot_5 =
     Css.property "margin" "-0.625rem"
@@ -31006,7 +30055,6 @@ neg_m_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_3 : Css.Style
 neg_m_3 =
     Css.property "margin" "-0.75rem"
@@ -31017,7 +30065,6 @@ neg_m_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_32 : Css.Style
 neg_m_32 =
     Css.property "margin" "-8rem"
@@ -31028,7 +30075,6 @@ neg_m_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_36 : Css.Style
 neg_m_36 =
     Css.property "margin" "-9rem"
@@ -31039,7 +30085,6 @@ neg_m_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_3_dot_5 : Css.Style
 neg_m_3_dot_5 =
     Css.property "margin" "-0.875rem"
@@ -31050,7 +30095,6 @@ neg_m_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_4 : Css.Style
 neg_m_4 =
     Css.property "margin" "-1rem"
@@ -31061,7 +30105,6 @@ neg_m_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_40 : Css.Style
 neg_m_40 =
     Css.property "margin" "-10rem"
@@ -31072,7 +30115,6 @@ neg_m_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_44 : Css.Style
 neg_m_44 =
     Css.property "margin" "-11rem"
@@ -31083,7 +30125,6 @@ neg_m_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_48 : Css.Style
 neg_m_48 =
     Css.property "margin" "-12rem"
@@ -31094,7 +30135,6 @@ neg_m_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_5 : Css.Style
 neg_m_5 =
     Css.property "margin" "-1.25rem"
@@ -31105,7 +30145,6 @@ neg_m_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_52 : Css.Style
 neg_m_52 =
     Css.property "margin" "-13rem"
@@ -31116,7 +30155,6 @@ neg_m_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_56 : Css.Style
 neg_m_56 =
     Css.property "margin" "-14rem"
@@ -31127,7 +30165,6 @@ neg_m_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_6 : Css.Style
 neg_m_6 =
     Css.property "margin" "-1.5rem"
@@ -31138,7 +30175,6 @@ neg_m_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_60 : Css.Style
 neg_m_60 =
     Css.property "margin" "-15rem"
@@ -31149,7 +30185,6 @@ neg_m_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_64 : Css.Style
 neg_m_64 =
     Css.property "margin" "-16rem"
@@ -31160,7 +30195,6 @@ neg_m_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_7 : Css.Style
 neg_m_7 =
     Css.property "margin" "-1.75rem"
@@ -31171,7 +30205,6 @@ neg_m_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_72 : Css.Style
 neg_m_72 =
     Css.property "margin" "-18rem"
@@ -31182,7 +30215,6 @@ neg_m_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_8 : Css.Style
 neg_m_8 =
     Css.property "margin" "-2rem"
@@ -31193,7 +30225,6 @@ neg_m_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_80 : Css.Style
 neg_m_80 =
     Css.property "margin" "-20rem"
@@ -31204,7 +30235,6 @@ neg_m_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_9 : Css.Style
 neg_m_9 =
     Css.property "margin" "-2.25rem"
@@ -31215,7 +30245,6 @@ neg_m_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_96 : Css.Style
 neg_m_96 =
     Css.property "margin" "-24rem"
@@ -31226,7 +30255,6 @@ neg_m_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_m_px : Css.Style
 neg_m_px =
     Css.property "margin" "-1px"
@@ -31237,7 +30265,6 @@ neg_m_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_0 : Css.Style
 neg_mb_0 =
     Css.property "margin-bottom" "0px"
@@ -31248,7 +30275,6 @@ neg_mb_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_0_dot_5 : Css.Style
 neg_mb_0_dot_5 =
     Css.property "margin-bottom" "-0.125rem"
@@ -31259,7 +30285,6 @@ neg_mb_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_1 : Css.Style
 neg_mb_1 =
     Css.property "margin-bottom" "-0.25rem"
@@ -31270,7 +30295,6 @@ neg_mb_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_10 : Css.Style
 neg_mb_10 =
     Css.property "margin-bottom" "-2.5rem"
@@ -31281,7 +30305,6 @@ neg_mb_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_11 : Css.Style
 neg_mb_11 =
     Css.property "margin-bottom" "-2.75rem"
@@ -31292,7 +30315,6 @@ neg_mb_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_12 : Css.Style
 neg_mb_12 =
     Css.property "margin-bottom" "-3rem"
@@ -31303,7 +30325,6 @@ neg_mb_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_14 : Css.Style
 neg_mb_14 =
     Css.property "margin-bottom" "-3.5rem"
@@ -31314,7 +30335,6 @@ neg_mb_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_16 : Css.Style
 neg_mb_16 =
     Css.property "margin-bottom" "-4rem"
@@ -31325,7 +30345,6 @@ neg_mb_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_1_dot_5 : Css.Style
 neg_mb_1_dot_5 =
     Css.property "margin-bottom" "-0.375rem"
@@ -31336,7 +30355,6 @@ neg_mb_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_2 : Css.Style
 neg_mb_2 =
     Css.property "margin-bottom" "-0.5rem"
@@ -31347,7 +30365,6 @@ neg_mb_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_20 : Css.Style
 neg_mb_20 =
     Css.property "margin-bottom" "-5rem"
@@ -31358,7 +30375,6 @@ neg_mb_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_24 : Css.Style
 neg_mb_24 =
     Css.property "margin-bottom" "-6rem"
@@ -31369,7 +30385,6 @@ neg_mb_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_28 : Css.Style
 neg_mb_28 =
     Css.property "margin-bottom" "-7rem"
@@ -31380,7 +30395,6 @@ neg_mb_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_2_dot_5 : Css.Style
 neg_mb_2_dot_5 =
     Css.property "margin-bottom" "-0.625rem"
@@ -31391,7 +30405,6 @@ neg_mb_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_3 : Css.Style
 neg_mb_3 =
     Css.property "margin-bottom" "-0.75rem"
@@ -31402,7 +30415,6 @@ neg_mb_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_32 : Css.Style
 neg_mb_32 =
     Css.property "margin-bottom" "-8rem"
@@ -31413,7 +30425,6 @@ neg_mb_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_36 : Css.Style
 neg_mb_36 =
     Css.property "margin-bottom" "-9rem"
@@ -31424,7 +30435,6 @@ neg_mb_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_3_dot_5 : Css.Style
 neg_mb_3_dot_5 =
     Css.property "margin-bottom" "-0.875rem"
@@ -31435,7 +30445,6 @@ neg_mb_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_4 : Css.Style
 neg_mb_4 =
     Css.property "margin-bottom" "-1rem"
@@ -31446,7 +30455,6 @@ neg_mb_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_40 : Css.Style
 neg_mb_40 =
     Css.property "margin-bottom" "-10rem"
@@ -31457,7 +30465,6 @@ neg_mb_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_44 : Css.Style
 neg_mb_44 =
     Css.property "margin-bottom" "-11rem"
@@ -31468,7 +30475,6 @@ neg_mb_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_48 : Css.Style
 neg_mb_48 =
     Css.property "margin-bottom" "-12rem"
@@ -31479,7 +30485,6 @@ neg_mb_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_5 : Css.Style
 neg_mb_5 =
     Css.property "margin-bottom" "-1.25rem"
@@ -31490,7 +30495,6 @@ neg_mb_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_52 : Css.Style
 neg_mb_52 =
     Css.property "margin-bottom" "-13rem"
@@ -31501,7 +30505,6 @@ neg_mb_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_56 : Css.Style
 neg_mb_56 =
     Css.property "margin-bottom" "-14rem"
@@ -31512,7 +30515,6 @@ neg_mb_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_6 : Css.Style
 neg_mb_6 =
     Css.property "margin-bottom" "-1.5rem"
@@ -31523,7 +30525,6 @@ neg_mb_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_60 : Css.Style
 neg_mb_60 =
     Css.property "margin-bottom" "-15rem"
@@ -31534,7 +30535,6 @@ neg_mb_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_64 : Css.Style
 neg_mb_64 =
     Css.property "margin-bottom" "-16rem"
@@ -31545,7 +30545,6 @@ neg_mb_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_7 : Css.Style
 neg_mb_7 =
     Css.property "margin-bottom" "-1.75rem"
@@ -31556,7 +30555,6 @@ neg_mb_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_72 : Css.Style
 neg_mb_72 =
     Css.property "margin-bottom" "-18rem"
@@ -31567,7 +30565,6 @@ neg_mb_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_8 : Css.Style
 neg_mb_8 =
     Css.property "margin-bottom" "-2rem"
@@ -31578,7 +30575,6 @@ neg_mb_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_80 : Css.Style
 neg_mb_80 =
     Css.property "margin-bottom" "-20rem"
@@ -31589,7 +30585,6 @@ neg_mb_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_9 : Css.Style
 neg_mb_9 =
     Css.property "margin-bottom" "-2.25rem"
@@ -31600,7 +30595,6 @@ neg_mb_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_96 : Css.Style
 neg_mb_96 =
     Css.property "margin-bottom" "-24rem"
@@ -31611,7 +30605,6 @@ neg_mb_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mb_px : Css.Style
 neg_mb_px =
     Css.property "margin-bottom" "-1px"
@@ -31622,7 +30615,6 @@ neg_mb_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_0 : Css.Style
 neg_ml_0 =
     Css.property "margin-left" "0px"
@@ -31633,7 +30625,6 @@ neg_ml_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_0_dot_5 : Css.Style
 neg_ml_0_dot_5 =
     Css.property "margin-left" "-0.125rem"
@@ -31644,7 +30635,6 @@ neg_ml_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_1 : Css.Style
 neg_ml_1 =
     Css.property "margin-left" "-0.25rem"
@@ -31655,7 +30645,6 @@ neg_ml_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_10 : Css.Style
 neg_ml_10 =
     Css.property "margin-left" "-2.5rem"
@@ -31666,7 +30655,6 @@ neg_ml_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_11 : Css.Style
 neg_ml_11 =
     Css.property "margin-left" "-2.75rem"
@@ -31677,7 +30665,6 @@ neg_ml_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_12 : Css.Style
 neg_ml_12 =
     Css.property "margin-left" "-3rem"
@@ -31688,7 +30675,6 @@ neg_ml_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_14 : Css.Style
 neg_ml_14 =
     Css.property "margin-left" "-3.5rem"
@@ -31699,7 +30685,6 @@ neg_ml_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_16 : Css.Style
 neg_ml_16 =
     Css.property "margin-left" "-4rem"
@@ -31710,7 +30695,6 @@ neg_ml_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_1_dot_5 : Css.Style
 neg_ml_1_dot_5 =
     Css.property "margin-left" "-0.375rem"
@@ -31721,7 +30705,6 @@ neg_ml_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_2 : Css.Style
 neg_ml_2 =
     Css.property "margin-left" "-0.5rem"
@@ -31732,7 +30715,6 @@ neg_ml_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_20 : Css.Style
 neg_ml_20 =
     Css.property "margin-left" "-5rem"
@@ -31743,7 +30725,6 @@ neg_ml_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_24 : Css.Style
 neg_ml_24 =
     Css.property "margin-left" "-6rem"
@@ -31754,7 +30735,6 @@ neg_ml_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_28 : Css.Style
 neg_ml_28 =
     Css.property "margin-left" "-7rem"
@@ -31765,7 +30745,6 @@ neg_ml_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_2_dot_5 : Css.Style
 neg_ml_2_dot_5 =
     Css.property "margin-left" "-0.625rem"
@@ -31776,7 +30755,6 @@ neg_ml_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_3 : Css.Style
 neg_ml_3 =
     Css.property "margin-left" "-0.75rem"
@@ -31787,7 +30765,6 @@ neg_ml_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_32 : Css.Style
 neg_ml_32 =
     Css.property "margin-left" "-8rem"
@@ -31798,7 +30775,6 @@ neg_ml_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_36 : Css.Style
 neg_ml_36 =
     Css.property "margin-left" "-9rem"
@@ -31809,7 +30785,6 @@ neg_ml_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_3_dot_5 : Css.Style
 neg_ml_3_dot_5 =
     Css.property "margin-left" "-0.875rem"
@@ -31820,7 +30795,6 @@ neg_ml_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_4 : Css.Style
 neg_ml_4 =
     Css.property "margin-left" "-1rem"
@@ -31831,7 +30805,6 @@ neg_ml_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_40 : Css.Style
 neg_ml_40 =
     Css.property "margin-left" "-10rem"
@@ -31842,7 +30815,6 @@ neg_ml_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_44 : Css.Style
 neg_ml_44 =
     Css.property "margin-left" "-11rem"
@@ -31853,7 +30825,6 @@ neg_ml_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_48 : Css.Style
 neg_ml_48 =
     Css.property "margin-left" "-12rem"
@@ -31864,7 +30835,6 @@ neg_ml_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_5 : Css.Style
 neg_ml_5 =
     Css.property "margin-left" "-1.25rem"
@@ -31875,7 +30845,6 @@ neg_ml_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_52 : Css.Style
 neg_ml_52 =
     Css.property "margin-left" "-13rem"
@@ -31886,7 +30855,6 @@ neg_ml_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_56 : Css.Style
 neg_ml_56 =
     Css.property "margin-left" "-14rem"
@@ -31897,7 +30865,6 @@ neg_ml_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_6 : Css.Style
 neg_ml_6 =
     Css.property "margin-left" "-1.5rem"
@@ -31908,7 +30875,6 @@ neg_ml_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_60 : Css.Style
 neg_ml_60 =
     Css.property "margin-left" "-15rem"
@@ -31919,7 +30885,6 @@ neg_ml_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_64 : Css.Style
 neg_ml_64 =
     Css.property "margin-left" "-16rem"
@@ -31930,7 +30895,6 @@ neg_ml_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_7 : Css.Style
 neg_ml_7 =
     Css.property "margin-left" "-1.75rem"
@@ -31941,7 +30905,6 @@ neg_ml_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_72 : Css.Style
 neg_ml_72 =
     Css.property "margin-left" "-18rem"
@@ -31952,7 +30915,6 @@ neg_ml_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_8 : Css.Style
 neg_ml_8 =
     Css.property "margin-left" "-2rem"
@@ -31963,7 +30925,6 @@ neg_ml_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_80 : Css.Style
 neg_ml_80 =
     Css.property "margin-left" "-20rem"
@@ -31974,7 +30935,6 @@ neg_ml_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_9 : Css.Style
 neg_ml_9 =
     Css.property "margin-left" "-2.25rem"
@@ -31985,7 +30945,6 @@ neg_ml_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_96 : Css.Style
 neg_ml_96 =
     Css.property "margin-left" "-24rem"
@@ -31996,7 +30955,6 @@ neg_ml_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_ml_px : Css.Style
 neg_ml_px =
     Css.property "margin-left" "-1px"
@@ -32007,7 +30965,6 @@ neg_ml_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_0 : Css.Style
 neg_mr_0 =
     Css.property "margin-right" "0px"
@@ -32018,7 +30975,6 @@ neg_mr_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_0_dot_5 : Css.Style
 neg_mr_0_dot_5 =
     Css.property "margin-right" "-0.125rem"
@@ -32029,7 +30985,6 @@ neg_mr_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_1 : Css.Style
 neg_mr_1 =
     Css.property "margin-right" "-0.25rem"
@@ -32040,7 +30995,6 @@ neg_mr_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_10 : Css.Style
 neg_mr_10 =
     Css.property "margin-right" "-2.5rem"
@@ -32051,7 +31005,6 @@ neg_mr_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_11 : Css.Style
 neg_mr_11 =
     Css.property "margin-right" "-2.75rem"
@@ -32062,7 +31015,6 @@ neg_mr_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_12 : Css.Style
 neg_mr_12 =
     Css.property "margin-right" "-3rem"
@@ -32073,7 +31025,6 @@ neg_mr_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_14 : Css.Style
 neg_mr_14 =
     Css.property "margin-right" "-3.5rem"
@@ -32084,7 +31035,6 @@ neg_mr_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_16 : Css.Style
 neg_mr_16 =
     Css.property "margin-right" "-4rem"
@@ -32095,7 +31045,6 @@ neg_mr_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_1_dot_5 : Css.Style
 neg_mr_1_dot_5 =
     Css.property "margin-right" "-0.375rem"
@@ -32106,7 +31055,6 @@ neg_mr_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_2 : Css.Style
 neg_mr_2 =
     Css.property "margin-right" "-0.5rem"
@@ -32117,7 +31065,6 @@ neg_mr_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_20 : Css.Style
 neg_mr_20 =
     Css.property "margin-right" "-5rem"
@@ -32128,7 +31075,6 @@ neg_mr_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_24 : Css.Style
 neg_mr_24 =
     Css.property "margin-right" "-6rem"
@@ -32139,7 +31085,6 @@ neg_mr_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_28 : Css.Style
 neg_mr_28 =
     Css.property "margin-right" "-7rem"
@@ -32150,7 +31095,6 @@ neg_mr_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_2_dot_5 : Css.Style
 neg_mr_2_dot_5 =
     Css.property "margin-right" "-0.625rem"
@@ -32161,7 +31105,6 @@ neg_mr_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_3 : Css.Style
 neg_mr_3 =
     Css.property "margin-right" "-0.75rem"
@@ -32172,7 +31115,6 @@ neg_mr_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_32 : Css.Style
 neg_mr_32 =
     Css.property "margin-right" "-8rem"
@@ -32183,7 +31125,6 @@ neg_mr_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_36 : Css.Style
 neg_mr_36 =
     Css.property "margin-right" "-9rem"
@@ -32194,7 +31135,6 @@ neg_mr_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_3_dot_5 : Css.Style
 neg_mr_3_dot_5 =
     Css.property "margin-right" "-0.875rem"
@@ -32205,7 +31145,6 @@ neg_mr_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_4 : Css.Style
 neg_mr_4 =
     Css.property "margin-right" "-1rem"
@@ -32216,7 +31155,6 @@ neg_mr_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_40 : Css.Style
 neg_mr_40 =
     Css.property "margin-right" "-10rem"
@@ -32227,7 +31165,6 @@ neg_mr_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_44 : Css.Style
 neg_mr_44 =
     Css.property "margin-right" "-11rem"
@@ -32238,7 +31175,6 @@ neg_mr_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_48 : Css.Style
 neg_mr_48 =
     Css.property "margin-right" "-12rem"
@@ -32249,7 +31185,6 @@ neg_mr_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_5 : Css.Style
 neg_mr_5 =
     Css.property "margin-right" "-1.25rem"
@@ -32260,7 +31195,6 @@ neg_mr_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_52 : Css.Style
 neg_mr_52 =
     Css.property "margin-right" "-13rem"
@@ -32271,7 +31205,6 @@ neg_mr_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_56 : Css.Style
 neg_mr_56 =
     Css.property "margin-right" "-14rem"
@@ -32282,7 +31215,6 @@ neg_mr_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_6 : Css.Style
 neg_mr_6 =
     Css.property "margin-right" "-1.5rem"
@@ -32293,7 +31225,6 @@ neg_mr_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_60 : Css.Style
 neg_mr_60 =
     Css.property "margin-right" "-15rem"
@@ -32304,7 +31235,6 @@ neg_mr_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_64 : Css.Style
 neg_mr_64 =
     Css.property "margin-right" "-16rem"
@@ -32315,7 +31245,6 @@ neg_mr_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_7 : Css.Style
 neg_mr_7 =
     Css.property "margin-right" "-1.75rem"
@@ -32326,7 +31255,6 @@ neg_mr_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_72 : Css.Style
 neg_mr_72 =
     Css.property "margin-right" "-18rem"
@@ -32337,7 +31265,6 @@ neg_mr_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_8 : Css.Style
 neg_mr_8 =
     Css.property "margin-right" "-2rem"
@@ -32348,7 +31275,6 @@ neg_mr_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_80 : Css.Style
 neg_mr_80 =
     Css.property "margin-right" "-20rem"
@@ -32359,7 +31285,6 @@ neg_mr_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_9 : Css.Style
 neg_mr_9 =
     Css.property "margin-right" "-2.25rem"
@@ -32370,7 +31295,6 @@ neg_mr_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_96 : Css.Style
 neg_mr_96 =
     Css.property "margin-right" "-24rem"
@@ -32381,7 +31305,6 @@ neg_mr_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mr_px : Css.Style
 neg_mr_px =
     Css.property "margin-right" "-1px"
@@ -32392,7 +31315,6 @@ neg_mr_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_0 : Css.Style
 neg_mt_0 =
     Css.property "margin-top" "0px"
@@ -32403,7 +31325,6 @@ neg_mt_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_0_dot_5 : Css.Style
 neg_mt_0_dot_5 =
     Css.property "margin-top" "-0.125rem"
@@ -32414,7 +31335,6 @@ neg_mt_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_1 : Css.Style
 neg_mt_1 =
     Css.property "margin-top" "-0.25rem"
@@ -32425,7 +31345,6 @@ neg_mt_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_10 : Css.Style
 neg_mt_10 =
     Css.property "margin-top" "-2.5rem"
@@ -32436,7 +31355,6 @@ neg_mt_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_11 : Css.Style
 neg_mt_11 =
     Css.property "margin-top" "-2.75rem"
@@ -32447,7 +31365,6 @@ neg_mt_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_12 : Css.Style
 neg_mt_12 =
     Css.property "margin-top" "-3rem"
@@ -32458,7 +31375,6 @@ neg_mt_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_14 : Css.Style
 neg_mt_14 =
     Css.property "margin-top" "-3.5rem"
@@ -32469,7 +31385,6 @@ neg_mt_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_16 : Css.Style
 neg_mt_16 =
     Css.property "margin-top" "-4rem"
@@ -32480,7 +31395,6 @@ neg_mt_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_1_dot_5 : Css.Style
 neg_mt_1_dot_5 =
     Css.property "margin-top" "-0.375rem"
@@ -32491,7 +31405,6 @@ neg_mt_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_2 : Css.Style
 neg_mt_2 =
     Css.property "margin-top" "-0.5rem"
@@ -32502,7 +31415,6 @@ neg_mt_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_20 : Css.Style
 neg_mt_20 =
     Css.property "margin-top" "-5rem"
@@ -32513,7 +31425,6 @@ neg_mt_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_24 : Css.Style
 neg_mt_24 =
     Css.property "margin-top" "-6rem"
@@ -32524,7 +31435,6 @@ neg_mt_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_28 : Css.Style
 neg_mt_28 =
     Css.property "margin-top" "-7rem"
@@ -32535,7 +31445,6 @@ neg_mt_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_2_dot_5 : Css.Style
 neg_mt_2_dot_5 =
     Css.property "margin-top" "-0.625rem"
@@ -32546,7 +31455,6 @@ neg_mt_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_3 : Css.Style
 neg_mt_3 =
     Css.property "margin-top" "-0.75rem"
@@ -32557,7 +31465,6 @@ neg_mt_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_32 : Css.Style
 neg_mt_32 =
     Css.property "margin-top" "-8rem"
@@ -32568,7 +31475,6 @@ neg_mt_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_36 : Css.Style
 neg_mt_36 =
     Css.property "margin-top" "-9rem"
@@ -32579,7 +31485,6 @@ neg_mt_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_3_dot_5 : Css.Style
 neg_mt_3_dot_5 =
     Css.property "margin-top" "-0.875rem"
@@ -32590,7 +31495,6 @@ neg_mt_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_4 : Css.Style
 neg_mt_4 =
     Css.property "margin-top" "-1rem"
@@ -32601,7 +31505,6 @@ neg_mt_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_40 : Css.Style
 neg_mt_40 =
     Css.property "margin-top" "-10rem"
@@ -32612,7 +31515,6 @@ neg_mt_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_44 : Css.Style
 neg_mt_44 =
     Css.property "margin-top" "-11rem"
@@ -32623,7 +31525,6 @@ neg_mt_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_48 : Css.Style
 neg_mt_48 =
     Css.property "margin-top" "-12rem"
@@ -32634,7 +31535,6 @@ neg_mt_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_5 : Css.Style
 neg_mt_5 =
     Css.property "margin-top" "-1.25rem"
@@ -32645,7 +31545,6 @@ neg_mt_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_52 : Css.Style
 neg_mt_52 =
     Css.property "margin-top" "-13rem"
@@ -32656,7 +31555,6 @@ neg_mt_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_56 : Css.Style
 neg_mt_56 =
     Css.property "margin-top" "-14rem"
@@ -32667,7 +31565,6 @@ neg_mt_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_6 : Css.Style
 neg_mt_6 =
     Css.property "margin-top" "-1.5rem"
@@ -32678,7 +31575,6 @@ neg_mt_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_60 : Css.Style
 neg_mt_60 =
     Css.property "margin-top" "-15rem"
@@ -32689,7 +31585,6 @@ neg_mt_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_64 : Css.Style
 neg_mt_64 =
     Css.property "margin-top" "-16rem"
@@ -32700,7 +31595,6 @@ neg_mt_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_7 : Css.Style
 neg_mt_7 =
     Css.property "margin-top" "-1.75rem"
@@ -32711,7 +31605,6 @@ neg_mt_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_72 : Css.Style
 neg_mt_72 =
     Css.property "margin-top" "-18rem"
@@ -32722,7 +31615,6 @@ neg_mt_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_8 : Css.Style
 neg_mt_8 =
     Css.property "margin-top" "-2rem"
@@ -32733,7 +31625,6 @@ neg_mt_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_80 : Css.Style
 neg_mt_80 =
     Css.property "margin-top" "-20rem"
@@ -32744,7 +31635,6 @@ neg_mt_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_9 : Css.Style
 neg_mt_9 =
     Css.property "margin-top" "-2.25rem"
@@ -32755,7 +31645,6 @@ neg_mt_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_96 : Css.Style
 neg_mt_96 =
     Css.property "margin-top" "-24rem"
@@ -32766,7 +31655,6 @@ neg_mt_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mt_px : Css.Style
 neg_mt_px =
     Css.property "margin-top" "-1px"
@@ -32777,7 +31665,6 @@ neg_mt_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_0 : Css.Style
 neg_mx_0 =
     Css.batch
@@ -32791,7 +31678,6 @@ neg_mx_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_0_dot_5 : Css.Style
 neg_mx_0_dot_5 =
     Css.batch
@@ -32805,7 +31691,6 @@ neg_mx_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_1 : Css.Style
 neg_mx_1 =
     Css.batch
@@ -32819,7 +31704,6 @@ neg_mx_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_10 : Css.Style
 neg_mx_10 =
     Css.batch
@@ -32833,7 +31717,6 @@ neg_mx_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_11 : Css.Style
 neg_mx_11 =
     Css.batch
@@ -32847,7 +31730,6 @@ neg_mx_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_12 : Css.Style
 neg_mx_12 =
     Css.batch
@@ -32861,7 +31743,6 @@ neg_mx_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_14 : Css.Style
 neg_mx_14 =
     Css.batch
@@ -32875,7 +31756,6 @@ neg_mx_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_16 : Css.Style
 neg_mx_16 =
     Css.batch
@@ -32889,7 +31769,6 @@ neg_mx_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_1_dot_5 : Css.Style
 neg_mx_1_dot_5 =
     Css.batch
@@ -32903,7 +31782,6 @@ neg_mx_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_2 : Css.Style
 neg_mx_2 =
     Css.batch
@@ -32917,7 +31795,6 @@ neg_mx_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_20 : Css.Style
 neg_mx_20 =
     Css.batch
@@ -32931,7 +31808,6 @@ neg_mx_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_24 : Css.Style
 neg_mx_24 =
     Css.batch
@@ -32945,7 +31821,6 @@ neg_mx_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_28 : Css.Style
 neg_mx_28 =
     Css.batch
@@ -32959,7 +31834,6 @@ neg_mx_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_2_dot_5 : Css.Style
 neg_mx_2_dot_5 =
     Css.batch
@@ -32973,7 +31847,6 @@ neg_mx_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_3 : Css.Style
 neg_mx_3 =
     Css.batch
@@ -32987,7 +31860,6 @@ neg_mx_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_32 : Css.Style
 neg_mx_32 =
     Css.batch
@@ -33001,7 +31873,6 @@ neg_mx_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_36 : Css.Style
 neg_mx_36 =
     Css.batch
@@ -33015,7 +31886,6 @@ neg_mx_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_3_dot_5 : Css.Style
 neg_mx_3_dot_5 =
     Css.batch
@@ -33029,7 +31899,6 @@ neg_mx_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_4 : Css.Style
 neg_mx_4 =
     Css.batch
@@ -33043,7 +31912,6 @@ neg_mx_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_40 : Css.Style
 neg_mx_40 =
     Css.batch
@@ -33057,7 +31925,6 @@ neg_mx_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_44 : Css.Style
 neg_mx_44 =
     Css.batch
@@ -33071,7 +31938,6 @@ neg_mx_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_48 : Css.Style
 neg_mx_48 =
     Css.batch
@@ -33085,7 +31951,6 @@ neg_mx_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_5 : Css.Style
 neg_mx_5 =
     Css.batch
@@ -33099,7 +31964,6 @@ neg_mx_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_52 : Css.Style
 neg_mx_52 =
     Css.batch
@@ -33113,7 +31977,6 @@ neg_mx_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_56 : Css.Style
 neg_mx_56 =
     Css.batch
@@ -33127,7 +31990,6 @@ neg_mx_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_6 : Css.Style
 neg_mx_6 =
     Css.batch
@@ -33141,7 +32003,6 @@ neg_mx_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_60 : Css.Style
 neg_mx_60 =
     Css.batch
@@ -33155,7 +32016,6 @@ neg_mx_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_64 : Css.Style
 neg_mx_64 =
     Css.batch
@@ -33169,7 +32029,6 @@ neg_mx_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_7 : Css.Style
 neg_mx_7 =
     Css.batch
@@ -33183,7 +32042,6 @@ neg_mx_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_72 : Css.Style
 neg_mx_72 =
     Css.batch
@@ -33197,7 +32055,6 @@ neg_mx_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_8 : Css.Style
 neg_mx_8 =
     Css.batch
@@ -33211,7 +32068,6 @@ neg_mx_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_80 : Css.Style
 neg_mx_80 =
     Css.batch
@@ -33225,7 +32081,6 @@ neg_mx_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_9 : Css.Style
 neg_mx_9 =
     Css.batch
@@ -33239,7 +32094,6 @@ neg_mx_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_96 : Css.Style
 neg_mx_96 =
     Css.batch
@@ -33253,7 +32107,6 @@ neg_mx_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_mx_px : Css.Style
 neg_mx_px =
     Css.batch
@@ -33267,7 +32120,6 @@ neg_mx_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_0 : Css.Style
 neg_my_0 =
     Css.batch
@@ -33281,7 +32133,6 @@ neg_my_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_0_dot_5 : Css.Style
 neg_my_0_dot_5 =
     Css.batch
@@ -33295,7 +32146,6 @@ neg_my_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_1 : Css.Style
 neg_my_1 =
     Css.batch
@@ -33309,7 +32159,6 @@ neg_my_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_10 : Css.Style
 neg_my_10 =
     Css.batch
@@ -33323,7 +32172,6 @@ neg_my_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_11 : Css.Style
 neg_my_11 =
     Css.batch
@@ -33337,7 +32185,6 @@ neg_my_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_12 : Css.Style
 neg_my_12 =
     Css.batch
@@ -33351,7 +32198,6 @@ neg_my_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_14 : Css.Style
 neg_my_14 =
     Css.batch
@@ -33365,7 +32211,6 @@ neg_my_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_16 : Css.Style
 neg_my_16 =
     Css.batch
@@ -33379,7 +32224,6 @@ neg_my_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_1_dot_5 : Css.Style
 neg_my_1_dot_5 =
     Css.batch
@@ -33393,7 +32237,6 @@ neg_my_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_2 : Css.Style
 neg_my_2 =
     Css.batch
@@ -33407,7 +32250,6 @@ neg_my_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_20 : Css.Style
 neg_my_20 =
     Css.batch
@@ -33421,7 +32263,6 @@ neg_my_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_24 : Css.Style
 neg_my_24 =
     Css.batch
@@ -33435,7 +32276,6 @@ neg_my_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_28 : Css.Style
 neg_my_28 =
     Css.batch
@@ -33449,7 +32289,6 @@ neg_my_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_2_dot_5 : Css.Style
 neg_my_2_dot_5 =
     Css.batch
@@ -33463,7 +32302,6 @@ neg_my_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_3 : Css.Style
 neg_my_3 =
     Css.batch
@@ -33477,7 +32315,6 @@ neg_my_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_32 : Css.Style
 neg_my_32 =
     Css.batch
@@ -33491,7 +32328,6 @@ neg_my_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_36 : Css.Style
 neg_my_36 =
     Css.batch
@@ -33505,7 +32341,6 @@ neg_my_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_3_dot_5 : Css.Style
 neg_my_3_dot_5 =
     Css.batch
@@ -33519,7 +32354,6 @@ neg_my_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_4 : Css.Style
 neg_my_4 =
     Css.batch
@@ -33533,7 +32367,6 @@ neg_my_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_40 : Css.Style
 neg_my_40 =
     Css.batch
@@ -33547,7 +32380,6 @@ neg_my_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_44 : Css.Style
 neg_my_44 =
     Css.batch
@@ -33561,7 +32393,6 @@ neg_my_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_48 : Css.Style
 neg_my_48 =
     Css.batch
@@ -33575,7 +32406,6 @@ neg_my_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_5 : Css.Style
 neg_my_5 =
     Css.batch
@@ -33589,7 +32419,6 @@ neg_my_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_52 : Css.Style
 neg_my_52 =
     Css.batch
@@ -33603,7 +32432,6 @@ neg_my_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_56 : Css.Style
 neg_my_56 =
     Css.batch
@@ -33617,7 +32445,6 @@ neg_my_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_6 : Css.Style
 neg_my_6 =
     Css.batch
@@ -33631,7 +32458,6 @@ neg_my_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_60 : Css.Style
 neg_my_60 =
     Css.batch
@@ -33645,7 +32471,6 @@ neg_my_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_64 : Css.Style
 neg_my_64 =
     Css.batch
@@ -33659,7 +32484,6 @@ neg_my_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_7 : Css.Style
 neg_my_7 =
     Css.batch
@@ -33673,7 +32497,6 @@ neg_my_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_72 : Css.Style
 neg_my_72 =
     Css.batch
@@ -33687,7 +32510,6 @@ neg_my_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_8 : Css.Style
 neg_my_8 =
     Css.batch
@@ -33701,7 +32523,6 @@ neg_my_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_80 : Css.Style
 neg_my_80 =
     Css.batch
@@ -33715,7 +32536,6 @@ neg_my_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_9 : Css.Style
 neg_my_9 =
     Css.batch
@@ -33729,7 +32549,6 @@ neg_my_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_96 : Css.Style
 neg_my_96 =
     Css.batch
@@ -33743,7 +32562,6 @@ neg_my_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_my_px : Css.Style
 neg_my_px =
     Css.batch
@@ -33757,7 +32575,6 @@ neg_my_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_0 : Css.Style
 neg_right_0 =
     Css.property "right" "0px"
@@ -33768,7 +32585,6 @@ neg_right_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_0_dot_5 : Css.Style
 neg_right_0_dot_5 =
     Css.property "right" "-0.125rem"
@@ -33779,7 +32595,6 @@ neg_right_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_1 : Css.Style
 neg_right_1 =
     Css.property "right" "-0.25rem"
@@ -33790,7 +32605,6 @@ neg_right_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_10 : Css.Style
 neg_right_10 =
     Css.property "right" "-2.5rem"
@@ -33801,7 +32615,6 @@ neg_right_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_11 : Css.Style
 neg_right_11 =
     Css.property "right" "-2.75rem"
@@ -33812,7 +32625,6 @@ neg_right_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_12 : Css.Style
 neg_right_12 =
     Css.property "right" "-3rem"
@@ -33823,7 +32635,6 @@ neg_right_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_14 : Css.Style
 neg_right_14 =
     Css.property "right" "-3.5rem"
@@ -33834,7 +32645,6 @@ neg_right_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_16 : Css.Style
 neg_right_16 =
     Css.property "right" "-4rem"
@@ -33845,7 +32655,6 @@ neg_right_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_1_dot_5 : Css.Style
 neg_right_1_dot_5 =
     Css.property "right" "-0.375rem"
@@ -33856,7 +32665,6 @@ neg_right_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_1over2 : Css.Style
 neg_right_1over2 =
     Css.property "right" "-50%"
@@ -33867,7 +32675,6 @@ neg_right_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_1over3 : Css.Style
 neg_right_1over3 =
     Css.property "right" "-33.333333%"
@@ -33878,7 +32685,6 @@ neg_right_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_1over4 : Css.Style
 neg_right_1over4 =
     Css.property "right" "-25%"
@@ -33889,7 +32695,6 @@ neg_right_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_2 : Css.Style
 neg_right_2 =
     Css.property "right" "-0.5rem"
@@ -33900,7 +32705,6 @@ neg_right_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_20 : Css.Style
 neg_right_20 =
     Css.property "right" "-5rem"
@@ -33911,7 +32715,6 @@ neg_right_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_24 : Css.Style
 neg_right_24 =
     Css.property "right" "-6rem"
@@ -33922,7 +32725,6 @@ neg_right_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_28 : Css.Style
 neg_right_28 =
     Css.property "right" "-7rem"
@@ -33933,7 +32735,6 @@ neg_right_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_2_dot_5 : Css.Style
 neg_right_2_dot_5 =
     Css.property "right" "-0.625rem"
@@ -33944,7 +32745,6 @@ neg_right_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_2over3 : Css.Style
 neg_right_2over3 =
     Css.property "right" "-66.666667%"
@@ -33955,7 +32755,6 @@ neg_right_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_2over4 : Css.Style
 neg_right_2over4 =
     Css.property "right" "-50%"
@@ -33966,7 +32765,6 @@ neg_right_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_3 : Css.Style
 neg_right_3 =
     Css.property "right" "-0.75rem"
@@ -33977,7 +32775,6 @@ neg_right_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_32 : Css.Style
 neg_right_32 =
     Css.property "right" "-8rem"
@@ -33988,7 +32785,6 @@ neg_right_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_36 : Css.Style
 neg_right_36 =
     Css.property "right" "-9rem"
@@ -33999,7 +32795,6 @@ neg_right_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_3_dot_5 : Css.Style
 neg_right_3_dot_5 =
     Css.property "right" "-0.875rem"
@@ -34010,7 +32805,6 @@ neg_right_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_3over4 : Css.Style
 neg_right_3over4 =
     Css.property "right" "-75%"
@@ -34021,7 +32815,6 @@ neg_right_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_4 : Css.Style
 neg_right_4 =
     Css.property "right" "-1rem"
@@ -34032,7 +32825,6 @@ neg_right_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_40 : Css.Style
 neg_right_40 =
     Css.property "right" "-10rem"
@@ -34043,7 +32835,6 @@ neg_right_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_44 : Css.Style
 neg_right_44 =
     Css.property "right" "-11rem"
@@ -34054,7 +32845,6 @@ neg_right_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_48 : Css.Style
 neg_right_48 =
     Css.property "right" "-12rem"
@@ -34065,7 +32855,6 @@ neg_right_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_5 : Css.Style
 neg_right_5 =
     Css.property "right" "-1.25rem"
@@ -34076,7 +32865,6 @@ neg_right_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_52 : Css.Style
 neg_right_52 =
     Css.property "right" "-13rem"
@@ -34087,7 +32875,6 @@ neg_right_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_56 : Css.Style
 neg_right_56 =
     Css.property "right" "-14rem"
@@ -34098,7 +32885,6 @@ neg_right_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_6 : Css.Style
 neg_right_6 =
     Css.property "right" "-1.5rem"
@@ -34109,7 +32895,6 @@ neg_right_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_60 : Css.Style
 neg_right_60 =
     Css.property "right" "-15rem"
@@ -34120,7 +32905,6 @@ neg_right_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_64 : Css.Style
 neg_right_64 =
     Css.property "right" "-16rem"
@@ -34131,7 +32915,6 @@ neg_right_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_7 : Css.Style
 neg_right_7 =
     Css.property "right" "-1.75rem"
@@ -34142,7 +32925,6 @@ neg_right_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_72 : Css.Style
 neg_right_72 =
     Css.property "right" "-18rem"
@@ -34153,7 +32935,6 @@ neg_right_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_8 : Css.Style
 neg_right_8 =
     Css.property "right" "-2rem"
@@ -34164,7 +32945,6 @@ neg_right_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_80 : Css.Style
 neg_right_80 =
     Css.property "right" "-20rem"
@@ -34175,7 +32955,6 @@ neg_right_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_9 : Css.Style
 neg_right_9 =
     Css.property "right" "-2.25rem"
@@ -34186,7 +32965,6 @@ neg_right_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_96 : Css.Style
 neg_right_96 =
     Css.property "right" "-24rem"
@@ -34197,7 +32975,6 @@ neg_right_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_full : Css.Style
 neg_right_full =
     Css.property "right" "-100%"
@@ -34208,7 +32985,6 @@ neg_right_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_right_px : Css.Style
 neg_right_px =
     Css.property "right" "-1px"
@@ -34219,7 +32995,6 @@ neg_right_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_1 : Css.Style
 neg_rotate_1 =
     Css.property "--tw-rotate" "-1deg"
@@ -34230,7 +33005,6 @@ neg_rotate_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_12 : Css.Style
 neg_rotate_12 =
     Css.property "--tw-rotate" "-12deg"
@@ -34241,7 +33015,6 @@ neg_rotate_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_180 : Css.Style
 neg_rotate_180 =
     Css.property "--tw-rotate" "-180deg"
@@ -34252,7 +33025,6 @@ neg_rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_2 : Css.Style
 neg_rotate_2 =
     Css.property "--tw-rotate" "-2deg"
@@ -34263,7 +33035,6 @@ neg_rotate_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_3 : Css.Style
 neg_rotate_3 =
     Css.property "--tw-rotate" "-3deg"
@@ -34274,7 +33045,6 @@ neg_rotate_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_45 : Css.Style
 neg_rotate_45 =
     Css.property "--tw-rotate" "-45deg"
@@ -34285,7 +33055,6 @@ neg_rotate_45 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_6 : Css.Style
 neg_rotate_6 =
     Css.property "--tw-rotate" "-6deg"
@@ -34296,7 +33065,6 @@ neg_rotate_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_rotate_90 : Css.Style
 neg_rotate_90 =
     Css.property "--tw-rotate" "-90deg"
@@ -34307,7 +33075,6 @@ neg_rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_x_1 : Css.Style
 neg_skew_x_1 =
     Css.property "--tw-skew-x" "-1deg"
@@ -34318,7 +33085,6 @@ neg_skew_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_x_12 : Css.Style
 neg_skew_x_12 =
     Css.property "--tw-skew-x" "-12deg"
@@ -34329,7 +33095,6 @@ neg_skew_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_x_2 : Css.Style
 neg_skew_x_2 =
     Css.property "--tw-skew-x" "-2deg"
@@ -34340,7 +33105,6 @@ neg_skew_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_x_3 : Css.Style
 neg_skew_x_3 =
     Css.property "--tw-skew-x" "-3deg"
@@ -34351,7 +33115,6 @@ neg_skew_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_x_6 : Css.Style
 neg_skew_x_6 =
     Css.property "--tw-skew-x" "-6deg"
@@ -34362,7 +33125,6 @@ neg_skew_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_y_1 : Css.Style
 neg_skew_y_1 =
     Css.property "--tw-skew-y" "-1deg"
@@ -34373,7 +33135,6 @@ neg_skew_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_y_12 : Css.Style
 neg_skew_y_12 =
     Css.property "--tw-skew-y" "-12deg"
@@ -34384,7 +33145,6 @@ neg_skew_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_y_2 : Css.Style
 neg_skew_y_2 =
     Css.property "--tw-skew-y" "-2deg"
@@ -34395,7 +33155,6 @@ neg_skew_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_y_3 : Css.Style
 neg_skew_y_3 =
     Css.property "--tw-skew-y" "-3deg"
@@ -34406,7 +33165,6 @@ neg_skew_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_skew_y_6 : Css.Style
 neg_skew_y_6 =
     Css.property "--tw-skew-y" "-6deg"
@@ -34417,7 +33175,6 @@ neg_skew_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_0 : Css.Style
 neg_space_x_0 =
     Css.batch
@@ -34436,7 +33193,6 @@ neg_space_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_0_dot_5 : Css.Style
 neg_space_x_0_dot_5 =
     Css.batch
@@ -34455,7 +33211,6 @@ neg_space_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_1 : Css.Style
 neg_space_x_1 =
     Css.batch
@@ -34474,7 +33229,6 @@ neg_space_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_10 : Css.Style
 neg_space_x_10 =
     Css.batch
@@ -34493,7 +33247,6 @@ neg_space_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_11 : Css.Style
 neg_space_x_11 =
     Css.batch
@@ -34512,7 +33265,6 @@ neg_space_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_12 : Css.Style
 neg_space_x_12 =
     Css.batch
@@ -34531,7 +33283,6 @@ neg_space_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_14 : Css.Style
 neg_space_x_14 =
     Css.batch
@@ -34550,7 +33301,6 @@ neg_space_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_16 : Css.Style
 neg_space_x_16 =
     Css.batch
@@ -34569,7 +33319,6 @@ neg_space_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_1_dot_5 : Css.Style
 neg_space_x_1_dot_5 =
     Css.batch
@@ -34588,7 +33337,6 @@ neg_space_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_2 : Css.Style
 neg_space_x_2 =
     Css.batch
@@ -34607,7 +33355,6 @@ neg_space_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_20 : Css.Style
 neg_space_x_20 =
     Css.batch
@@ -34626,7 +33373,6 @@ neg_space_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_24 : Css.Style
 neg_space_x_24 =
     Css.batch
@@ -34645,7 +33391,6 @@ neg_space_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_28 : Css.Style
 neg_space_x_28 =
     Css.batch
@@ -34664,7 +33409,6 @@ neg_space_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_2_dot_5 : Css.Style
 neg_space_x_2_dot_5 =
     Css.batch
@@ -34683,7 +33427,6 @@ neg_space_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_3 : Css.Style
 neg_space_x_3 =
     Css.batch
@@ -34702,7 +33445,6 @@ neg_space_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_32 : Css.Style
 neg_space_x_32 =
     Css.batch
@@ -34721,7 +33463,6 @@ neg_space_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_36 : Css.Style
 neg_space_x_36 =
     Css.batch
@@ -34740,7 +33481,6 @@ neg_space_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_3_dot_5 : Css.Style
 neg_space_x_3_dot_5 =
     Css.batch
@@ -34759,7 +33499,6 @@ neg_space_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_4 : Css.Style
 neg_space_x_4 =
     Css.batch
@@ -34778,7 +33517,6 @@ neg_space_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_40 : Css.Style
 neg_space_x_40 =
     Css.batch
@@ -34797,7 +33535,6 @@ neg_space_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_44 : Css.Style
 neg_space_x_44 =
     Css.batch
@@ -34816,7 +33553,6 @@ neg_space_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_48 : Css.Style
 neg_space_x_48 =
     Css.batch
@@ -34835,7 +33571,6 @@ neg_space_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_5 : Css.Style
 neg_space_x_5 =
     Css.batch
@@ -34854,7 +33589,6 @@ neg_space_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_52 : Css.Style
 neg_space_x_52 =
     Css.batch
@@ -34873,7 +33607,6 @@ neg_space_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_56 : Css.Style
 neg_space_x_56 =
     Css.batch
@@ -34892,7 +33625,6 @@ neg_space_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_6 : Css.Style
 neg_space_x_6 =
     Css.batch
@@ -34911,7 +33643,6 @@ neg_space_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_60 : Css.Style
 neg_space_x_60 =
     Css.batch
@@ -34930,7 +33661,6 @@ neg_space_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_64 : Css.Style
 neg_space_x_64 =
     Css.batch
@@ -34949,7 +33679,6 @@ neg_space_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_7 : Css.Style
 neg_space_x_7 =
     Css.batch
@@ -34968,7 +33697,6 @@ neg_space_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_72 : Css.Style
 neg_space_x_72 =
     Css.batch
@@ -34987,7 +33715,6 @@ neg_space_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_8 : Css.Style
 neg_space_x_8 =
     Css.batch
@@ -35006,7 +33733,6 @@ neg_space_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_80 : Css.Style
 neg_space_x_80 =
     Css.batch
@@ -35025,7 +33751,6 @@ neg_space_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_9 : Css.Style
 neg_space_x_9 =
     Css.batch
@@ -35044,7 +33769,6 @@ neg_space_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_96 : Css.Style
 neg_space_x_96 =
     Css.batch
@@ -35063,7 +33787,6 @@ neg_space_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_x_px : Css.Style
 neg_space_x_px =
     Css.batch
@@ -35082,7 +33805,6 @@ neg_space_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_0 : Css.Style
 neg_space_y_0 =
     Css.batch
@@ -35101,7 +33823,6 @@ neg_space_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_0_dot_5 : Css.Style
 neg_space_y_0_dot_5 =
     Css.batch
@@ -35120,7 +33841,6 @@ neg_space_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_1 : Css.Style
 neg_space_y_1 =
     Css.batch
@@ -35139,7 +33859,6 @@ neg_space_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_10 : Css.Style
 neg_space_y_10 =
     Css.batch
@@ -35158,7 +33877,6 @@ neg_space_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_11 : Css.Style
 neg_space_y_11 =
     Css.batch
@@ -35177,7 +33895,6 @@ neg_space_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_12 : Css.Style
 neg_space_y_12 =
     Css.batch
@@ -35196,7 +33913,6 @@ neg_space_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_14 : Css.Style
 neg_space_y_14 =
     Css.batch
@@ -35215,7 +33931,6 @@ neg_space_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_16 : Css.Style
 neg_space_y_16 =
     Css.batch
@@ -35234,7 +33949,6 @@ neg_space_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_1_dot_5 : Css.Style
 neg_space_y_1_dot_5 =
     Css.batch
@@ -35253,7 +33967,6 @@ neg_space_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_2 : Css.Style
 neg_space_y_2 =
     Css.batch
@@ -35272,7 +33985,6 @@ neg_space_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_20 : Css.Style
 neg_space_y_20 =
     Css.batch
@@ -35291,7 +34003,6 @@ neg_space_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_24 : Css.Style
 neg_space_y_24 =
     Css.batch
@@ -35310,7 +34021,6 @@ neg_space_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_28 : Css.Style
 neg_space_y_28 =
     Css.batch
@@ -35329,7 +34039,6 @@ neg_space_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_2_dot_5 : Css.Style
 neg_space_y_2_dot_5 =
     Css.batch
@@ -35348,7 +34057,6 @@ neg_space_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_3 : Css.Style
 neg_space_y_3 =
     Css.batch
@@ -35367,7 +34075,6 @@ neg_space_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_32 : Css.Style
 neg_space_y_32 =
     Css.batch
@@ -35386,7 +34093,6 @@ neg_space_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_36 : Css.Style
 neg_space_y_36 =
     Css.batch
@@ -35405,7 +34111,6 @@ neg_space_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_3_dot_5 : Css.Style
 neg_space_y_3_dot_5 =
     Css.batch
@@ -35424,7 +34129,6 @@ neg_space_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_4 : Css.Style
 neg_space_y_4 =
     Css.batch
@@ -35443,7 +34147,6 @@ neg_space_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_40 : Css.Style
 neg_space_y_40 =
     Css.batch
@@ -35462,7 +34165,6 @@ neg_space_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_44 : Css.Style
 neg_space_y_44 =
     Css.batch
@@ -35481,7 +34183,6 @@ neg_space_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_48 : Css.Style
 neg_space_y_48 =
     Css.batch
@@ -35500,7 +34201,6 @@ neg_space_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_5 : Css.Style
 neg_space_y_5 =
     Css.batch
@@ -35519,7 +34219,6 @@ neg_space_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_52 : Css.Style
 neg_space_y_52 =
     Css.batch
@@ -35538,7 +34237,6 @@ neg_space_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_56 : Css.Style
 neg_space_y_56 =
     Css.batch
@@ -35557,7 +34255,6 @@ neg_space_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_6 : Css.Style
 neg_space_y_6 =
     Css.batch
@@ -35576,7 +34273,6 @@ neg_space_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_60 : Css.Style
 neg_space_y_60 =
     Css.batch
@@ -35595,7 +34291,6 @@ neg_space_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_64 : Css.Style
 neg_space_y_64 =
     Css.batch
@@ -35614,7 +34309,6 @@ neg_space_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_7 : Css.Style
 neg_space_y_7 =
     Css.batch
@@ -35633,7 +34327,6 @@ neg_space_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_72 : Css.Style
 neg_space_y_72 =
     Css.batch
@@ -35652,7 +34345,6 @@ neg_space_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_8 : Css.Style
 neg_space_y_8 =
     Css.batch
@@ -35671,7 +34363,6 @@ neg_space_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_80 : Css.Style
 neg_space_y_80 =
     Css.batch
@@ -35690,7 +34381,6 @@ neg_space_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_9 : Css.Style
 neg_space_y_9 =
     Css.batch
@@ -35709,7 +34399,6 @@ neg_space_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_96 : Css.Style
 neg_space_y_96 =
     Css.batch
@@ -35728,7 +34417,6 @@ neg_space_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_space_y_px : Css.Style
 neg_space_y_px =
     Css.batch
@@ -35747,7 +34435,6 @@ neg_space_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_0 : Css.Style
 neg_top_0 =
     Css.property "top" "0px"
@@ -35758,7 +34445,6 @@ neg_top_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_0_dot_5 : Css.Style
 neg_top_0_dot_5 =
     Css.property "top" "-0.125rem"
@@ -35769,7 +34455,6 @@ neg_top_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_1 : Css.Style
 neg_top_1 =
     Css.property "top" "-0.25rem"
@@ -35780,7 +34465,6 @@ neg_top_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_10 : Css.Style
 neg_top_10 =
     Css.property "top" "-2.5rem"
@@ -35791,7 +34475,6 @@ neg_top_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_11 : Css.Style
 neg_top_11 =
     Css.property "top" "-2.75rem"
@@ -35802,7 +34485,6 @@ neg_top_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_12 : Css.Style
 neg_top_12 =
     Css.property "top" "-3rem"
@@ -35813,7 +34495,6 @@ neg_top_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_14 : Css.Style
 neg_top_14 =
     Css.property "top" "-3.5rem"
@@ -35824,7 +34505,6 @@ neg_top_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_16 : Css.Style
 neg_top_16 =
     Css.property "top" "-4rem"
@@ -35835,7 +34515,6 @@ neg_top_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_1_dot_5 : Css.Style
 neg_top_1_dot_5 =
     Css.property "top" "-0.375rem"
@@ -35846,7 +34525,6 @@ neg_top_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_1over2 : Css.Style
 neg_top_1over2 =
     Css.property "top" "-50%"
@@ -35857,7 +34535,6 @@ neg_top_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_1over3 : Css.Style
 neg_top_1over3 =
     Css.property "top" "-33.333333%"
@@ -35868,7 +34545,6 @@ neg_top_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_1over4 : Css.Style
 neg_top_1over4 =
     Css.property "top" "-25%"
@@ -35879,7 +34555,6 @@ neg_top_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_2 : Css.Style
 neg_top_2 =
     Css.property "top" "-0.5rem"
@@ -35890,7 +34565,6 @@ neg_top_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_20 : Css.Style
 neg_top_20 =
     Css.property "top" "-5rem"
@@ -35901,7 +34575,6 @@ neg_top_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_24 : Css.Style
 neg_top_24 =
     Css.property "top" "-6rem"
@@ -35912,7 +34585,6 @@ neg_top_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_28 : Css.Style
 neg_top_28 =
     Css.property "top" "-7rem"
@@ -35923,7 +34595,6 @@ neg_top_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_2_dot_5 : Css.Style
 neg_top_2_dot_5 =
     Css.property "top" "-0.625rem"
@@ -35934,7 +34605,6 @@ neg_top_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_2over3 : Css.Style
 neg_top_2over3 =
     Css.property "top" "-66.666667%"
@@ -35945,7 +34615,6 @@ neg_top_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_2over4 : Css.Style
 neg_top_2over4 =
     Css.property "top" "-50%"
@@ -35956,7 +34625,6 @@ neg_top_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_3 : Css.Style
 neg_top_3 =
     Css.property "top" "-0.75rem"
@@ -35967,7 +34635,6 @@ neg_top_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_32 : Css.Style
 neg_top_32 =
     Css.property "top" "-8rem"
@@ -35978,7 +34645,6 @@ neg_top_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_36 : Css.Style
 neg_top_36 =
     Css.property "top" "-9rem"
@@ -35989,7 +34655,6 @@ neg_top_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_3_dot_5 : Css.Style
 neg_top_3_dot_5 =
     Css.property "top" "-0.875rem"
@@ -36000,7 +34665,6 @@ neg_top_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_3over4 : Css.Style
 neg_top_3over4 =
     Css.property "top" "-75%"
@@ -36011,7 +34675,6 @@ neg_top_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_4 : Css.Style
 neg_top_4 =
     Css.property "top" "-1rem"
@@ -36022,7 +34685,6 @@ neg_top_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_40 : Css.Style
 neg_top_40 =
     Css.property "top" "-10rem"
@@ -36033,7 +34695,6 @@ neg_top_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_44 : Css.Style
 neg_top_44 =
     Css.property "top" "-11rem"
@@ -36044,7 +34705,6 @@ neg_top_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_48 : Css.Style
 neg_top_48 =
     Css.property "top" "-12rem"
@@ -36055,7 +34715,6 @@ neg_top_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_5 : Css.Style
 neg_top_5 =
     Css.property "top" "-1.25rem"
@@ -36066,7 +34725,6 @@ neg_top_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_52 : Css.Style
 neg_top_52 =
     Css.property "top" "-13rem"
@@ -36077,7 +34735,6 @@ neg_top_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_56 : Css.Style
 neg_top_56 =
     Css.property "top" "-14rem"
@@ -36088,7 +34745,6 @@ neg_top_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_6 : Css.Style
 neg_top_6 =
     Css.property "top" "-1.5rem"
@@ -36099,7 +34755,6 @@ neg_top_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_60 : Css.Style
 neg_top_60 =
     Css.property "top" "-15rem"
@@ -36110,7 +34765,6 @@ neg_top_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_64 : Css.Style
 neg_top_64 =
     Css.property "top" "-16rem"
@@ -36121,7 +34775,6 @@ neg_top_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_7 : Css.Style
 neg_top_7 =
     Css.property "top" "-1.75rem"
@@ -36132,7 +34785,6 @@ neg_top_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_72 : Css.Style
 neg_top_72 =
     Css.property "top" "-18rem"
@@ -36143,7 +34795,6 @@ neg_top_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_8 : Css.Style
 neg_top_8 =
     Css.property "top" "-2rem"
@@ -36154,7 +34805,6 @@ neg_top_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_80 : Css.Style
 neg_top_80 =
     Css.property "top" "-20rem"
@@ -36165,7 +34815,6 @@ neg_top_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_9 : Css.Style
 neg_top_9 =
     Css.property "top" "-2.25rem"
@@ -36176,7 +34825,6 @@ neg_top_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_96 : Css.Style
 neg_top_96 =
     Css.property "top" "-24rem"
@@ -36187,7 +34835,6 @@ neg_top_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_full : Css.Style
 neg_top_full =
     Css.property "top" "-100%"
@@ -36198,7 +34845,6 @@ neg_top_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_top_px : Css.Style
 neg_top_px =
     Css.property "top" "-1px"
@@ -36209,7 +34855,6 @@ neg_top_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_0 : Css.Style
 neg_translate_x_0 =
     Css.property "--tw-translate-x" "0px"
@@ -36220,7 +34865,6 @@ neg_translate_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_0_dot_5 : Css.Style
 neg_translate_x_0_dot_5 =
     Css.property "--tw-translate-x" "-0.125rem"
@@ -36231,7 +34875,6 @@ neg_translate_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_1 : Css.Style
 neg_translate_x_1 =
     Css.property "--tw-translate-x" "-0.25rem"
@@ -36242,7 +34885,6 @@ neg_translate_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_10 : Css.Style
 neg_translate_x_10 =
     Css.property "--tw-translate-x" "-2.5rem"
@@ -36253,7 +34895,6 @@ neg_translate_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_11 : Css.Style
 neg_translate_x_11 =
     Css.property "--tw-translate-x" "-2.75rem"
@@ -36264,7 +34905,6 @@ neg_translate_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_12 : Css.Style
 neg_translate_x_12 =
     Css.property "--tw-translate-x" "-3rem"
@@ -36275,7 +34915,6 @@ neg_translate_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_14 : Css.Style
 neg_translate_x_14 =
     Css.property "--tw-translate-x" "-3.5rem"
@@ -36286,7 +34925,6 @@ neg_translate_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_16 : Css.Style
 neg_translate_x_16 =
     Css.property "--tw-translate-x" "-4rem"
@@ -36297,7 +34935,6 @@ neg_translate_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_1_dot_5 : Css.Style
 neg_translate_x_1_dot_5 =
     Css.property "--tw-translate-x" "-0.375rem"
@@ -36308,7 +34945,6 @@ neg_translate_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_1over2 : Css.Style
 neg_translate_x_1over2 =
     Css.property "--tw-translate-x" "-50%"
@@ -36319,7 +34955,6 @@ neg_translate_x_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_1over3 : Css.Style
 neg_translate_x_1over3 =
     Css.property "--tw-translate-x" "-33.333333%"
@@ -36330,7 +34965,6 @@ neg_translate_x_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_1over4 : Css.Style
 neg_translate_x_1over4 =
     Css.property "--tw-translate-x" "-25%"
@@ -36341,7 +34975,6 @@ neg_translate_x_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_2 : Css.Style
 neg_translate_x_2 =
     Css.property "--tw-translate-x" "-0.5rem"
@@ -36352,7 +34985,6 @@ neg_translate_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_20 : Css.Style
 neg_translate_x_20 =
     Css.property "--tw-translate-x" "-5rem"
@@ -36363,7 +34995,6 @@ neg_translate_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_24 : Css.Style
 neg_translate_x_24 =
     Css.property "--tw-translate-x" "-6rem"
@@ -36374,7 +35005,6 @@ neg_translate_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_28 : Css.Style
 neg_translate_x_28 =
     Css.property "--tw-translate-x" "-7rem"
@@ -36385,7 +35015,6 @@ neg_translate_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_2_dot_5 : Css.Style
 neg_translate_x_2_dot_5 =
     Css.property "--tw-translate-x" "-0.625rem"
@@ -36396,7 +35025,6 @@ neg_translate_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_2over3 : Css.Style
 neg_translate_x_2over3 =
     Css.property "--tw-translate-x" "-66.666667%"
@@ -36407,7 +35035,6 @@ neg_translate_x_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_2over4 : Css.Style
 neg_translate_x_2over4 =
     Css.property "--tw-translate-x" "-50%"
@@ -36418,7 +35045,6 @@ neg_translate_x_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_3 : Css.Style
 neg_translate_x_3 =
     Css.property "--tw-translate-x" "-0.75rem"
@@ -36429,7 +35055,6 @@ neg_translate_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_32 : Css.Style
 neg_translate_x_32 =
     Css.property "--tw-translate-x" "-8rem"
@@ -36440,7 +35065,6 @@ neg_translate_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_36 : Css.Style
 neg_translate_x_36 =
     Css.property "--tw-translate-x" "-9rem"
@@ -36451,7 +35075,6 @@ neg_translate_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_3_dot_5 : Css.Style
 neg_translate_x_3_dot_5 =
     Css.property "--tw-translate-x" "-0.875rem"
@@ -36462,7 +35085,6 @@ neg_translate_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_3over4 : Css.Style
 neg_translate_x_3over4 =
     Css.property "--tw-translate-x" "-75%"
@@ -36473,7 +35095,6 @@ neg_translate_x_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_4 : Css.Style
 neg_translate_x_4 =
     Css.property "--tw-translate-x" "-1rem"
@@ -36484,7 +35105,6 @@ neg_translate_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_40 : Css.Style
 neg_translate_x_40 =
     Css.property "--tw-translate-x" "-10rem"
@@ -36495,7 +35115,6 @@ neg_translate_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_44 : Css.Style
 neg_translate_x_44 =
     Css.property "--tw-translate-x" "-11rem"
@@ -36506,7 +35125,6 @@ neg_translate_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_48 : Css.Style
 neg_translate_x_48 =
     Css.property "--tw-translate-x" "-12rem"
@@ -36517,7 +35135,6 @@ neg_translate_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_5 : Css.Style
 neg_translate_x_5 =
     Css.property "--tw-translate-x" "-1.25rem"
@@ -36528,7 +35145,6 @@ neg_translate_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_52 : Css.Style
 neg_translate_x_52 =
     Css.property "--tw-translate-x" "-13rem"
@@ -36539,7 +35155,6 @@ neg_translate_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_56 : Css.Style
 neg_translate_x_56 =
     Css.property "--tw-translate-x" "-14rem"
@@ -36550,7 +35165,6 @@ neg_translate_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_6 : Css.Style
 neg_translate_x_6 =
     Css.property "--tw-translate-x" "-1.5rem"
@@ -36561,7 +35175,6 @@ neg_translate_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_60 : Css.Style
 neg_translate_x_60 =
     Css.property "--tw-translate-x" "-15rem"
@@ -36572,7 +35185,6 @@ neg_translate_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_64 : Css.Style
 neg_translate_x_64 =
     Css.property "--tw-translate-x" "-16rem"
@@ -36583,7 +35195,6 @@ neg_translate_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_7 : Css.Style
 neg_translate_x_7 =
     Css.property "--tw-translate-x" "-1.75rem"
@@ -36594,7 +35205,6 @@ neg_translate_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_72 : Css.Style
 neg_translate_x_72 =
     Css.property "--tw-translate-x" "-18rem"
@@ -36605,7 +35215,6 @@ neg_translate_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_8 : Css.Style
 neg_translate_x_8 =
     Css.property "--tw-translate-x" "-2rem"
@@ -36616,7 +35225,6 @@ neg_translate_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_80 : Css.Style
 neg_translate_x_80 =
     Css.property "--tw-translate-x" "-20rem"
@@ -36627,7 +35235,6 @@ neg_translate_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_9 : Css.Style
 neg_translate_x_9 =
     Css.property "--tw-translate-x" "-2.25rem"
@@ -36638,7 +35245,6 @@ neg_translate_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_96 : Css.Style
 neg_translate_x_96 =
     Css.property "--tw-translate-x" "-24rem"
@@ -36649,7 +35255,6 @@ neg_translate_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_full : Css.Style
 neg_translate_x_full =
     Css.property "--tw-translate-x" "-100%"
@@ -36660,7 +35265,6 @@ neg_translate_x_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_x_px : Css.Style
 neg_translate_x_px =
     Css.property "--tw-translate-x" "-1px"
@@ -36671,7 +35275,6 @@ neg_translate_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_0 : Css.Style
 neg_translate_y_0 =
     Css.property "--tw-translate-y" "0px"
@@ -36682,7 +35285,6 @@ neg_translate_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_0_dot_5 : Css.Style
 neg_translate_y_0_dot_5 =
     Css.property "--tw-translate-y" "-0.125rem"
@@ -36693,7 +35295,6 @@ neg_translate_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_1 : Css.Style
 neg_translate_y_1 =
     Css.property "--tw-translate-y" "-0.25rem"
@@ -36704,7 +35305,6 @@ neg_translate_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_10 : Css.Style
 neg_translate_y_10 =
     Css.property "--tw-translate-y" "-2.5rem"
@@ -36715,7 +35315,6 @@ neg_translate_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_11 : Css.Style
 neg_translate_y_11 =
     Css.property "--tw-translate-y" "-2.75rem"
@@ -36726,7 +35325,6 @@ neg_translate_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_12 : Css.Style
 neg_translate_y_12 =
     Css.property "--tw-translate-y" "-3rem"
@@ -36737,7 +35335,6 @@ neg_translate_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_14 : Css.Style
 neg_translate_y_14 =
     Css.property "--tw-translate-y" "-3.5rem"
@@ -36748,7 +35345,6 @@ neg_translate_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_16 : Css.Style
 neg_translate_y_16 =
     Css.property "--tw-translate-y" "-4rem"
@@ -36759,7 +35355,6 @@ neg_translate_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_1_dot_5 : Css.Style
 neg_translate_y_1_dot_5 =
     Css.property "--tw-translate-y" "-0.375rem"
@@ -36770,7 +35365,6 @@ neg_translate_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_1over2 : Css.Style
 neg_translate_y_1over2 =
     Css.property "--tw-translate-y" "-50%"
@@ -36781,7 +35375,6 @@ neg_translate_y_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_1over3 : Css.Style
 neg_translate_y_1over3 =
     Css.property "--tw-translate-y" "-33.333333%"
@@ -36792,7 +35385,6 @@ neg_translate_y_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_1over4 : Css.Style
 neg_translate_y_1over4 =
     Css.property "--tw-translate-y" "-25%"
@@ -36803,7 +35395,6 @@ neg_translate_y_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_2 : Css.Style
 neg_translate_y_2 =
     Css.property "--tw-translate-y" "-0.5rem"
@@ -36814,7 +35405,6 @@ neg_translate_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_20 : Css.Style
 neg_translate_y_20 =
     Css.property "--tw-translate-y" "-5rem"
@@ -36825,7 +35415,6 @@ neg_translate_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_24 : Css.Style
 neg_translate_y_24 =
     Css.property "--tw-translate-y" "-6rem"
@@ -36836,7 +35425,6 @@ neg_translate_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_28 : Css.Style
 neg_translate_y_28 =
     Css.property "--tw-translate-y" "-7rem"
@@ -36847,7 +35435,6 @@ neg_translate_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_2_dot_5 : Css.Style
 neg_translate_y_2_dot_5 =
     Css.property "--tw-translate-y" "-0.625rem"
@@ -36858,7 +35445,6 @@ neg_translate_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_2over3 : Css.Style
 neg_translate_y_2over3 =
     Css.property "--tw-translate-y" "-66.666667%"
@@ -36869,7 +35455,6 @@ neg_translate_y_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_2over4 : Css.Style
 neg_translate_y_2over4 =
     Css.property "--tw-translate-y" "-50%"
@@ -36880,7 +35465,6 @@ neg_translate_y_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_3 : Css.Style
 neg_translate_y_3 =
     Css.property "--tw-translate-y" "-0.75rem"
@@ -36891,7 +35475,6 @@ neg_translate_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_32 : Css.Style
 neg_translate_y_32 =
     Css.property "--tw-translate-y" "-8rem"
@@ -36902,7 +35485,6 @@ neg_translate_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_36 : Css.Style
 neg_translate_y_36 =
     Css.property "--tw-translate-y" "-9rem"
@@ -36913,7 +35495,6 @@ neg_translate_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_3_dot_5 : Css.Style
 neg_translate_y_3_dot_5 =
     Css.property "--tw-translate-y" "-0.875rem"
@@ -36924,7 +35505,6 @@ neg_translate_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_3over4 : Css.Style
 neg_translate_y_3over4 =
     Css.property "--tw-translate-y" "-75%"
@@ -36935,7 +35515,6 @@ neg_translate_y_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_4 : Css.Style
 neg_translate_y_4 =
     Css.property "--tw-translate-y" "-1rem"
@@ -36946,7 +35525,6 @@ neg_translate_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_40 : Css.Style
 neg_translate_y_40 =
     Css.property "--tw-translate-y" "-10rem"
@@ -36957,7 +35535,6 @@ neg_translate_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_44 : Css.Style
 neg_translate_y_44 =
     Css.property "--tw-translate-y" "-11rem"
@@ -36968,7 +35545,6 @@ neg_translate_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_48 : Css.Style
 neg_translate_y_48 =
     Css.property "--tw-translate-y" "-12rem"
@@ -36979,7 +35555,6 @@ neg_translate_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_5 : Css.Style
 neg_translate_y_5 =
     Css.property "--tw-translate-y" "-1.25rem"
@@ -36990,7 +35565,6 @@ neg_translate_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_52 : Css.Style
 neg_translate_y_52 =
     Css.property "--tw-translate-y" "-13rem"
@@ -37001,7 +35575,6 @@ neg_translate_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_56 : Css.Style
 neg_translate_y_56 =
     Css.property "--tw-translate-y" "-14rem"
@@ -37012,7 +35585,6 @@ neg_translate_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_6 : Css.Style
 neg_translate_y_6 =
     Css.property "--tw-translate-y" "-1.5rem"
@@ -37023,7 +35595,6 @@ neg_translate_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_60 : Css.Style
 neg_translate_y_60 =
     Css.property "--tw-translate-y" "-15rem"
@@ -37034,7 +35605,6 @@ neg_translate_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_64 : Css.Style
 neg_translate_y_64 =
     Css.property "--tw-translate-y" "-16rem"
@@ -37045,7 +35615,6 @@ neg_translate_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_7 : Css.Style
 neg_translate_y_7 =
     Css.property "--tw-translate-y" "-1.75rem"
@@ -37056,7 +35625,6 @@ neg_translate_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_72 : Css.Style
 neg_translate_y_72 =
     Css.property "--tw-translate-y" "-18rem"
@@ -37067,7 +35635,6 @@ neg_translate_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_8 : Css.Style
 neg_translate_y_8 =
     Css.property "--tw-translate-y" "-2rem"
@@ -37078,7 +35645,6 @@ neg_translate_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_80 : Css.Style
 neg_translate_y_80 =
     Css.property "--tw-translate-y" "-20rem"
@@ -37089,7 +35655,6 @@ neg_translate_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_9 : Css.Style
 neg_translate_y_9 =
     Css.property "--tw-translate-y" "-2.25rem"
@@ -37100,7 +35665,6 @@ neg_translate_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_96 : Css.Style
 neg_translate_y_96 =
     Css.property "--tw-translate-y" "-24rem"
@@ -37111,7 +35675,6 @@ neg_translate_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_full : Css.Style
 neg_translate_y_full =
     Css.property "--tw-translate-y" "-100%"
@@ -37122,7 +35685,6 @@ neg_translate_y_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 neg_translate_y_px : Css.Style
 neg_translate_y_px =
     Css.property "--tw-translate-y" "-1px"
@@ -37133,7 +35695,6 @@ neg_translate_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 no_underline : Css.Style
 no_underline =
     Css.property "text-decoration" "none"
@@ -37144,7 +35705,6 @@ no_underline =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 normal_case : Css.Style
 normal_case =
     Css.property "text-transform" "none"
@@ -37155,7 +35715,6 @@ normal_case =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 normal_nums : Css.Style
 normal_nums =
     Css.property "font-variant-numeric" "normal"
@@ -37166,7 +35725,6 @@ normal_nums =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 not_italic : Css.Style
 not_italic =
     Css.property "font-style" "normal"
@@ -37177,7 +35735,6 @@ not_italic =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 not_sr_only : Css.Style
 not_sr_only =
     Css.batch
@@ -37197,7 +35754,6 @@ not_sr_only =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_bottom : Css.Style
 object_bottom =
     Css.batch
@@ -37211,7 +35767,6 @@ object_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_center : Css.Style
 object_center =
     Css.batch
@@ -37225,7 +35780,6 @@ object_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_contain : Css.Style
 object_contain =
     Css.batch
@@ -37239,7 +35793,6 @@ object_contain =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_cover : Css.Style
 object_cover =
     Css.batch
@@ -37253,7 +35806,6 @@ object_cover =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_fill : Css.Style
 object_fill =
     Css.batch
@@ -37267,7 +35819,6 @@ object_fill =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_left : Css.Style
 object_left =
     Css.batch
@@ -37281,7 +35832,6 @@ object_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_left_bottom : Css.Style
 object_left_bottom =
     Css.batch
@@ -37295,7 +35845,6 @@ object_left_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_left_top : Css.Style
 object_left_top =
     Css.batch
@@ -37309,7 +35858,6 @@ object_left_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_none : Css.Style
 object_none =
     Css.batch
@@ -37323,7 +35871,6 @@ object_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_right : Css.Style
 object_right =
     Css.batch
@@ -37337,7 +35884,6 @@ object_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_right_bottom : Css.Style
 object_right_bottom =
     Css.batch
@@ -37351,7 +35897,6 @@ object_right_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_right_top : Css.Style
 object_right_top =
     Css.batch
@@ -37365,7 +35910,6 @@ object_right_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_scale_down : Css.Style
 object_scale_down =
     Css.batch
@@ -37379,7 +35923,6 @@ object_scale_down =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 object_top : Css.Style
 object_top =
     Css.batch
@@ -37393,7 +35936,6 @@ object_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 oldstyle_nums : Css.Style
 oldstyle_nums =
     Css.batch
@@ -37412,7 +35954,6 @@ oldstyle_nums =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_0 : Css.Style
 opacity_0 =
     Css.property "opacity" "0"
@@ -37423,7 +35964,6 @@ opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_10 : Css.Style
 opacity_10 =
     Css.property "opacity" "0.1"
@@ -37434,7 +35974,6 @@ opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_100 : Css.Style
 opacity_100 =
     Css.property "opacity" "1"
@@ -37445,7 +35984,6 @@ opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_20 : Css.Style
 opacity_20 =
     Css.property "opacity" "0.2"
@@ -37456,7 +35994,6 @@ opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_25 : Css.Style
 opacity_25 =
     Css.property "opacity" "0.25"
@@ -37467,7 +36004,6 @@ opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_30 : Css.Style
 opacity_30 =
     Css.property "opacity" "0.3"
@@ -37478,7 +36014,6 @@ opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_40 : Css.Style
 opacity_40 =
     Css.property "opacity" "0.4"
@@ -37489,7 +36024,6 @@ opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_5 : Css.Style
 opacity_5 =
     Css.property "opacity" "0.05"
@@ -37500,7 +36034,6 @@ opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_50 : Css.Style
 opacity_50 =
     Css.property "opacity" "0.5"
@@ -37511,7 +36044,6 @@ opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_60 : Css.Style
 opacity_60 =
     Css.property "opacity" "0.6"
@@ -37522,7 +36054,6 @@ opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_70 : Css.Style
 opacity_70 =
     Css.property "opacity" "0.7"
@@ -37533,7 +36064,6 @@ opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_75 : Css.Style
 opacity_75 =
     Css.property "opacity" "0.75"
@@ -37544,7 +36074,6 @@ opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_80 : Css.Style
 opacity_80 =
     Css.property "opacity" "0.8"
@@ -37555,7 +36084,6 @@ opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_90 : Css.Style
 opacity_90 =
     Css.property "opacity" "0.9"
@@ -37566,7 +36094,6 @@ opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 opacity_95 : Css.Style
 opacity_95 =
     Css.property "opacity" "0.95"
@@ -37577,7 +36104,6 @@ opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_1 : Css.Style
 order_1 =
     Css.property "order" "1"
@@ -37588,7 +36114,6 @@ order_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_10 : Css.Style
 order_10 =
     Css.property "order" "10"
@@ -37599,7 +36124,6 @@ order_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_11 : Css.Style
 order_11 =
     Css.property "order" "11"
@@ -37610,7 +36134,6 @@ order_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_12 : Css.Style
 order_12 =
     Css.property "order" "12"
@@ -37621,7 +36144,6 @@ order_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_2 : Css.Style
 order_2 =
     Css.property "order" "2"
@@ -37632,7 +36154,6 @@ order_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_3 : Css.Style
 order_3 =
     Css.property "order" "3"
@@ -37643,7 +36164,6 @@ order_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_4 : Css.Style
 order_4 =
     Css.property "order" "4"
@@ -37654,7 +36174,6 @@ order_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_5 : Css.Style
 order_5 =
     Css.property "order" "5"
@@ -37665,7 +36184,6 @@ order_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_6 : Css.Style
 order_6 =
     Css.property "order" "6"
@@ -37676,7 +36194,6 @@ order_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_7 : Css.Style
 order_7 =
     Css.property "order" "7"
@@ -37687,7 +36204,6 @@ order_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_8 : Css.Style
 order_8 =
     Css.property "order" "8"
@@ -37698,7 +36214,6 @@ order_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_9 : Css.Style
 order_9 =
     Css.property "order" "9"
@@ -37709,7 +36224,6 @@ order_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_first : Css.Style
 order_first =
     Css.property "order" "-9999"
@@ -37720,7 +36234,6 @@ order_first =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_last : Css.Style
 order_last =
     Css.property "order" "9999"
@@ -37731,7 +36244,6 @@ order_last =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 order_none : Css.Style
 order_none =
     Css.property "order" "0"
@@ -37742,7 +36254,6 @@ order_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ordinal : Css.Style
 ordinal =
     Css.batch
@@ -37761,7 +36272,6 @@ ordinal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_bottom : Css.Style
 origin_bottom =
     Css.property "transform-origin" "bottom"
@@ -37772,7 +36282,6 @@ origin_bottom =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_bottom_left : Css.Style
 origin_bottom_left =
     Css.property "transform-origin" "bottom left"
@@ -37783,7 +36292,6 @@ origin_bottom_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_bottom_right : Css.Style
 origin_bottom_right =
     Css.property "transform-origin" "bottom right"
@@ -37794,7 +36302,6 @@ origin_bottom_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_center : Css.Style
 origin_center =
     Css.property "transform-origin" "center"
@@ -37805,7 +36312,6 @@ origin_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_left : Css.Style
 origin_left =
     Css.property "transform-origin" "left"
@@ -37816,7 +36322,6 @@ origin_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_right : Css.Style
 origin_right =
     Css.property "transform-origin" "right"
@@ -37827,7 +36332,6 @@ origin_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_top : Css.Style
 origin_top =
     Css.property "transform-origin" "top"
@@ -37838,7 +36342,6 @@ origin_top =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_top_left : Css.Style
 origin_top_left =
     Css.property "transform-origin" "top left"
@@ -37849,7 +36352,6 @@ origin_top_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 origin_top_right : Css.Style
 origin_top_right =
     Css.property "transform-origin" "top right"
@@ -37860,7 +36362,6 @@ origin_top_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 outline_black : Css.Style
 outline_black =
     Css.batch
@@ -37874,7 +36375,6 @@ outline_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 outline_none : Css.Style
 outline_none =
     Css.batch
@@ -37888,7 +36388,6 @@ outline_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 outline_white : Css.Style
 outline_white =
     Css.batch
@@ -37902,7 +36401,6 @@ outline_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_auto : Css.Style
 overflow_auto =
     Css.property "overflow" "auto"
@@ -37913,7 +36411,6 @@ overflow_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_clip : Css.Style
 overflow_clip =
     Css.property "text-overflow" "clip"
@@ -37924,7 +36421,6 @@ overflow_clip =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_ellipsis : Css.Style
 overflow_ellipsis =
     Css.property "text-overflow" "ellipsis"
@@ -37935,7 +36431,6 @@ overflow_ellipsis =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_hidden : Css.Style
 overflow_hidden =
     Css.property "overflow" "hidden"
@@ -37946,7 +36441,6 @@ overflow_hidden =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_scroll : Css.Style
 overflow_scroll =
     Css.property "overflow" "scroll"
@@ -37957,7 +36451,6 @@ overflow_scroll =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_visible : Css.Style
 overflow_visible =
     Css.property "overflow" "visible"
@@ -37968,7 +36461,6 @@ overflow_visible =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_x_auto : Css.Style
 overflow_x_auto =
     Css.property "overflow-x" "auto"
@@ -37979,7 +36471,6 @@ overflow_x_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_x_hidden : Css.Style
 overflow_x_hidden =
     Css.property "overflow-x" "hidden"
@@ -37990,7 +36481,6 @@ overflow_x_hidden =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_x_scroll : Css.Style
 overflow_x_scroll =
     Css.property "overflow-x" "scroll"
@@ -38001,7 +36491,6 @@ overflow_x_scroll =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_x_visible : Css.Style
 overflow_x_visible =
     Css.property "overflow-x" "visible"
@@ -38012,7 +36501,6 @@ overflow_x_visible =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_y_auto : Css.Style
 overflow_y_auto =
     Css.property "overflow-y" "auto"
@@ -38023,7 +36511,6 @@ overflow_y_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_y_hidden : Css.Style
 overflow_y_hidden =
     Css.property "overflow-y" "hidden"
@@ -38034,7 +36521,6 @@ overflow_y_hidden =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_y_scroll : Css.Style
 overflow_y_scroll =
     Css.property "overflow-y" "scroll"
@@ -38045,7 +36531,6 @@ overflow_y_scroll =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overflow_y_visible : Css.Style
 overflow_y_visible =
     Css.property "overflow-y" "visible"
@@ -38056,7 +36541,6 @@ overflow_y_visible =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_auto : Css.Style
 overscroll_auto =
     Css.batch
@@ -38070,7 +36554,6 @@ overscroll_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_contain : Css.Style
 overscroll_contain =
     Css.batch
@@ -38084,7 +36567,6 @@ overscroll_contain =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_none : Css.Style
 overscroll_none =
     Css.batch
@@ -38098,7 +36580,6 @@ overscroll_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_x_auto : Css.Style
 overscroll_x_auto =
     Css.property "overscroll-behavior-x" "auto"
@@ -38109,7 +36590,6 @@ overscroll_x_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_x_contain : Css.Style
 overscroll_x_contain =
     Css.property "overscroll-behavior-x" "contain"
@@ -38120,7 +36600,6 @@ overscroll_x_contain =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_x_none : Css.Style
 overscroll_x_none =
     Css.property "overscroll-behavior-x" "none"
@@ -38131,7 +36610,6 @@ overscroll_x_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_y_auto : Css.Style
 overscroll_y_auto =
     Css.property "overscroll-behavior-y" "auto"
@@ -38142,7 +36620,6 @@ overscroll_y_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_y_contain : Css.Style
 overscroll_y_contain =
     Css.property "overscroll-behavior-y" "contain"
@@ -38153,7 +36630,6 @@ overscroll_y_contain =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 overscroll_y_none : Css.Style
 overscroll_y_none =
     Css.property "overscroll-behavior-y" "none"
@@ -38164,7 +36640,6 @@ overscroll_y_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_0 : Css.Style
 p_0 =
     Css.property "padding" "0px"
@@ -38175,7 +36650,6 @@ p_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_0_dot_5 : Css.Style
 p_0_dot_5 =
     Css.property "padding" "0.125rem"
@@ -38186,7 +36660,6 @@ p_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_1 : Css.Style
 p_1 =
     Css.property "padding" "0.25rem"
@@ -38197,7 +36670,6 @@ p_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_10 : Css.Style
 p_10 =
     Css.property "padding" "2.5rem"
@@ -38208,7 +36680,6 @@ p_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_11 : Css.Style
 p_11 =
     Css.property "padding" "2.75rem"
@@ -38219,7 +36690,6 @@ p_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_12 : Css.Style
 p_12 =
     Css.property "padding" "3rem"
@@ -38230,7 +36700,6 @@ p_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_14 : Css.Style
 p_14 =
     Css.property "padding" "3.5rem"
@@ -38241,7 +36710,6 @@ p_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_16 : Css.Style
 p_16 =
     Css.property "padding" "4rem"
@@ -38252,7 +36720,6 @@ p_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_1_dot_5 : Css.Style
 p_1_dot_5 =
     Css.property "padding" "0.375rem"
@@ -38263,7 +36730,6 @@ p_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_2 : Css.Style
 p_2 =
     Css.property "padding" "0.5rem"
@@ -38274,7 +36740,6 @@ p_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_20 : Css.Style
 p_20 =
     Css.property "padding" "5rem"
@@ -38285,7 +36750,6 @@ p_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_24 : Css.Style
 p_24 =
     Css.property "padding" "6rem"
@@ -38296,7 +36760,6 @@ p_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_28 : Css.Style
 p_28 =
     Css.property "padding" "7rem"
@@ -38307,7 +36770,6 @@ p_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_2_dot_5 : Css.Style
 p_2_dot_5 =
     Css.property "padding" "0.625rem"
@@ -38318,7 +36780,6 @@ p_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_3 : Css.Style
 p_3 =
     Css.property "padding" "0.75rem"
@@ -38329,7 +36790,6 @@ p_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_32 : Css.Style
 p_32 =
     Css.property "padding" "8rem"
@@ -38340,7 +36800,6 @@ p_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_36 : Css.Style
 p_36 =
     Css.property "padding" "9rem"
@@ -38351,7 +36810,6 @@ p_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_3_dot_5 : Css.Style
 p_3_dot_5 =
     Css.property "padding" "0.875rem"
@@ -38362,7 +36820,6 @@ p_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_4 : Css.Style
 p_4 =
     Css.property "padding" "1rem"
@@ -38373,7 +36830,6 @@ p_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_40 : Css.Style
 p_40 =
     Css.property "padding" "10rem"
@@ -38384,7 +36840,6 @@ p_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_44 : Css.Style
 p_44 =
     Css.property "padding" "11rem"
@@ -38395,7 +36850,6 @@ p_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_48 : Css.Style
 p_48 =
     Css.property "padding" "12rem"
@@ -38406,7 +36860,6 @@ p_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_5 : Css.Style
 p_5 =
     Css.property "padding" "1.25rem"
@@ -38417,7 +36870,6 @@ p_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_52 : Css.Style
 p_52 =
     Css.property "padding" "13rem"
@@ -38428,7 +36880,6 @@ p_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_56 : Css.Style
 p_56 =
     Css.property "padding" "14rem"
@@ -38439,7 +36890,6 @@ p_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_6 : Css.Style
 p_6 =
     Css.property "padding" "1.5rem"
@@ -38450,7 +36900,6 @@ p_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_60 : Css.Style
 p_60 =
     Css.property "padding" "15rem"
@@ -38461,7 +36910,6 @@ p_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_64 : Css.Style
 p_64 =
     Css.property "padding" "16rem"
@@ -38472,7 +36920,6 @@ p_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_7 : Css.Style
 p_7 =
     Css.property "padding" "1.75rem"
@@ -38483,7 +36930,6 @@ p_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_72 : Css.Style
 p_72 =
     Css.property "padding" "18rem"
@@ -38494,7 +36940,6 @@ p_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_8 : Css.Style
 p_8 =
     Css.property "padding" "2rem"
@@ -38505,7 +36950,6 @@ p_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_80 : Css.Style
 p_80 =
     Css.property "padding" "20rem"
@@ -38516,7 +36960,6 @@ p_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_9 : Css.Style
 p_9 =
     Css.property "padding" "2.25rem"
@@ -38527,7 +36970,6 @@ p_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_96 : Css.Style
 p_96 =
     Css.property "padding" "24rem"
@@ -38538,7 +36980,6 @@ p_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 p_px : Css.Style
 p_px =
     Css.property "padding" "1px"
@@ -38549,7 +36990,6 @@ p_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_0 : Css.Style
 pb_0 =
     Css.property "padding-bottom" "0px"
@@ -38560,7 +37000,6 @@ pb_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_0_dot_5 : Css.Style
 pb_0_dot_5 =
     Css.property "padding-bottom" "0.125rem"
@@ -38571,7 +37010,6 @@ pb_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_1 : Css.Style
 pb_1 =
     Css.property "padding-bottom" "0.25rem"
@@ -38582,7 +37020,6 @@ pb_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_10 : Css.Style
 pb_10 =
     Css.property "padding-bottom" "2.5rem"
@@ -38593,7 +37030,6 @@ pb_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_11 : Css.Style
 pb_11 =
     Css.property "padding-bottom" "2.75rem"
@@ -38604,7 +37040,6 @@ pb_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_12 : Css.Style
 pb_12 =
     Css.property "padding-bottom" "3rem"
@@ -38615,7 +37050,6 @@ pb_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_14 : Css.Style
 pb_14 =
     Css.property "padding-bottom" "3.5rem"
@@ -38626,7 +37060,6 @@ pb_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_16 : Css.Style
 pb_16 =
     Css.property "padding-bottom" "4rem"
@@ -38637,7 +37070,6 @@ pb_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_1_dot_5 : Css.Style
 pb_1_dot_5 =
     Css.property "padding-bottom" "0.375rem"
@@ -38648,7 +37080,6 @@ pb_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_2 : Css.Style
 pb_2 =
     Css.property "padding-bottom" "0.5rem"
@@ -38659,7 +37090,6 @@ pb_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_20 : Css.Style
 pb_20 =
     Css.property "padding-bottom" "5rem"
@@ -38670,7 +37100,6 @@ pb_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_24 : Css.Style
 pb_24 =
     Css.property "padding-bottom" "6rem"
@@ -38681,7 +37110,6 @@ pb_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_28 : Css.Style
 pb_28 =
     Css.property "padding-bottom" "7rem"
@@ -38692,7 +37120,6 @@ pb_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_2_dot_5 : Css.Style
 pb_2_dot_5 =
     Css.property "padding-bottom" "0.625rem"
@@ -38703,7 +37130,6 @@ pb_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_3 : Css.Style
 pb_3 =
     Css.property "padding-bottom" "0.75rem"
@@ -38714,7 +37140,6 @@ pb_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_32 : Css.Style
 pb_32 =
     Css.property "padding-bottom" "8rem"
@@ -38725,7 +37150,6 @@ pb_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_36 : Css.Style
 pb_36 =
     Css.property "padding-bottom" "9rem"
@@ -38736,7 +37160,6 @@ pb_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_3_dot_5 : Css.Style
 pb_3_dot_5 =
     Css.property "padding-bottom" "0.875rem"
@@ -38747,7 +37170,6 @@ pb_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_4 : Css.Style
 pb_4 =
     Css.property "padding-bottom" "1rem"
@@ -38758,7 +37180,6 @@ pb_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_40 : Css.Style
 pb_40 =
     Css.property "padding-bottom" "10rem"
@@ -38769,7 +37190,6 @@ pb_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_44 : Css.Style
 pb_44 =
     Css.property "padding-bottom" "11rem"
@@ -38780,7 +37200,6 @@ pb_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_48 : Css.Style
 pb_48 =
     Css.property "padding-bottom" "12rem"
@@ -38791,7 +37210,6 @@ pb_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_5 : Css.Style
 pb_5 =
     Css.property "padding-bottom" "1.25rem"
@@ -38802,7 +37220,6 @@ pb_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_52 : Css.Style
 pb_52 =
     Css.property "padding-bottom" "13rem"
@@ -38813,7 +37230,6 @@ pb_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_56 : Css.Style
 pb_56 =
     Css.property "padding-bottom" "14rem"
@@ -38824,7 +37240,6 @@ pb_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_6 : Css.Style
 pb_6 =
     Css.property "padding-bottom" "1.5rem"
@@ -38835,7 +37250,6 @@ pb_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_60 : Css.Style
 pb_60 =
     Css.property "padding-bottom" "15rem"
@@ -38846,7 +37260,6 @@ pb_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_64 : Css.Style
 pb_64 =
     Css.property "padding-bottom" "16rem"
@@ -38857,7 +37270,6 @@ pb_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_7 : Css.Style
 pb_7 =
     Css.property "padding-bottom" "1.75rem"
@@ -38868,7 +37280,6 @@ pb_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_72 : Css.Style
 pb_72 =
     Css.property "padding-bottom" "18rem"
@@ -38879,7 +37290,6 @@ pb_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_8 : Css.Style
 pb_8 =
     Css.property "padding-bottom" "2rem"
@@ -38890,7 +37300,6 @@ pb_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_80 : Css.Style
 pb_80 =
     Css.property "padding-bottom" "20rem"
@@ -38901,7 +37310,6 @@ pb_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_9 : Css.Style
 pb_9 =
     Css.property "padding-bottom" "2.25rem"
@@ -38912,7 +37320,6 @@ pb_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_96 : Css.Style
 pb_96 =
     Css.property "padding-bottom" "24rem"
@@ -38923,7 +37330,6 @@ pb_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pb_px : Css.Style
 pb_px =
     Css.property "padding-bottom" "1px"
@@ -38934,7 +37340,6 @@ pb_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_0 : Css.Style
 pl_0 =
     Css.property "padding-left" "0px"
@@ -38945,7 +37350,6 @@ pl_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_0_dot_5 : Css.Style
 pl_0_dot_5 =
     Css.property "padding-left" "0.125rem"
@@ -38956,7 +37360,6 @@ pl_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_1 : Css.Style
 pl_1 =
     Css.property "padding-left" "0.25rem"
@@ -38967,7 +37370,6 @@ pl_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_10 : Css.Style
 pl_10 =
     Css.property "padding-left" "2.5rem"
@@ -38978,7 +37380,6 @@ pl_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_11 : Css.Style
 pl_11 =
     Css.property "padding-left" "2.75rem"
@@ -38989,7 +37390,6 @@ pl_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_12 : Css.Style
 pl_12 =
     Css.property "padding-left" "3rem"
@@ -39000,7 +37400,6 @@ pl_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_14 : Css.Style
 pl_14 =
     Css.property "padding-left" "3.5rem"
@@ -39011,7 +37410,6 @@ pl_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_16 : Css.Style
 pl_16 =
     Css.property "padding-left" "4rem"
@@ -39022,7 +37420,6 @@ pl_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_1_dot_5 : Css.Style
 pl_1_dot_5 =
     Css.property "padding-left" "0.375rem"
@@ -39033,7 +37430,6 @@ pl_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_2 : Css.Style
 pl_2 =
     Css.property "padding-left" "0.5rem"
@@ -39044,7 +37440,6 @@ pl_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_20 : Css.Style
 pl_20 =
     Css.property "padding-left" "5rem"
@@ -39055,7 +37450,6 @@ pl_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_24 : Css.Style
 pl_24 =
     Css.property "padding-left" "6rem"
@@ -39066,7 +37460,6 @@ pl_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_28 : Css.Style
 pl_28 =
     Css.property "padding-left" "7rem"
@@ -39077,7 +37470,6 @@ pl_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_2_dot_5 : Css.Style
 pl_2_dot_5 =
     Css.property "padding-left" "0.625rem"
@@ -39088,7 +37480,6 @@ pl_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_3 : Css.Style
 pl_3 =
     Css.property "padding-left" "0.75rem"
@@ -39099,7 +37490,6 @@ pl_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_32 : Css.Style
 pl_32 =
     Css.property "padding-left" "8rem"
@@ -39110,7 +37500,6 @@ pl_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_36 : Css.Style
 pl_36 =
     Css.property "padding-left" "9rem"
@@ -39121,7 +37510,6 @@ pl_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_3_dot_5 : Css.Style
 pl_3_dot_5 =
     Css.property "padding-left" "0.875rem"
@@ -39132,7 +37520,6 @@ pl_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_4 : Css.Style
 pl_4 =
     Css.property "padding-left" "1rem"
@@ -39143,7 +37530,6 @@ pl_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_40 : Css.Style
 pl_40 =
     Css.property "padding-left" "10rem"
@@ -39154,7 +37540,6 @@ pl_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_44 : Css.Style
 pl_44 =
     Css.property "padding-left" "11rem"
@@ -39165,7 +37550,6 @@ pl_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_48 : Css.Style
 pl_48 =
     Css.property "padding-left" "12rem"
@@ -39176,7 +37560,6 @@ pl_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_5 : Css.Style
 pl_5 =
     Css.property "padding-left" "1.25rem"
@@ -39187,7 +37570,6 @@ pl_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_52 : Css.Style
 pl_52 =
     Css.property "padding-left" "13rem"
@@ -39198,7 +37580,6 @@ pl_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_56 : Css.Style
 pl_56 =
     Css.property "padding-left" "14rem"
@@ -39209,7 +37590,6 @@ pl_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_6 : Css.Style
 pl_6 =
     Css.property "padding-left" "1.5rem"
@@ -39220,7 +37600,6 @@ pl_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_60 : Css.Style
 pl_60 =
     Css.property "padding-left" "15rem"
@@ -39231,7 +37610,6 @@ pl_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_64 : Css.Style
 pl_64 =
     Css.property "padding-left" "16rem"
@@ -39242,7 +37620,6 @@ pl_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_7 : Css.Style
 pl_7 =
     Css.property "padding-left" "1.75rem"
@@ -39253,7 +37630,6 @@ pl_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_72 : Css.Style
 pl_72 =
     Css.property "padding-left" "18rem"
@@ -39264,7 +37640,6 @@ pl_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_8 : Css.Style
 pl_8 =
     Css.property "padding-left" "2rem"
@@ -39275,7 +37650,6 @@ pl_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_80 : Css.Style
 pl_80 =
     Css.property "padding-left" "20rem"
@@ -39286,7 +37660,6 @@ pl_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_9 : Css.Style
 pl_9 =
     Css.property "padding-left" "2.25rem"
@@ -39297,7 +37670,6 @@ pl_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_96 : Css.Style
 pl_96 =
     Css.property "padding-left" "24rem"
@@ -39308,7 +37680,6 @@ pl_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pl_px : Css.Style
 pl_px =
     Css.property "padding-left" "1px"
@@ -39319,7 +37690,6 @@ pl_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_around : Css.Style
 place_content_around =
     Css.property "place-content" "space-around"
@@ -39330,7 +37700,6 @@ place_content_around =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_between : Css.Style
 place_content_between =
     Css.property "place-content" "space-between"
@@ -39341,7 +37710,6 @@ place_content_between =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_center : Css.Style
 place_content_center =
     Css.property "place-content" "center"
@@ -39352,7 +37720,6 @@ place_content_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_end : Css.Style
 place_content_end =
     Css.property "place-content" "end"
@@ -39363,7 +37730,6 @@ place_content_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_evenly : Css.Style
 place_content_evenly =
     Css.property "place-content" "space-evenly"
@@ -39374,7 +37740,6 @@ place_content_evenly =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_start : Css.Style
 place_content_start =
     Css.property "place-content" "start"
@@ -39385,7 +37750,6 @@ place_content_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_content_stretch : Css.Style
 place_content_stretch =
     Css.property "place-content" "stretch"
@@ -39396,7 +37760,6 @@ place_content_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_items_center : Css.Style
 place_items_center =
     Css.property "place-items" "center"
@@ -39407,7 +37770,6 @@ place_items_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_items_end : Css.Style
 place_items_end =
     Css.property "place-items" "end"
@@ -39418,7 +37780,6 @@ place_items_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_items_start : Css.Style
 place_items_start =
     Css.property "place-items" "start"
@@ -39429,7 +37790,6 @@ place_items_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_items_stretch : Css.Style
 place_items_stretch =
     Css.property "place-items" "stretch"
@@ -39440,7 +37800,6 @@ place_items_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_self_auto : Css.Style
 place_self_auto =
     Css.property "place-self" "auto"
@@ -39451,7 +37810,6 @@ place_self_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_self_center : Css.Style
 place_self_center =
     Css.property "place-self" "center"
@@ -39462,7 +37820,6 @@ place_self_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_self_end : Css.Style
 place_self_end =
     Css.property "place-self" "end"
@@ -39473,7 +37830,6 @@ place_self_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_self_start : Css.Style
 place_self_start =
     Css.property "place-self" "start"
@@ -39484,7 +37840,6 @@ place_self_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 place_self_stretch : Css.Style
 place_self_stretch =
     Css.property "place-self" "stretch"
@@ -39495,7 +37850,6 @@ place_self_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_black : Css.Style
 placeholder_black =
     Css.batch
@@ -39519,7 +37873,6 @@ placeholder_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_100 : Css.Style
 placeholder_blue_100 =
     Css.batch
@@ -39543,7 +37896,6 @@ placeholder_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_200 : Css.Style
 placeholder_blue_200 =
     Css.batch
@@ -39567,7 +37919,6 @@ placeholder_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_300 : Css.Style
 placeholder_blue_300 =
     Css.batch
@@ -39591,7 +37942,6 @@ placeholder_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_400 : Css.Style
 placeholder_blue_400 =
     Css.batch
@@ -39615,7 +37965,6 @@ placeholder_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_50 : Css.Style
 placeholder_blue_50 =
     Css.batch
@@ -39639,7 +37988,6 @@ placeholder_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_500 : Css.Style
 placeholder_blue_500 =
     Css.batch
@@ -39663,7 +38011,6 @@ placeholder_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_600 : Css.Style
 placeholder_blue_600 =
     Css.batch
@@ -39687,7 +38034,6 @@ placeholder_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_700 : Css.Style
 placeholder_blue_700 =
     Css.batch
@@ -39711,7 +38057,6 @@ placeholder_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_800 : Css.Style
 placeholder_blue_800 =
     Css.batch
@@ -39735,7 +38080,6 @@ placeholder_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_blue_900 : Css.Style
 placeholder_blue_900 =
     Css.batch
@@ -39759,7 +38103,6 @@ placeholder_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_current : Css.Style
 placeholder_current =
     Css.batch
@@ -39780,7 +38123,6 @@ placeholder_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_100 : Css.Style
 placeholder_gray_100 =
     Css.batch
@@ -39804,7 +38146,6 @@ placeholder_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_200 : Css.Style
 placeholder_gray_200 =
     Css.batch
@@ -39828,7 +38169,6 @@ placeholder_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_300 : Css.Style
 placeholder_gray_300 =
     Css.batch
@@ -39852,7 +38192,6 @@ placeholder_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_400 : Css.Style
 placeholder_gray_400 =
     Css.batch
@@ -39876,7 +38215,6 @@ placeholder_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_50 : Css.Style
 placeholder_gray_50 =
     Css.batch
@@ -39900,7 +38238,6 @@ placeholder_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_500 : Css.Style
 placeholder_gray_500 =
     Css.batch
@@ -39924,7 +38261,6 @@ placeholder_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_600 : Css.Style
 placeholder_gray_600 =
     Css.batch
@@ -39948,7 +38284,6 @@ placeholder_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_700 : Css.Style
 placeholder_gray_700 =
     Css.batch
@@ -39972,7 +38307,6 @@ placeholder_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_800 : Css.Style
 placeholder_gray_800 =
     Css.batch
@@ -39996,7 +38330,6 @@ placeholder_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_gray_900 : Css.Style
 placeholder_gray_900 =
     Css.batch
@@ -40020,7 +38353,6 @@ placeholder_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_100 : Css.Style
 placeholder_green_100 =
     Css.batch
@@ -40044,7 +38376,6 @@ placeholder_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_200 : Css.Style
 placeholder_green_200 =
     Css.batch
@@ -40068,7 +38399,6 @@ placeholder_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_300 : Css.Style
 placeholder_green_300 =
     Css.batch
@@ -40092,7 +38422,6 @@ placeholder_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_400 : Css.Style
 placeholder_green_400 =
     Css.batch
@@ -40116,7 +38445,6 @@ placeholder_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_50 : Css.Style
 placeholder_green_50 =
     Css.batch
@@ -40140,7 +38468,6 @@ placeholder_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_500 : Css.Style
 placeholder_green_500 =
     Css.batch
@@ -40164,7 +38491,6 @@ placeholder_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_600 : Css.Style
 placeholder_green_600 =
     Css.batch
@@ -40188,7 +38514,6 @@ placeholder_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_700 : Css.Style
 placeholder_green_700 =
     Css.batch
@@ -40212,7 +38537,6 @@ placeholder_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_800 : Css.Style
 placeholder_green_800 =
     Css.batch
@@ -40236,7 +38560,6 @@ placeholder_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_green_900 : Css.Style
 placeholder_green_900 =
     Css.batch
@@ -40260,7 +38583,6 @@ placeholder_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_100 : Css.Style
 placeholder_indigo_100 =
     Css.batch
@@ -40284,7 +38606,6 @@ placeholder_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_200 : Css.Style
 placeholder_indigo_200 =
     Css.batch
@@ -40308,7 +38629,6 @@ placeholder_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_300 : Css.Style
 placeholder_indigo_300 =
     Css.batch
@@ -40332,7 +38652,6 @@ placeholder_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_400 : Css.Style
 placeholder_indigo_400 =
     Css.batch
@@ -40356,7 +38675,6 @@ placeholder_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_50 : Css.Style
 placeholder_indigo_50 =
     Css.batch
@@ -40380,7 +38698,6 @@ placeholder_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_500 : Css.Style
 placeholder_indigo_500 =
     Css.batch
@@ -40404,7 +38721,6 @@ placeholder_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_600 : Css.Style
 placeholder_indigo_600 =
     Css.batch
@@ -40428,7 +38744,6 @@ placeholder_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_700 : Css.Style
 placeholder_indigo_700 =
     Css.batch
@@ -40452,7 +38767,6 @@ placeholder_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_800 : Css.Style
 placeholder_indigo_800 =
     Css.batch
@@ -40476,7 +38790,6 @@ placeholder_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_indigo_900 : Css.Style
 placeholder_indigo_900 =
     Css.batch
@@ -40500,7 +38813,6 @@ placeholder_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_0 : Css.Style
 placeholder_opacity_0 =
     Css.batch
@@ -40521,7 +38833,6 @@ placeholder_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_10 : Css.Style
 placeholder_opacity_10 =
     Css.batch
@@ -40542,7 +38853,6 @@ placeholder_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_100 : Css.Style
 placeholder_opacity_100 =
     Css.batch
@@ -40563,7 +38873,6 @@ placeholder_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_20 : Css.Style
 placeholder_opacity_20 =
     Css.batch
@@ -40584,7 +38893,6 @@ placeholder_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_25 : Css.Style
 placeholder_opacity_25 =
     Css.batch
@@ -40605,7 +38913,6 @@ placeholder_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_30 : Css.Style
 placeholder_opacity_30 =
     Css.batch
@@ -40626,7 +38933,6 @@ placeholder_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_40 : Css.Style
 placeholder_opacity_40 =
     Css.batch
@@ -40647,7 +38953,6 @@ placeholder_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_5 : Css.Style
 placeholder_opacity_5 =
     Css.batch
@@ -40668,7 +38973,6 @@ placeholder_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_50 : Css.Style
 placeholder_opacity_50 =
     Css.batch
@@ -40689,7 +38993,6 @@ placeholder_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_60 : Css.Style
 placeholder_opacity_60 =
     Css.batch
@@ -40710,7 +39013,6 @@ placeholder_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_70 : Css.Style
 placeholder_opacity_70 =
     Css.batch
@@ -40731,7 +39033,6 @@ placeholder_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_75 : Css.Style
 placeholder_opacity_75 =
     Css.batch
@@ -40752,7 +39053,6 @@ placeholder_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_80 : Css.Style
 placeholder_opacity_80 =
     Css.batch
@@ -40773,7 +39073,6 @@ placeholder_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_90 : Css.Style
 placeholder_opacity_90 =
     Css.batch
@@ -40794,7 +39093,6 @@ placeholder_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_opacity_95 : Css.Style
 placeholder_opacity_95 =
     Css.batch
@@ -40815,7 +39113,6 @@ placeholder_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_100 : Css.Style
 placeholder_pink_100 =
     Css.batch
@@ -40839,7 +39136,6 @@ placeholder_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_200 : Css.Style
 placeholder_pink_200 =
     Css.batch
@@ -40863,7 +39159,6 @@ placeholder_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_300 : Css.Style
 placeholder_pink_300 =
     Css.batch
@@ -40887,7 +39182,6 @@ placeholder_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_400 : Css.Style
 placeholder_pink_400 =
     Css.batch
@@ -40911,7 +39205,6 @@ placeholder_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_50 : Css.Style
 placeholder_pink_50 =
     Css.batch
@@ -40935,7 +39228,6 @@ placeholder_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_500 : Css.Style
 placeholder_pink_500 =
     Css.batch
@@ -40959,7 +39251,6 @@ placeholder_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_600 : Css.Style
 placeholder_pink_600 =
     Css.batch
@@ -40983,7 +39274,6 @@ placeholder_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_700 : Css.Style
 placeholder_pink_700 =
     Css.batch
@@ -41007,7 +39297,6 @@ placeholder_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_800 : Css.Style
 placeholder_pink_800 =
     Css.batch
@@ -41031,7 +39320,6 @@ placeholder_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_pink_900 : Css.Style
 placeholder_pink_900 =
     Css.batch
@@ -41055,7 +39343,6 @@ placeholder_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_100 : Css.Style
 placeholder_purple_100 =
     Css.batch
@@ -41079,7 +39366,6 @@ placeholder_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_200 : Css.Style
 placeholder_purple_200 =
     Css.batch
@@ -41103,7 +39389,6 @@ placeholder_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_300 : Css.Style
 placeholder_purple_300 =
     Css.batch
@@ -41127,7 +39412,6 @@ placeholder_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_400 : Css.Style
 placeholder_purple_400 =
     Css.batch
@@ -41151,7 +39435,6 @@ placeholder_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_50 : Css.Style
 placeholder_purple_50 =
     Css.batch
@@ -41175,7 +39458,6 @@ placeholder_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_500 : Css.Style
 placeholder_purple_500 =
     Css.batch
@@ -41199,7 +39481,6 @@ placeholder_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_600 : Css.Style
 placeholder_purple_600 =
     Css.batch
@@ -41223,7 +39504,6 @@ placeholder_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_700 : Css.Style
 placeholder_purple_700 =
     Css.batch
@@ -41247,7 +39527,6 @@ placeholder_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_800 : Css.Style
 placeholder_purple_800 =
     Css.batch
@@ -41271,7 +39550,6 @@ placeholder_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_purple_900 : Css.Style
 placeholder_purple_900 =
     Css.batch
@@ -41295,7 +39573,6 @@ placeholder_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_100 : Css.Style
 placeholder_red_100 =
     Css.batch
@@ -41319,7 +39596,6 @@ placeholder_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_200 : Css.Style
 placeholder_red_200 =
     Css.batch
@@ -41343,7 +39619,6 @@ placeholder_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_300 : Css.Style
 placeholder_red_300 =
     Css.batch
@@ -41367,7 +39642,6 @@ placeholder_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_400 : Css.Style
 placeholder_red_400 =
     Css.batch
@@ -41391,7 +39665,6 @@ placeholder_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_50 : Css.Style
 placeholder_red_50 =
     Css.batch
@@ -41415,7 +39688,6 @@ placeholder_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_500 : Css.Style
 placeholder_red_500 =
     Css.batch
@@ -41439,7 +39711,6 @@ placeholder_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_600 : Css.Style
 placeholder_red_600 =
     Css.batch
@@ -41463,7 +39734,6 @@ placeholder_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_700 : Css.Style
 placeholder_red_700 =
     Css.batch
@@ -41487,7 +39757,6 @@ placeholder_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_800 : Css.Style
 placeholder_red_800 =
     Css.batch
@@ -41511,7 +39780,6 @@ placeholder_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_red_900 : Css.Style
 placeholder_red_900 =
     Css.batch
@@ -41535,7 +39803,6 @@ placeholder_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_transparent : Css.Style
 placeholder_transparent =
     Css.batch
@@ -41556,7 +39823,6 @@ placeholder_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_white : Css.Style
 placeholder_white =
     Css.batch
@@ -41580,7 +39846,6 @@ placeholder_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_100 : Css.Style
 placeholder_yellow_100 =
     Css.batch
@@ -41604,7 +39869,6 @@ placeholder_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_200 : Css.Style
 placeholder_yellow_200 =
     Css.batch
@@ -41628,7 +39892,6 @@ placeholder_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_300 : Css.Style
 placeholder_yellow_300 =
     Css.batch
@@ -41652,7 +39915,6 @@ placeholder_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_400 : Css.Style
 placeholder_yellow_400 =
     Css.batch
@@ -41676,7 +39938,6 @@ placeholder_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_50 : Css.Style
 placeholder_yellow_50 =
     Css.batch
@@ -41700,7 +39961,6 @@ placeholder_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_500 : Css.Style
 placeholder_yellow_500 =
     Css.batch
@@ -41724,7 +39984,6 @@ placeholder_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_600 : Css.Style
 placeholder_yellow_600 =
     Css.batch
@@ -41748,7 +40007,6 @@ placeholder_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_700 : Css.Style
 placeholder_yellow_700 =
     Css.batch
@@ -41772,7 +40030,6 @@ placeholder_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_800 : Css.Style
 placeholder_yellow_800 =
     Css.batch
@@ -41796,7 +40053,6 @@ placeholder_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 placeholder_yellow_900 : Css.Style
 placeholder_yellow_900 =
     Css.batch
@@ -41820,7 +40076,6 @@ placeholder_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pointer_events_auto : Css.Style
 pointer_events_auto =
     Css.property "pointer-events" "auto"
@@ -41831,7 +40086,6 @@ pointer_events_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pointer_events_none : Css.Style
 pointer_events_none =
     Css.property "pointer-events" "none"
@@ -41842,7 +40096,6 @@ pointer_events_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_0 : Css.Style
 pr_0 =
     Css.property "padding-right" "0px"
@@ -41853,7 +40106,6 @@ pr_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_0_dot_5 : Css.Style
 pr_0_dot_5 =
     Css.property "padding-right" "0.125rem"
@@ -41864,7 +40116,6 @@ pr_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_1 : Css.Style
 pr_1 =
     Css.property "padding-right" "0.25rem"
@@ -41875,7 +40126,6 @@ pr_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_10 : Css.Style
 pr_10 =
     Css.property "padding-right" "2.5rem"
@@ -41886,7 +40136,6 @@ pr_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_11 : Css.Style
 pr_11 =
     Css.property "padding-right" "2.75rem"
@@ -41897,7 +40146,6 @@ pr_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_12 : Css.Style
 pr_12 =
     Css.property "padding-right" "3rem"
@@ -41908,7 +40156,6 @@ pr_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_14 : Css.Style
 pr_14 =
     Css.property "padding-right" "3.5rem"
@@ -41919,7 +40166,6 @@ pr_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_16 : Css.Style
 pr_16 =
     Css.property "padding-right" "4rem"
@@ -41930,7 +40176,6 @@ pr_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_1_dot_5 : Css.Style
 pr_1_dot_5 =
     Css.property "padding-right" "0.375rem"
@@ -41941,7 +40186,6 @@ pr_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_2 : Css.Style
 pr_2 =
     Css.property "padding-right" "0.5rem"
@@ -41952,7 +40196,6 @@ pr_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_20 : Css.Style
 pr_20 =
     Css.property "padding-right" "5rem"
@@ -41963,7 +40206,6 @@ pr_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_24 : Css.Style
 pr_24 =
     Css.property "padding-right" "6rem"
@@ -41974,7 +40216,6 @@ pr_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_28 : Css.Style
 pr_28 =
     Css.property "padding-right" "7rem"
@@ -41985,7 +40226,6 @@ pr_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_2_dot_5 : Css.Style
 pr_2_dot_5 =
     Css.property "padding-right" "0.625rem"
@@ -41996,7 +40236,6 @@ pr_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_3 : Css.Style
 pr_3 =
     Css.property "padding-right" "0.75rem"
@@ -42007,7 +40246,6 @@ pr_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_32 : Css.Style
 pr_32 =
     Css.property "padding-right" "8rem"
@@ -42018,7 +40256,6 @@ pr_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_36 : Css.Style
 pr_36 =
     Css.property "padding-right" "9rem"
@@ -42029,7 +40266,6 @@ pr_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_3_dot_5 : Css.Style
 pr_3_dot_5 =
     Css.property "padding-right" "0.875rem"
@@ -42040,7 +40276,6 @@ pr_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_4 : Css.Style
 pr_4 =
     Css.property "padding-right" "1rem"
@@ -42051,7 +40286,6 @@ pr_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_40 : Css.Style
 pr_40 =
     Css.property "padding-right" "10rem"
@@ -42062,7 +40296,6 @@ pr_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_44 : Css.Style
 pr_44 =
     Css.property "padding-right" "11rem"
@@ -42073,7 +40306,6 @@ pr_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_48 : Css.Style
 pr_48 =
     Css.property "padding-right" "12rem"
@@ -42084,7 +40316,6 @@ pr_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_5 : Css.Style
 pr_5 =
     Css.property "padding-right" "1.25rem"
@@ -42095,7 +40326,6 @@ pr_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_52 : Css.Style
 pr_52 =
     Css.property "padding-right" "13rem"
@@ -42106,7 +40336,6 @@ pr_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_56 : Css.Style
 pr_56 =
     Css.property "padding-right" "14rem"
@@ -42117,7 +40346,6 @@ pr_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_6 : Css.Style
 pr_6 =
     Css.property "padding-right" "1.5rem"
@@ -42128,7 +40356,6 @@ pr_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_60 : Css.Style
 pr_60 =
     Css.property "padding-right" "15rem"
@@ -42139,7 +40366,6 @@ pr_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_64 : Css.Style
 pr_64 =
     Css.property "padding-right" "16rem"
@@ -42150,7 +40376,6 @@ pr_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_7 : Css.Style
 pr_7 =
     Css.property "padding-right" "1.75rem"
@@ -42161,7 +40386,6 @@ pr_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_72 : Css.Style
 pr_72 =
     Css.property "padding-right" "18rem"
@@ -42172,7 +40396,6 @@ pr_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_8 : Css.Style
 pr_8 =
     Css.property "padding-right" "2rem"
@@ -42183,7 +40406,6 @@ pr_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_80 : Css.Style
 pr_80 =
     Css.property "padding-right" "20rem"
@@ -42194,7 +40416,6 @@ pr_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_9 : Css.Style
 pr_9 =
     Css.property "padding-right" "2.25rem"
@@ -42205,7 +40426,6 @@ pr_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_96 : Css.Style
 pr_96 =
     Css.property "padding-right" "24rem"
@@ -42216,7 +40436,6 @@ pr_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pr_px : Css.Style
 pr_px =
     Css.property "padding-right" "1px"
@@ -42227,7 +40446,6 @@ pr_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 proportional_nums : Css.Style
 proportional_nums =
     Css.batch
@@ -42246,7 +40464,6 @@ proportional_nums =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose : Css.Style
 prose =
     Css.batch
@@ -42706,7 +40923,6 @@ prose =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_2xl : Css.Style
 prose_2xl =
     Css.batch
@@ -42999,7 +41215,6 @@ prose_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_blue : Css.Style
 prose_blue =
     Css.batch
@@ -43021,7 +41236,6 @@ prose_blue =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_green : Css.Style
 prose_green =
     Css.batch
@@ -43043,7 +41257,6 @@ prose_green =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_indigo : Css.Style
 prose_indigo =
     Css.batch
@@ -43065,7 +41278,6 @@ prose_indigo =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_lg : Css.Style
 prose_lg =
     Css.batch
@@ -43358,7 +41570,6 @@ prose_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_pink : Css.Style
 prose_pink =
     Css.batch
@@ -43380,7 +41591,6 @@ prose_pink =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_purple : Css.Style
 prose_purple =
     Css.batch
@@ -43402,7 +41612,6 @@ prose_purple =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_red : Css.Style
 prose_red =
     Css.batch
@@ -43424,7 +41633,6 @@ prose_red =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_sm : Css.Style
 prose_sm =
     Css.batch
@@ -43717,7 +41925,6 @@ prose_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_xl : Css.Style
 prose_xl =
     Css.batch
@@ -44010,7 +42217,6 @@ prose_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 prose_yellow : Css.Style
 prose_yellow =
     Css.batch
@@ -44032,7 +42238,6 @@ prose_yellow =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_0 : Css.Style
 pt_0 =
     Css.property "padding-top" "0px"
@@ -44043,7 +42248,6 @@ pt_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_0_dot_5 : Css.Style
 pt_0_dot_5 =
     Css.property "padding-top" "0.125rem"
@@ -44054,7 +42258,6 @@ pt_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_1 : Css.Style
 pt_1 =
     Css.property "padding-top" "0.25rem"
@@ -44065,7 +42268,6 @@ pt_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_10 : Css.Style
 pt_10 =
     Css.property "padding-top" "2.5rem"
@@ -44076,7 +42278,6 @@ pt_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_11 : Css.Style
 pt_11 =
     Css.property "padding-top" "2.75rem"
@@ -44087,7 +42288,6 @@ pt_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_12 : Css.Style
 pt_12 =
     Css.property "padding-top" "3rem"
@@ -44098,7 +42298,6 @@ pt_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_14 : Css.Style
 pt_14 =
     Css.property "padding-top" "3.5rem"
@@ -44109,7 +42308,6 @@ pt_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_16 : Css.Style
 pt_16 =
     Css.property "padding-top" "4rem"
@@ -44120,7 +42318,6 @@ pt_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_1_dot_5 : Css.Style
 pt_1_dot_5 =
     Css.property "padding-top" "0.375rem"
@@ -44131,7 +42328,6 @@ pt_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_2 : Css.Style
 pt_2 =
     Css.property "padding-top" "0.5rem"
@@ -44142,7 +42338,6 @@ pt_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_20 : Css.Style
 pt_20 =
     Css.property "padding-top" "5rem"
@@ -44153,7 +42348,6 @@ pt_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_24 : Css.Style
 pt_24 =
     Css.property "padding-top" "6rem"
@@ -44164,7 +42358,6 @@ pt_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_28 : Css.Style
 pt_28 =
     Css.property "padding-top" "7rem"
@@ -44175,7 +42368,6 @@ pt_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_2_dot_5 : Css.Style
 pt_2_dot_5 =
     Css.property "padding-top" "0.625rem"
@@ -44186,7 +42378,6 @@ pt_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_3 : Css.Style
 pt_3 =
     Css.property "padding-top" "0.75rem"
@@ -44197,7 +42388,6 @@ pt_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_32 : Css.Style
 pt_32 =
     Css.property "padding-top" "8rem"
@@ -44208,7 +42398,6 @@ pt_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_36 : Css.Style
 pt_36 =
     Css.property "padding-top" "9rem"
@@ -44219,7 +42408,6 @@ pt_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_3_dot_5 : Css.Style
 pt_3_dot_5 =
     Css.property "padding-top" "0.875rem"
@@ -44230,7 +42418,6 @@ pt_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_4 : Css.Style
 pt_4 =
     Css.property "padding-top" "1rem"
@@ -44241,7 +42428,6 @@ pt_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_40 : Css.Style
 pt_40 =
     Css.property "padding-top" "10rem"
@@ -44252,7 +42438,6 @@ pt_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_44 : Css.Style
 pt_44 =
     Css.property "padding-top" "11rem"
@@ -44263,7 +42448,6 @@ pt_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_48 : Css.Style
 pt_48 =
     Css.property "padding-top" "12rem"
@@ -44274,7 +42458,6 @@ pt_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_5 : Css.Style
 pt_5 =
     Css.property "padding-top" "1.25rem"
@@ -44285,7 +42468,6 @@ pt_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_52 : Css.Style
 pt_52 =
     Css.property "padding-top" "13rem"
@@ -44296,7 +42478,6 @@ pt_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_56 : Css.Style
 pt_56 =
     Css.property "padding-top" "14rem"
@@ -44307,7 +42488,6 @@ pt_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_6 : Css.Style
 pt_6 =
     Css.property "padding-top" "1.5rem"
@@ -44318,7 +42498,6 @@ pt_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_60 : Css.Style
 pt_60 =
     Css.property "padding-top" "15rem"
@@ -44329,7 +42508,6 @@ pt_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_64 : Css.Style
 pt_64 =
     Css.property "padding-top" "16rem"
@@ -44340,7 +42518,6 @@ pt_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_7 : Css.Style
 pt_7 =
     Css.property "padding-top" "1.75rem"
@@ -44351,7 +42528,6 @@ pt_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_72 : Css.Style
 pt_72 =
     Css.property "padding-top" "18rem"
@@ -44362,7 +42538,6 @@ pt_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_8 : Css.Style
 pt_8 =
     Css.property "padding-top" "2rem"
@@ -44373,7 +42548,6 @@ pt_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_80 : Css.Style
 pt_80 =
     Css.property "padding-top" "20rem"
@@ -44384,7 +42558,6 @@ pt_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_9 : Css.Style
 pt_9 =
     Css.property "padding-top" "2.25rem"
@@ -44395,7 +42568,6 @@ pt_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_96 : Css.Style
 pt_96 =
     Css.property "padding-top" "24rem"
@@ -44406,7 +42578,6 @@ pt_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 pt_px : Css.Style
 pt_px =
     Css.property "padding-top" "1px"
@@ -44417,7 +42588,6 @@ pt_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_0 : Css.Style
 px_0 =
     Css.batch
@@ -44431,7 +42601,6 @@ px_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_0_dot_5 : Css.Style
 px_0_dot_5 =
     Css.batch
@@ -44445,7 +42614,6 @@ px_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_1 : Css.Style
 px_1 =
     Css.batch
@@ -44459,7 +42627,6 @@ px_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_10 : Css.Style
 px_10 =
     Css.batch
@@ -44473,7 +42640,6 @@ px_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_11 : Css.Style
 px_11 =
     Css.batch
@@ -44487,7 +42653,6 @@ px_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_12 : Css.Style
 px_12 =
     Css.batch
@@ -44501,7 +42666,6 @@ px_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_14 : Css.Style
 px_14 =
     Css.batch
@@ -44515,7 +42679,6 @@ px_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_16 : Css.Style
 px_16 =
     Css.batch
@@ -44529,7 +42692,6 @@ px_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_1_dot_5 : Css.Style
 px_1_dot_5 =
     Css.batch
@@ -44543,7 +42705,6 @@ px_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_2 : Css.Style
 px_2 =
     Css.batch
@@ -44557,7 +42718,6 @@ px_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_20 : Css.Style
 px_20 =
     Css.batch
@@ -44571,7 +42731,6 @@ px_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_24 : Css.Style
 px_24 =
     Css.batch
@@ -44585,7 +42744,6 @@ px_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_28 : Css.Style
 px_28 =
     Css.batch
@@ -44599,7 +42757,6 @@ px_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_2_dot_5 : Css.Style
 px_2_dot_5 =
     Css.batch
@@ -44613,7 +42770,6 @@ px_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_3 : Css.Style
 px_3 =
     Css.batch
@@ -44627,7 +42783,6 @@ px_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_32 : Css.Style
 px_32 =
     Css.batch
@@ -44641,7 +42796,6 @@ px_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_36 : Css.Style
 px_36 =
     Css.batch
@@ -44655,7 +42809,6 @@ px_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_3_dot_5 : Css.Style
 px_3_dot_5 =
     Css.batch
@@ -44669,7 +42822,6 @@ px_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_4 : Css.Style
 px_4 =
     Css.batch
@@ -44683,7 +42835,6 @@ px_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_40 : Css.Style
 px_40 =
     Css.batch
@@ -44697,7 +42848,6 @@ px_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_44 : Css.Style
 px_44 =
     Css.batch
@@ -44711,7 +42861,6 @@ px_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_48 : Css.Style
 px_48 =
     Css.batch
@@ -44725,7 +42874,6 @@ px_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_5 : Css.Style
 px_5 =
     Css.batch
@@ -44739,7 +42887,6 @@ px_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_52 : Css.Style
 px_52 =
     Css.batch
@@ -44753,7 +42900,6 @@ px_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_56 : Css.Style
 px_56 =
     Css.batch
@@ -44767,7 +42913,6 @@ px_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_6 : Css.Style
 px_6 =
     Css.batch
@@ -44781,7 +42926,6 @@ px_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_60 : Css.Style
 px_60 =
     Css.batch
@@ -44795,7 +42939,6 @@ px_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_64 : Css.Style
 px_64 =
     Css.batch
@@ -44809,7 +42952,6 @@ px_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_7 : Css.Style
 px_7 =
     Css.batch
@@ -44823,7 +42965,6 @@ px_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_72 : Css.Style
 px_72 =
     Css.batch
@@ -44837,7 +42978,6 @@ px_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_8 : Css.Style
 px_8 =
     Css.batch
@@ -44851,7 +42991,6 @@ px_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_80 : Css.Style
 px_80 =
     Css.batch
@@ -44865,7 +43004,6 @@ px_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_9 : Css.Style
 px_9 =
     Css.batch
@@ -44879,7 +43017,6 @@ px_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_96 : Css.Style
 px_96 =
     Css.batch
@@ -44893,7 +43030,6 @@ px_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 px_px : Css.Style
 px_px =
     Css.batch
@@ -44907,7 +43043,6 @@ px_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_0 : Css.Style
 py_0 =
     Css.batch
@@ -44921,7 +43056,6 @@ py_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_0_dot_5 : Css.Style
 py_0_dot_5 =
     Css.batch
@@ -44935,7 +43069,6 @@ py_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_1 : Css.Style
 py_1 =
     Css.batch
@@ -44949,7 +43082,6 @@ py_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_10 : Css.Style
 py_10 =
     Css.batch
@@ -44963,7 +43095,6 @@ py_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_11 : Css.Style
 py_11 =
     Css.batch
@@ -44977,7 +43108,6 @@ py_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_12 : Css.Style
 py_12 =
     Css.batch
@@ -44991,7 +43121,6 @@ py_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_14 : Css.Style
 py_14 =
     Css.batch
@@ -45005,7 +43134,6 @@ py_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_16 : Css.Style
 py_16 =
     Css.batch
@@ -45019,7 +43147,6 @@ py_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_1_dot_5 : Css.Style
 py_1_dot_5 =
     Css.batch
@@ -45033,7 +43160,6 @@ py_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_2 : Css.Style
 py_2 =
     Css.batch
@@ -45047,7 +43173,6 @@ py_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_20 : Css.Style
 py_20 =
     Css.batch
@@ -45061,7 +43186,6 @@ py_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_24 : Css.Style
 py_24 =
     Css.batch
@@ -45075,7 +43199,6 @@ py_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_28 : Css.Style
 py_28 =
     Css.batch
@@ -45089,7 +43212,6 @@ py_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_2_dot_5 : Css.Style
 py_2_dot_5 =
     Css.batch
@@ -45103,7 +43225,6 @@ py_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_3 : Css.Style
 py_3 =
     Css.batch
@@ -45117,7 +43238,6 @@ py_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_32 : Css.Style
 py_32 =
     Css.batch
@@ -45131,7 +43251,6 @@ py_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_36 : Css.Style
 py_36 =
     Css.batch
@@ -45145,7 +43264,6 @@ py_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_3_dot_5 : Css.Style
 py_3_dot_5 =
     Css.batch
@@ -45159,7 +43277,6 @@ py_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_4 : Css.Style
 py_4 =
     Css.batch
@@ -45173,7 +43290,6 @@ py_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_40 : Css.Style
 py_40 =
     Css.batch
@@ -45187,7 +43303,6 @@ py_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_44 : Css.Style
 py_44 =
     Css.batch
@@ -45201,7 +43316,6 @@ py_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_48 : Css.Style
 py_48 =
     Css.batch
@@ -45215,7 +43329,6 @@ py_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_5 : Css.Style
 py_5 =
     Css.batch
@@ -45229,7 +43342,6 @@ py_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_52 : Css.Style
 py_52 =
     Css.batch
@@ -45243,7 +43355,6 @@ py_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_56 : Css.Style
 py_56 =
     Css.batch
@@ -45257,7 +43368,6 @@ py_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_6 : Css.Style
 py_6 =
     Css.batch
@@ -45271,7 +43381,6 @@ py_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_60 : Css.Style
 py_60 =
     Css.batch
@@ -45285,7 +43394,6 @@ py_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_64 : Css.Style
 py_64 =
     Css.batch
@@ -45299,7 +43407,6 @@ py_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_7 : Css.Style
 py_7 =
     Css.batch
@@ -45313,7 +43420,6 @@ py_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_72 : Css.Style
 py_72 =
     Css.batch
@@ -45327,7 +43433,6 @@ py_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_8 : Css.Style
 py_8 =
     Css.batch
@@ -45341,7 +43446,6 @@ py_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_80 : Css.Style
 py_80 =
     Css.batch
@@ -45355,7 +43459,6 @@ py_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_9 : Css.Style
 py_9 =
     Css.batch
@@ -45369,7 +43472,6 @@ py_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_96 : Css.Style
 py_96 =
     Css.batch
@@ -45383,7 +43485,6 @@ py_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 py_px : Css.Style
 py_px =
     Css.batch
@@ -45397,7 +43498,6 @@ py_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 relative : Css.Style
 relative =
     Css.property "position" "relative"
@@ -45408,7 +43508,6 @@ relative =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 resize : Css.Style
 resize =
     Css.property "resize" "both"
@@ -45419,7 +43518,6 @@ resize =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 resize_none : Css.Style
 resize_none =
     Css.property "resize" "none"
@@ -45430,7 +43528,6 @@ resize_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 resize_x : Css.Style
 resize_x =
     Css.property "resize" "horizontal"
@@ -45441,7 +43538,6 @@ resize_x =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 resize_y : Css.Style
 resize_y =
     Css.property "resize" "vertical"
@@ -45452,7 +43548,6 @@ resize_y =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_0 : Css.Style
 right_0 =
     Css.property "right" "0px"
@@ -45463,7 +43558,6 @@ right_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_0_dot_5 : Css.Style
 right_0_dot_5 =
     Css.property "right" "0.125rem"
@@ -45474,7 +43568,6 @@ right_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_1 : Css.Style
 right_1 =
     Css.property "right" "0.25rem"
@@ -45485,7 +43578,6 @@ right_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_10 : Css.Style
 right_10 =
     Css.property "right" "2.5rem"
@@ -45496,7 +43588,6 @@ right_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_11 : Css.Style
 right_11 =
     Css.property "right" "2.75rem"
@@ -45507,7 +43598,6 @@ right_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_12 : Css.Style
 right_12 =
     Css.property "right" "3rem"
@@ -45518,7 +43608,6 @@ right_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_14 : Css.Style
 right_14 =
     Css.property "right" "3.5rem"
@@ -45529,7 +43618,6 @@ right_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_16 : Css.Style
 right_16 =
     Css.property "right" "4rem"
@@ -45540,7 +43628,6 @@ right_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_1_dot_5 : Css.Style
 right_1_dot_5 =
     Css.property "right" "0.375rem"
@@ -45551,7 +43638,6 @@ right_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_1over2 : Css.Style
 right_1over2 =
     Css.property "right" "50%"
@@ -45562,7 +43648,6 @@ right_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_1over3 : Css.Style
 right_1over3 =
     Css.property "right" "33.333333%"
@@ -45573,7 +43658,6 @@ right_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_1over4 : Css.Style
 right_1over4 =
     Css.property "right" "25%"
@@ -45584,7 +43668,6 @@ right_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_2 : Css.Style
 right_2 =
     Css.property "right" "0.5rem"
@@ -45595,7 +43678,6 @@ right_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_20 : Css.Style
 right_20 =
     Css.property "right" "5rem"
@@ -45606,7 +43688,6 @@ right_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_24 : Css.Style
 right_24 =
     Css.property "right" "6rem"
@@ -45617,7 +43698,6 @@ right_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_28 : Css.Style
 right_28 =
     Css.property "right" "7rem"
@@ -45628,7 +43708,6 @@ right_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_2_dot_5 : Css.Style
 right_2_dot_5 =
     Css.property "right" "0.625rem"
@@ -45639,7 +43718,6 @@ right_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_2over3 : Css.Style
 right_2over3 =
     Css.property "right" "66.666667%"
@@ -45650,7 +43728,6 @@ right_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_2over4 : Css.Style
 right_2over4 =
     Css.property "right" "50%"
@@ -45661,7 +43738,6 @@ right_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_3 : Css.Style
 right_3 =
     Css.property "right" "0.75rem"
@@ -45672,7 +43748,6 @@ right_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_32 : Css.Style
 right_32 =
     Css.property "right" "8rem"
@@ -45683,7 +43758,6 @@ right_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_36 : Css.Style
 right_36 =
     Css.property "right" "9rem"
@@ -45694,7 +43768,6 @@ right_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_3_dot_5 : Css.Style
 right_3_dot_5 =
     Css.property "right" "0.875rem"
@@ -45705,7 +43778,6 @@ right_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_3over4 : Css.Style
 right_3over4 =
     Css.property "right" "75%"
@@ -45716,7 +43788,6 @@ right_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_4 : Css.Style
 right_4 =
     Css.property "right" "1rem"
@@ -45727,7 +43798,6 @@ right_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_40 : Css.Style
 right_40 =
     Css.property "right" "10rem"
@@ -45738,7 +43808,6 @@ right_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_44 : Css.Style
 right_44 =
     Css.property "right" "11rem"
@@ -45749,7 +43818,6 @@ right_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_48 : Css.Style
 right_48 =
     Css.property "right" "12rem"
@@ -45760,7 +43828,6 @@ right_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_5 : Css.Style
 right_5 =
     Css.property "right" "1.25rem"
@@ -45771,7 +43838,6 @@ right_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_52 : Css.Style
 right_52 =
     Css.property "right" "13rem"
@@ -45782,7 +43848,6 @@ right_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_56 : Css.Style
 right_56 =
     Css.property "right" "14rem"
@@ -45793,7 +43858,6 @@ right_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_6 : Css.Style
 right_6 =
     Css.property "right" "1.5rem"
@@ -45804,7 +43868,6 @@ right_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_60 : Css.Style
 right_60 =
     Css.property "right" "15rem"
@@ -45815,7 +43878,6 @@ right_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_64 : Css.Style
 right_64 =
     Css.property "right" "16rem"
@@ -45826,7 +43888,6 @@ right_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_7 : Css.Style
 right_7 =
     Css.property "right" "1.75rem"
@@ -45837,7 +43898,6 @@ right_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_72 : Css.Style
 right_72 =
     Css.property "right" "18rem"
@@ -45848,7 +43908,6 @@ right_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_8 : Css.Style
 right_8 =
     Css.property "right" "2rem"
@@ -45859,7 +43918,6 @@ right_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_80 : Css.Style
 right_80 =
     Css.property "right" "20rem"
@@ -45870,7 +43928,6 @@ right_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_9 : Css.Style
 right_9 =
     Css.property "right" "2.25rem"
@@ -45881,7 +43938,6 @@ right_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_96 : Css.Style
 right_96 =
     Css.property "right" "24rem"
@@ -45892,7 +43948,6 @@ right_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_auto : Css.Style
 right_auto =
     Css.property "right" "auto"
@@ -45903,7 +43958,6 @@ right_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_full : Css.Style
 right_full =
     Css.property "right" "100%"
@@ -45914,7 +43968,6 @@ right_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 right_px : Css.Style
 right_px =
     Css.property "right" "1px"
@@ -45925,7 +43978,6 @@ right_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring : Css.Style
 ring =
     Css.batch
@@ -45940,7 +43992,6 @@ ring =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_0 : Css.Style
 ring_0 =
     Css.batch
@@ -45955,7 +44006,6 @@ ring_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_1 : Css.Style
 ring_1 =
     Css.batch
@@ -45970,7 +44020,6 @@ ring_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_2 : Css.Style
 ring_2 =
     Css.batch
@@ -45985,7 +44034,6 @@ ring_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_4 : Css.Style
 ring_4 =
     Css.batch
@@ -46000,7 +44048,6 @@ ring_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_8 : Css.Style
 ring_8 =
     Css.batch
@@ -46015,7 +44062,6 @@ ring_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_black : Css.Style
 ring_black =
     Css.batch
@@ -46029,7 +44075,6 @@ ring_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_100 : Css.Style
 ring_blue_100 =
     Css.batch
@@ -46043,7 +44088,6 @@ ring_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_200 : Css.Style
 ring_blue_200 =
     Css.batch
@@ -46057,7 +44101,6 @@ ring_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_300 : Css.Style
 ring_blue_300 =
     Css.batch
@@ -46071,7 +44114,6 @@ ring_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_400 : Css.Style
 ring_blue_400 =
     Css.batch
@@ -46085,7 +44127,6 @@ ring_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_50 : Css.Style
 ring_blue_50 =
     Css.batch
@@ -46099,7 +44140,6 @@ ring_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_500 : Css.Style
 ring_blue_500 =
     Css.batch
@@ -46113,7 +44153,6 @@ ring_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_600 : Css.Style
 ring_blue_600 =
     Css.batch
@@ -46127,7 +44166,6 @@ ring_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_700 : Css.Style
 ring_blue_700 =
     Css.batch
@@ -46141,7 +44179,6 @@ ring_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_800 : Css.Style
 ring_blue_800 =
     Css.batch
@@ -46155,7 +44192,6 @@ ring_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_blue_900 : Css.Style
 ring_blue_900 =
     Css.batch
@@ -46169,7 +44205,6 @@ ring_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_current : Css.Style
 ring_current =
     Css.property "--tw-ring-color" "currentColor"
@@ -46180,7 +44215,6 @@ ring_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_100 : Css.Style
 ring_gray_100 =
     Css.batch
@@ -46194,7 +44228,6 @@ ring_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_200 : Css.Style
 ring_gray_200 =
     Css.batch
@@ -46208,7 +44241,6 @@ ring_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_300 : Css.Style
 ring_gray_300 =
     Css.batch
@@ -46222,7 +44254,6 @@ ring_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_400 : Css.Style
 ring_gray_400 =
     Css.batch
@@ -46236,7 +44267,6 @@ ring_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_50 : Css.Style
 ring_gray_50 =
     Css.batch
@@ -46250,7 +44280,6 @@ ring_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_500 : Css.Style
 ring_gray_500 =
     Css.batch
@@ -46264,7 +44293,6 @@ ring_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_600 : Css.Style
 ring_gray_600 =
     Css.batch
@@ -46278,7 +44306,6 @@ ring_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_700 : Css.Style
 ring_gray_700 =
     Css.batch
@@ -46292,7 +44319,6 @@ ring_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_800 : Css.Style
 ring_gray_800 =
     Css.batch
@@ -46306,7 +44332,6 @@ ring_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_gray_900 : Css.Style
 ring_gray_900 =
     Css.batch
@@ -46320,7 +44345,6 @@ ring_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_100 : Css.Style
 ring_green_100 =
     Css.batch
@@ -46334,7 +44358,6 @@ ring_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_200 : Css.Style
 ring_green_200 =
     Css.batch
@@ -46348,7 +44371,6 @@ ring_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_300 : Css.Style
 ring_green_300 =
     Css.batch
@@ -46362,7 +44384,6 @@ ring_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_400 : Css.Style
 ring_green_400 =
     Css.batch
@@ -46376,7 +44397,6 @@ ring_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_50 : Css.Style
 ring_green_50 =
     Css.batch
@@ -46390,7 +44410,6 @@ ring_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_500 : Css.Style
 ring_green_500 =
     Css.batch
@@ -46404,7 +44423,6 @@ ring_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_600 : Css.Style
 ring_green_600 =
     Css.batch
@@ -46418,7 +44436,6 @@ ring_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_700 : Css.Style
 ring_green_700 =
     Css.batch
@@ -46432,7 +44449,6 @@ ring_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_800 : Css.Style
 ring_green_800 =
     Css.batch
@@ -46446,7 +44462,6 @@ ring_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_green_900 : Css.Style
 ring_green_900 =
     Css.batch
@@ -46460,7 +44475,6 @@ ring_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_100 : Css.Style
 ring_indigo_100 =
     Css.batch
@@ -46474,7 +44488,6 @@ ring_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_200 : Css.Style
 ring_indigo_200 =
     Css.batch
@@ -46488,7 +44501,6 @@ ring_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_300 : Css.Style
 ring_indigo_300 =
     Css.batch
@@ -46502,7 +44514,6 @@ ring_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_400 : Css.Style
 ring_indigo_400 =
     Css.batch
@@ -46516,7 +44527,6 @@ ring_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_50 : Css.Style
 ring_indigo_50 =
     Css.batch
@@ -46530,7 +44540,6 @@ ring_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_500 : Css.Style
 ring_indigo_500 =
     Css.batch
@@ -46544,7 +44553,6 @@ ring_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_600 : Css.Style
 ring_indigo_600 =
     Css.batch
@@ -46558,7 +44566,6 @@ ring_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_700 : Css.Style
 ring_indigo_700 =
     Css.batch
@@ -46572,7 +44579,6 @@ ring_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_800 : Css.Style
 ring_indigo_800 =
     Css.batch
@@ -46586,7 +44592,6 @@ ring_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_indigo_900 : Css.Style
 ring_indigo_900 =
     Css.batch
@@ -46600,7 +44605,6 @@ ring_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_inset : Css.Style
 ring_inset =
     Css.property "--tw-ring-inset" "inset"
@@ -46611,7 +44615,6 @@ ring_inset =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_0 : Css.Style
 ring_offset_0 =
     Css.property "--tw-ring-offset-width" "0px"
@@ -46622,7 +44625,6 @@ ring_offset_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_1 : Css.Style
 ring_offset_1 =
     Css.property "--tw-ring-offset-width" "1px"
@@ -46633,7 +44635,6 @@ ring_offset_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_2 : Css.Style
 ring_offset_2 =
     Css.property "--tw-ring-offset-width" "2px"
@@ -46644,7 +44645,6 @@ ring_offset_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_4 : Css.Style
 ring_offset_4 =
     Css.property "--tw-ring-offset-width" "4px"
@@ -46655,7 +44655,6 @@ ring_offset_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_8 : Css.Style
 ring_offset_8 =
     Css.property "--tw-ring-offset-width" "8px"
@@ -46666,7 +44665,6 @@ ring_offset_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_black : Css.Style
 ring_offset_black =
     Css.property "--tw-ring-offset-color" "#000"
@@ -46677,7 +44675,6 @@ ring_offset_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_100 : Css.Style
 ring_offset_blue_100 =
     Css.property "--tw-ring-offset-color" "#dbeafe"
@@ -46688,7 +44685,6 @@ ring_offset_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_200 : Css.Style
 ring_offset_blue_200 =
     Css.property "--tw-ring-offset-color" "#bfdbfe"
@@ -46699,7 +44695,6 @@ ring_offset_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_300 : Css.Style
 ring_offset_blue_300 =
     Css.property "--tw-ring-offset-color" "#93c5fd"
@@ -46710,7 +44705,6 @@ ring_offset_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_400 : Css.Style
 ring_offset_blue_400 =
     Css.property "--tw-ring-offset-color" "#60a5fa"
@@ -46721,7 +44715,6 @@ ring_offset_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_50 : Css.Style
 ring_offset_blue_50 =
     Css.property "--tw-ring-offset-color" "#eff6ff"
@@ -46732,7 +44725,6 @@ ring_offset_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_500 : Css.Style
 ring_offset_blue_500 =
     Css.property "--tw-ring-offset-color" "#3b82f6"
@@ -46743,7 +44735,6 @@ ring_offset_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_600 : Css.Style
 ring_offset_blue_600 =
     Css.property "--tw-ring-offset-color" "#2563eb"
@@ -46754,7 +44745,6 @@ ring_offset_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_700 : Css.Style
 ring_offset_blue_700 =
     Css.property "--tw-ring-offset-color" "#1d4ed8"
@@ -46765,7 +44755,6 @@ ring_offset_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_800 : Css.Style
 ring_offset_blue_800 =
     Css.property "--tw-ring-offset-color" "#1e40af"
@@ -46776,7 +44765,6 @@ ring_offset_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_blue_900 : Css.Style
 ring_offset_blue_900 =
     Css.property "--tw-ring-offset-color" "#1e3a8a"
@@ -46787,7 +44775,6 @@ ring_offset_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_current : Css.Style
 ring_offset_current =
     Css.property "--tw-ring-offset-color" "currentColor"
@@ -46798,7 +44785,6 @@ ring_offset_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_100 : Css.Style
 ring_offset_gray_100 =
     Css.property "--tw-ring-offset-color" "#f3f4f6"
@@ -46809,7 +44795,6 @@ ring_offset_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_200 : Css.Style
 ring_offset_gray_200 =
     Css.property "--tw-ring-offset-color" "#e5e7eb"
@@ -46820,7 +44805,6 @@ ring_offset_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_300 : Css.Style
 ring_offset_gray_300 =
     Css.property "--tw-ring-offset-color" "#d1d5db"
@@ -46831,7 +44815,6 @@ ring_offset_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_400 : Css.Style
 ring_offset_gray_400 =
     Css.property "--tw-ring-offset-color" "#9ca3af"
@@ -46842,7 +44825,6 @@ ring_offset_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_50 : Css.Style
 ring_offset_gray_50 =
     Css.property "--tw-ring-offset-color" "#f9fafb"
@@ -46853,7 +44835,6 @@ ring_offset_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_500 : Css.Style
 ring_offset_gray_500 =
     Css.property "--tw-ring-offset-color" "#6b7280"
@@ -46864,7 +44845,6 @@ ring_offset_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_600 : Css.Style
 ring_offset_gray_600 =
     Css.property "--tw-ring-offset-color" "#4b5563"
@@ -46875,7 +44855,6 @@ ring_offset_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_700 : Css.Style
 ring_offset_gray_700 =
     Css.property "--tw-ring-offset-color" "#374151"
@@ -46886,7 +44865,6 @@ ring_offset_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_800 : Css.Style
 ring_offset_gray_800 =
     Css.property "--tw-ring-offset-color" "#1f2937"
@@ -46897,7 +44875,6 @@ ring_offset_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_gray_900 : Css.Style
 ring_offset_gray_900 =
     Css.property "--tw-ring-offset-color" "#111827"
@@ -46908,7 +44885,6 @@ ring_offset_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_100 : Css.Style
 ring_offset_green_100 =
     Css.property "--tw-ring-offset-color" "#d1fae5"
@@ -46919,7 +44895,6 @@ ring_offset_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_200 : Css.Style
 ring_offset_green_200 =
     Css.property "--tw-ring-offset-color" "#a7f3d0"
@@ -46930,7 +44905,6 @@ ring_offset_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_300 : Css.Style
 ring_offset_green_300 =
     Css.property "--tw-ring-offset-color" "#6ee7b7"
@@ -46941,7 +44915,6 @@ ring_offset_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_400 : Css.Style
 ring_offset_green_400 =
     Css.property "--tw-ring-offset-color" "#34d399"
@@ -46952,7 +44925,6 @@ ring_offset_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_50 : Css.Style
 ring_offset_green_50 =
     Css.property "--tw-ring-offset-color" "#ecfdf5"
@@ -46963,7 +44935,6 @@ ring_offset_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_500 : Css.Style
 ring_offset_green_500 =
     Css.property "--tw-ring-offset-color" "#10b981"
@@ -46974,7 +44945,6 @@ ring_offset_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_600 : Css.Style
 ring_offset_green_600 =
     Css.property "--tw-ring-offset-color" "#059669"
@@ -46985,7 +44955,6 @@ ring_offset_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_700 : Css.Style
 ring_offset_green_700 =
     Css.property "--tw-ring-offset-color" "#047857"
@@ -46996,7 +44965,6 @@ ring_offset_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_800 : Css.Style
 ring_offset_green_800 =
     Css.property "--tw-ring-offset-color" "#065f46"
@@ -47007,7 +44975,6 @@ ring_offset_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_green_900 : Css.Style
 ring_offset_green_900 =
     Css.property "--tw-ring-offset-color" "#064e3b"
@@ -47018,7 +44985,6 @@ ring_offset_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_100 : Css.Style
 ring_offset_indigo_100 =
     Css.property "--tw-ring-offset-color" "#e0e7ff"
@@ -47029,7 +44995,6 @@ ring_offset_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_200 : Css.Style
 ring_offset_indigo_200 =
     Css.property "--tw-ring-offset-color" "#c7d2fe"
@@ -47040,7 +45005,6 @@ ring_offset_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_300 : Css.Style
 ring_offset_indigo_300 =
     Css.property "--tw-ring-offset-color" "#a5b4fc"
@@ -47051,7 +45015,6 @@ ring_offset_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_400 : Css.Style
 ring_offset_indigo_400 =
     Css.property "--tw-ring-offset-color" "#818cf8"
@@ -47062,7 +45025,6 @@ ring_offset_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_50 : Css.Style
 ring_offset_indigo_50 =
     Css.property "--tw-ring-offset-color" "#eef2ff"
@@ -47073,7 +45035,6 @@ ring_offset_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_500 : Css.Style
 ring_offset_indigo_500 =
     Css.property "--tw-ring-offset-color" "#6366f1"
@@ -47084,7 +45045,6 @@ ring_offset_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_600 : Css.Style
 ring_offset_indigo_600 =
     Css.property "--tw-ring-offset-color" "#4f46e5"
@@ -47095,7 +45055,6 @@ ring_offset_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_700 : Css.Style
 ring_offset_indigo_700 =
     Css.property "--tw-ring-offset-color" "#4338ca"
@@ -47106,7 +45065,6 @@ ring_offset_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_800 : Css.Style
 ring_offset_indigo_800 =
     Css.property "--tw-ring-offset-color" "#3730a3"
@@ -47117,7 +45075,6 @@ ring_offset_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_indigo_900 : Css.Style
 ring_offset_indigo_900 =
     Css.property "--tw-ring-offset-color" "#312e81"
@@ -47128,7 +45085,6 @@ ring_offset_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_100 : Css.Style
 ring_offset_pink_100 =
     Css.property "--tw-ring-offset-color" "#fce7f3"
@@ -47139,7 +45095,6 @@ ring_offset_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_200 : Css.Style
 ring_offset_pink_200 =
     Css.property "--tw-ring-offset-color" "#fbcfe8"
@@ -47150,7 +45105,6 @@ ring_offset_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_300 : Css.Style
 ring_offset_pink_300 =
     Css.property "--tw-ring-offset-color" "#f9a8d4"
@@ -47161,7 +45115,6 @@ ring_offset_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_400 : Css.Style
 ring_offset_pink_400 =
     Css.property "--tw-ring-offset-color" "#f472b6"
@@ -47172,7 +45125,6 @@ ring_offset_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_50 : Css.Style
 ring_offset_pink_50 =
     Css.property "--tw-ring-offset-color" "#fdf2f8"
@@ -47183,7 +45135,6 @@ ring_offset_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_500 : Css.Style
 ring_offset_pink_500 =
     Css.property "--tw-ring-offset-color" "#ec4899"
@@ -47194,7 +45145,6 @@ ring_offset_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_600 : Css.Style
 ring_offset_pink_600 =
     Css.property "--tw-ring-offset-color" "#db2777"
@@ -47205,7 +45155,6 @@ ring_offset_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_700 : Css.Style
 ring_offset_pink_700 =
     Css.property "--tw-ring-offset-color" "#be185d"
@@ -47216,7 +45165,6 @@ ring_offset_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_800 : Css.Style
 ring_offset_pink_800 =
     Css.property "--tw-ring-offset-color" "#9d174d"
@@ -47227,7 +45175,6 @@ ring_offset_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_pink_900 : Css.Style
 ring_offset_pink_900 =
     Css.property "--tw-ring-offset-color" "#831843"
@@ -47238,7 +45185,6 @@ ring_offset_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_100 : Css.Style
 ring_offset_purple_100 =
     Css.property "--tw-ring-offset-color" "#ede9fe"
@@ -47249,7 +45195,6 @@ ring_offset_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_200 : Css.Style
 ring_offset_purple_200 =
     Css.property "--tw-ring-offset-color" "#ddd6fe"
@@ -47260,7 +45205,6 @@ ring_offset_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_300 : Css.Style
 ring_offset_purple_300 =
     Css.property "--tw-ring-offset-color" "#c4b5fd"
@@ -47271,7 +45215,6 @@ ring_offset_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_400 : Css.Style
 ring_offset_purple_400 =
     Css.property "--tw-ring-offset-color" "#a78bfa"
@@ -47282,7 +45225,6 @@ ring_offset_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_50 : Css.Style
 ring_offset_purple_50 =
     Css.property "--tw-ring-offset-color" "#f5f3ff"
@@ -47293,7 +45235,6 @@ ring_offset_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_500 : Css.Style
 ring_offset_purple_500 =
     Css.property "--tw-ring-offset-color" "#8b5cf6"
@@ -47304,7 +45245,6 @@ ring_offset_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_600 : Css.Style
 ring_offset_purple_600 =
     Css.property "--tw-ring-offset-color" "#7c3aed"
@@ -47315,7 +45255,6 @@ ring_offset_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_700 : Css.Style
 ring_offset_purple_700 =
     Css.property "--tw-ring-offset-color" "#6d28d9"
@@ -47326,7 +45265,6 @@ ring_offset_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_800 : Css.Style
 ring_offset_purple_800 =
     Css.property "--tw-ring-offset-color" "#5b21b6"
@@ -47337,7 +45275,6 @@ ring_offset_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_purple_900 : Css.Style
 ring_offset_purple_900 =
     Css.property "--tw-ring-offset-color" "#4c1d95"
@@ -47348,7 +45285,6 @@ ring_offset_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_100 : Css.Style
 ring_offset_red_100 =
     Css.property "--tw-ring-offset-color" "#fee2e2"
@@ -47359,7 +45295,6 @@ ring_offset_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_200 : Css.Style
 ring_offset_red_200 =
     Css.property "--tw-ring-offset-color" "#fecaca"
@@ -47370,7 +45305,6 @@ ring_offset_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_300 : Css.Style
 ring_offset_red_300 =
     Css.property "--tw-ring-offset-color" "#fca5a5"
@@ -47381,7 +45315,6 @@ ring_offset_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_400 : Css.Style
 ring_offset_red_400 =
     Css.property "--tw-ring-offset-color" "#f87171"
@@ -47392,7 +45325,6 @@ ring_offset_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_50 : Css.Style
 ring_offset_red_50 =
     Css.property "--tw-ring-offset-color" "#fef2f2"
@@ -47403,7 +45335,6 @@ ring_offset_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_500 : Css.Style
 ring_offset_red_500 =
     Css.property "--tw-ring-offset-color" "#ef4444"
@@ -47414,7 +45345,6 @@ ring_offset_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_600 : Css.Style
 ring_offset_red_600 =
     Css.property "--tw-ring-offset-color" "#dc2626"
@@ -47425,7 +45355,6 @@ ring_offset_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_700 : Css.Style
 ring_offset_red_700 =
     Css.property "--tw-ring-offset-color" "#b91c1c"
@@ -47436,7 +45365,6 @@ ring_offset_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_800 : Css.Style
 ring_offset_red_800 =
     Css.property "--tw-ring-offset-color" "#991b1b"
@@ -47447,7 +45375,6 @@ ring_offset_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_red_900 : Css.Style
 ring_offset_red_900 =
     Css.property "--tw-ring-offset-color" "#7f1d1d"
@@ -47458,7 +45385,6 @@ ring_offset_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_transparent : Css.Style
 ring_offset_transparent =
     Css.property "--tw-ring-offset-color" "transparent"
@@ -47469,7 +45395,6 @@ ring_offset_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_white : Css.Style
 ring_offset_white =
     Css.property "--tw-ring-offset-color" "#fff"
@@ -47480,7 +45405,6 @@ ring_offset_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_100 : Css.Style
 ring_offset_yellow_100 =
     Css.property "--tw-ring-offset-color" "#fef3c7"
@@ -47491,7 +45415,6 @@ ring_offset_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_200 : Css.Style
 ring_offset_yellow_200 =
     Css.property "--tw-ring-offset-color" "#fde68a"
@@ -47502,7 +45425,6 @@ ring_offset_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_300 : Css.Style
 ring_offset_yellow_300 =
     Css.property "--tw-ring-offset-color" "#fcd34d"
@@ -47513,7 +45435,6 @@ ring_offset_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_400 : Css.Style
 ring_offset_yellow_400 =
     Css.property "--tw-ring-offset-color" "#fbbf24"
@@ -47524,7 +45445,6 @@ ring_offset_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_50 : Css.Style
 ring_offset_yellow_50 =
     Css.property "--tw-ring-offset-color" "#fffbeb"
@@ -47535,7 +45455,6 @@ ring_offset_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_500 : Css.Style
 ring_offset_yellow_500 =
     Css.property "--tw-ring-offset-color" "#f59e0b"
@@ -47546,7 +45465,6 @@ ring_offset_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_600 : Css.Style
 ring_offset_yellow_600 =
     Css.property "--tw-ring-offset-color" "#d97706"
@@ -47557,7 +45475,6 @@ ring_offset_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_700 : Css.Style
 ring_offset_yellow_700 =
     Css.property "--tw-ring-offset-color" "#b45309"
@@ -47568,7 +45485,6 @@ ring_offset_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_800 : Css.Style
 ring_offset_yellow_800 =
     Css.property "--tw-ring-offset-color" "#92400e"
@@ -47579,7 +45495,6 @@ ring_offset_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_offset_yellow_900 : Css.Style
 ring_offset_yellow_900 =
     Css.property "--tw-ring-offset-color" "#78350f"
@@ -47590,7 +45505,6 @@ ring_offset_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_0 : Css.Style
 ring_opacity_0 =
     Css.property "--tw-ring-opacity" "0"
@@ -47601,7 +45515,6 @@ ring_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_10 : Css.Style
 ring_opacity_10 =
     Css.property "--tw-ring-opacity" "0.1"
@@ -47612,7 +45525,6 @@ ring_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_100 : Css.Style
 ring_opacity_100 =
     Css.property "--tw-ring-opacity" "1"
@@ -47623,7 +45535,6 @@ ring_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_20 : Css.Style
 ring_opacity_20 =
     Css.property "--tw-ring-opacity" "0.2"
@@ -47634,7 +45545,6 @@ ring_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_25 : Css.Style
 ring_opacity_25 =
     Css.property "--tw-ring-opacity" "0.25"
@@ -47645,7 +45555,6 @@ ring_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_30 : Css.Style
 ring_opacity_30 =
     Css.property "--tw-ring-opacity" "0.3"
@@ -47656,7 +45565,6 @@ ring_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_40 : Css.Style
 ring_opacity_40 =
     Css.property "--tw-ring-opacity" "0.4"
@@ -47667,7 +45575,6 @@ ring_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_5 : Css.Style
 ring_opacity_5 =
     Css.property "--tw-ring-opacity" "0.05"
@@ -47678,7 +45585,6 @@ ring_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_50 : Css.Style
 ring_opacity_50 =
     Css.property "--tw-ring-opacity" "0.5"
@@ -47689,7 +45595,6 @@ ring_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_60 : Css.Style
 ring_opacity_60 =
     Css.property "--tw-ring-opacity" "0.6"
@@ -47700,7 +45605,6 @@ ring_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_70 : Css.Style
 ring_opacity_70 =
     Css.property "--tw-ring-opacity" "0.7"
@@ -47711,7 +45615,6 @@ ring_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_75 : Css.Style
 ring_opacity_75 =
     Css.property "--tw-ring-opacity" "0.75"
@@ -47722,7 +45625,6 @@ ring_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_80 : Css.Style
 ring_opacity_80 =
     Css.property "--tw-ring-opacity" "0.8"
@@ -47733,7 +45635,6 @@ ring_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_90 : Css.Style
 ring_opacity_90 =
     Css.property "--tw-ring-opacity" "0.9"
@@ -47744,7 +45645,6 @@ ring_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_opacity_95 : Css.Style
 ring_opacity_95 =
     Css.property "--tw-ring-opacity" "0.95"
@@ -47755,7 +45655,6 @@ ring_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_100 : Css.Style
 ring_pink_100 =
     Css.batch
@@ -47769,7 +45668,6 @@ ring_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_200 : Css.Style
 ring_pink_200 =
     Css.batch
@@ -47783,7 +45681,6 @@ ring_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_300 : Css.Style
 ring_pink_300 =
     Css.batch
@@ -47797,7 +45694,6 @@ ring_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_400 : Css.Style
 ring_pink_400 =
     Css.batch
@@ -47811,7 +45707,6 @@ ring_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_50 : Css.Style
 ring_pink_50 =
     Css.batch
@@ -47825,7 +45720,6 @@ ring_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_500 : Css.Style
 ring_pink_500 =
     Css.batch
@@ -47839,7 +45733,6 @@ ring_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_600 : Css.Style
 ring_pink_600 =
     Css.batch
@@ -47853,7 +45746,6 @@ ring_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_700 : Css.Style
 ring_pink_700 =
     Css.batch
@@ -47867,7 +45759,6 @@ ring_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_800 : Css.Style
 ring_pink_800 =
     Css.batch
@@ -47881,7 +45772,6 @@ ring_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_pink_900 : Css.Style
 ring_pink_900 =
     Css.batch
@@ -47895,7 +45785,6 @@ ring_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_100 : Css.Style
 ring_purple_100 =
     Css.batch
@@ -47909,7 +45798,6 @@ ring_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_200 : Css.Style
 ring_purple_200 =
     Css.batch
@@ -47923,7 +45811,6 @@ ring_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_300 : Css.Style
 ring_purple_300 =
     Css.batch
@@ -47937,7 +45824,6 @@ ring_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_400 : Css.Style
 ring_purple_400 =
     Css.batch
@@ -47951,7 +45837,6 @@ ring_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_50 : Css.Style
 ring_purple_50 =
     Css.batch
@@ -47965,7 +45850,6 @@ ring_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_500 : Css.Style
 ring_purple_500 =
     Css.batch
@@ -47979,7 +45863,6 @@ ring_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_600 : Css.Style
 ring_purple_600 =
     Css.batch
@@ -47993,7 +45876,6 @@ ring_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_700 : Css.Style
 ring_purple_700 =
     Css.batch
@@ -48007,7 +45889,6 @@ ring_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_800 : Css.Style
 ring_purple_800 =
     Css.batch
@@ -48021,7 +45902,6 @@ ring_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_purple_900 : Css.Style
 ring_purple_900 =
     Css.batch
@@ -48035,7 +45915,6 @@ ring_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_100 : Css.Style
 ring_red_100 =
     Css.batch
@@ -48049,7 +45928,6 @@ ring_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_200 : Css.Style
 ring_red_200 =
     Css.batch
@@ -48063,7 +45941,6 @@ ring_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_300 : Css.Style
 ring_red_300 =
     Css.batch
@@ -48077,7 +45954,6 @@ ring_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_400 : Css.Style
 ring_red_400 =
     Css.batch
@@ -48091,7 +45967,6 @@ ring_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_50 : Css.Style
 ring_red_50 =
     Css.batch
@@ -48105,7 +45980,6 @@ ring_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_500 : Css.Style
 ring_red_500 =
     Css.batch
@@ -48119,7 +45993,6 @@ ring_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_600 : Css.Style
 ring_red_600 =
     Css.batch
@@ -48133,7 +46006,6 @@ ring_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_700 : Css.Style
 ring_red_700 =
     Css.batch
@@ -48147,7 +46019,6 @@ ring_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_800 : Css.Style
 ring_red_800 =
     Css.batch
@@ -48161,7 +46032,6 @@ ring_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_red_900 : Css.Style
 ring_red_900 =
     Css.batch
@@ -48175,7 +46045,6 @@ ring_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_transparent : Css.Style
 ring_transparent =
     Css.property "--tw-ring-color" "transparent"
@@ -48186,7 +46055,6 @@ ring_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_white : Css.Style
 ring_white =
     Css.batch
@@ -48200,7 +46068,6 @@ ring_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_100 : Css.Style
 ring_yellow_100 =
     Css.batch
@@ -48214,7 +46081,6 @@ ring_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_200 : Css.Style
 ring_yellow_200 =
     Css.batch
@@ -48228,7 +46094,6 @@ ring_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_300 : Css.Style
 ring_yellow_300 =
     Css.batch
@@ -48242,7 +46107,6 @@ ring_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_400 : Css.Style
 ring_yellow_400 =
     Css.batch
@@ -48256,7 +46120,6 @@ ring_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_50 : Css.Style
 ring_yellow_50 =
     Css.batch
@@ -48270,7 +46133,6 @@ ring_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_500 : Css.Style
 ring_yellow_500 =
     Css.batch
@@ -48284,7 +46146,6 @@ ring_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_600 : Css.Style
 ring_yellow_600 =
     Css.batch
@@ -48298,7 +46159,6 @@ ring_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_700 : Css.Style
 ring_yellow_700 =
     Css.batch
@@ -48312,7 +46172,6 @@ ring_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_800 : Css.Style
 ring_yellow_800 =
     Css.batch
@@ -48326,7 +46185,6 @@ ring_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 ring_yellow_900 : Css.Style
 ring_yellow_900 =
     Css.batch
@@ -48340,7 +46198,6 @@ ring_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_0 : Css.Style
 rotate_0 =
     Css.property "--tw-rotate" "0deg"
@@ -48351,7 +46208,6 @@ rotate_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_1 : Css.Style
 rotate_1 =
     Css.property "--tw-rotate" "1deg"
@@ -48362,7 +46218,6 @@ rotate_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_12 : Css.Style
 rotate_12 =
     Css.property "--tw-rotate" "12deg"
@@ -48373,7 +46228,6 @@ rotate_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_180 : Css.Style
 rotate_180 =
     Css.property "--tw-rotate" "180deg"
@@ -48384,7 +46238,6 @@ rotate_180 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_2 : Css.Style
 rotate_2 =
     Css.property "--tw-rotate" "2deg"
@@ -48395,7 +46248,6 @@ rotate_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_3 : Css.Style
 rotate_3 =
     Css.property "--tw-rotate" "3deg"
@@ -48406,7 +46258,6 @@ rotate_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_45 : Css.Style
 rotate_45 =
     Css.property "--tw-rotate" "45deg"
@@ -48417,7 +46268,6 @@ rotate_45 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_6 : Css.Style
 rotate_6 =
     Css.property "--tw-rotate" "6deg"
@@ -48428,7 +46278,6 @@ rotate_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rotate_90 : Css.Style
 rotate_90 =
     Css.property "--tw-rotate" "90deg"
@@ -48439,7 +46288,6 @@ rotate_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded : Css.Style
 rounded =
     Css.property "border-radius" "0.25rem"
@@ -48450,7 +46298,6 @@ rounded =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_2xl : Css.Style
 rounded_2xl =
     Css.property "border-radius" "1rem"
@@ -48461,7 +46308,6 @@ rounded_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_3xl : Css.Style
 rounded_3xl =
     Css.property "border-radius" "1.5rem"
@@ -48472,7 +46318,6 @@ rounded_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b : Css.Style
 rounded_b =
     Css.batch
@@ -48486,7 +46331,6 @@ rounded_b =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_2xl : Css.Style
 rounded_b_2xl =
     Css.batch
@@ -48500,7 +46344,6 @@ rounded_b_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_3xl : Css.Style
 rounded_b_3xl =
     Css.batch
@@ -48514,7 +46357,6 @@ rounded_b_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_full : Css.Style
 rounded_b_full =
     Css.batch
@@ -48528,7 +46370,6 @@ rounded_b_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_lg : Css.Style
 rounded_b_lg =
     Css.batch
@@ -48542,7 +46383,6 @@ rounded_b_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_md : Css.Style
 rounded_b_md =
     Css.batch
@@ -48556,7 +46396,6 @@ rounded_b_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_none : Css.Style
 rounded_b_none =
     Css.batch
@@ -48570,7 +46409,6 @@ rounded_b_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_sm : Css.Style
 rounded_b_sm =
     Css.batch
@@ -48584,7 +46422,6 @@ rounded_b_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_b_xl : Css.Style
 rounded_b_xl =
     Css.batch
@@ -48598,7 +46435,6 @@ rounded_b_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl : Css.Style
 rounded_bl =
     Css.property "border-bottom-left-radius" "0.25rem"
@@ -48609,7 +46445,6 @@ rounded_bl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_2xl : Css.Style
 rounded_bl_2xl =
     Css.property "border-bottom-left-radius" "1rem"
@@ -48620,7 +46455,6 @@ rounded_bl_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_3xl : Css.Style
 rounded_bl_3xl =
     Css.property "border-bottom-left-radius" "1.5rem"
@@ -48631,7 +46465,6 @@ rounded_bl_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_full : Css.Style
 rounded_bl_full =
     Css.property "border-bottom-left-radius" "9999px"
@@ -48642,7 +46475,6 @@ rounded_bl_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_lg : Css.Style
 rounded_bl_lg =
     Css.property "border-bottom-left-radius" "0.5rem"
@@ -48653,7 +46485,6 @@ rounded_bl_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_md : Css.Style
 rounded_bl_md =
     Css.property "border-bottom-left-radius" "0.375rem"
@@ -48664,7 +46495,6 @@ rounded_bl_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_none : Css.Style
 rounded_bl_none =
     Css.property "border-bottom-left-radius" "0px"
@@ -48675,7 +46505,6 @@ rounded_bl_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_sm : Css.Style
 rounded_bl_sm =
     Css.property "border-bottom-left-radius" "0.125rem"
@@ -48686,7 +46515,6 @@ rounded_bl_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_bl_xl : Css.Style
 rounded_bl_xl =
     Css.property "border-bottom-left-radius" "0.75rem"
@@ -48697,7 +46525,6 @@ rounded_bl_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br : Css.Style
 rounded_br =
     Css.property "border-bottom-right-radius" "0.25rem"
@@ -48708,7 +46535,6 @@ rounded_br =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_2xl : Css.Style
 rounded_br_2xl =
     Css.property "border-bottom-right-radius" "1rem"
@@ -48719,7 +46545,6 @@ rounded_br_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_3xl : Css.Style
 rounded_br_3xl =
     Css.property "border-bottom-right-radius" "1.5rem"
@@ -48730,7 +46555,6 @@ rounded_br_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_full : Css.Style
 rounded_br_full =
     Css.property "border-bottom-right-radius" "9999px"
@@ -48741,7 +46565,6 @@ rounded_br_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_lg : Css.Style
 rounded_br_lg =
     Css.property "border-bottom-right-radius" "0.5rem"
@@ -48752,7 +46575,6 @@ rounded_br_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_md : Css.Style
 rounded_br_md =
     Css.property "border-bottom-right-radius" "0.375rem"
@@ -48763,7 +46585,6 @@ rounded_br_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_none : Css.Style
 rounded_br_none =
     Css.property "border-bottom-right-radius" "0px"
@@ -48774,7 +46595,6 @@ rounded_br_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_sm : Css.Style
 rounded_br_sm =
     Css.property "border-bottom-right-radius" "0.125rem"
@@ -48785,7 +46605,6 @@ rounded_br_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_br_xl : Css.Style
 rounded_br_xl =
     Css.property "border-bottom-right-radius" "0.75rem"
@@ -48796,7 +46615,6 @@ rounded_br_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_full : Css.Style
 rounded_full =
     Css.property "border-radius" "9999px"
@@ -48807,7 +46625,6 @@ rounded_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l : Css.Style
 rounded_l =
     Css.batch
@@ -48821,7 +46638,6 @@ rounded_l =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_2xl : Css.Style
 rounded_l_2xl =
     Css.batch
@@ -48835,7 +46651,6 @@ rounded_l_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_3xl : Css.Style
 rounded_l_3xl =
     Css.batch
@@ -48849,7 +46664,6 @@ rounded_l_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_full : Css.Style
 rounded_l_full =
     Css.batch
@@ -48863,7 +46677,6 @@ rounded_l_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_lg : Css.Style
 rounded_l_lg =
     Css.batch
@@ -48877,7 +46690,6 @@ rounded_l_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_md : Css.Style
 rounded_l_md =
     Css.batch
@@ -48891,7 +46703,6 @@ rounded_l_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_none : Css.Style
 rounded_l_none =
     Css.batch
@@ -48905,7 +46716,6 @@ rounded_l_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_sm : Css.Style
 rounded_l_sm =
     Css.batch
@@ -48919,7 +46729,6 @@ rounded_l_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_l_xl : Css.Style
 rounded_l_xl =
     Css.batch
@@ -48933,7 +46742,6 @@ rounded_l_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_lg : Css.Style
 rounded_lg =
     Css.property "border-radius" "0.5rem"
@@ -48944,7 +46752,6 @@ rounded_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_md : Css.Style
 rounded_md =
     Css.property "border-radius" "0.375rem"
@@ -48955,7 +46762,6 @@ rounded_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_none : Css.Style
 rounded_none =
     Css.property "border-radius" "0px"
@@ -48966,7 +46772,6 @@ rounded_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r : Css.Style
 rounded_r =
     Css.batch
@@ -48980,7 +46785,6 @@ rounded_r =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_2xl : Css.Style
 rounded_r_2xl =
     Css.batch
@@ -48994,7 +46798,6 @@ rounded_r_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_3xl : Css.Style
 rounded_r_3xl =
     Css.batch
@@ -49008,7 +46811,6 @@ rounded_r_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_full : Css.Style
 rounded_r_full =
     Css.batch
@@ -49022,7 +46824,6 @@ rounded_r_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_lg : Css.Style
 rounded_r_lg =
     Css.batch
@@ -49036,7 +46837,6 @@ rounded_r_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_md : Css.Style
 rounded_r_md =
     Css.batch
@@ -49050,7 +46850,6 @@ rounded_r_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_none : Css.Style
 rounded_r_none =
     Css.batch
@@ -49064,7 +46863,6 @@ rounded_r_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_sm : Css.Style
 rounded_r_sm =
     Css.batch
@@ -49078,7 +46876,6 @@ rounded_r_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_r_xl : Css.Style
 rounded_r_xl =
     Css.batch
@@ -49092,7 +46889,6 @@ rounded_r_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_sm : Css.Style
 rounded_sm =
     Css.property "border-radius" "0.125rem"
@@ -49103,7 +46899,6 @@ rounded_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t : Css.Style
 rounded_t =
     Css.batch
@@ -49117,7 +46912,6 @@ rounded_t =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_2xl : Css.Style
 rounded_t_2xl =
     Css.batch
@@ -49131,7 +46925,6 @@ rounded_t_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_3xl : Css.Style
 rounded_t_3xl =
     Css.batch
@@ -49145,7 +46938,6 @@ rounded_t_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_full : Css.Style
 rounded_t_full =
     Css.batch
@@ -49159,7 +46951,6 @@ rounded_t_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_lg : Css.Style
 rounded_t_lg =
     Css.batch
@@ -49173,7 +46964,6 @@ rounded_t_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_md : Css.Style
 rounded_t_md =
     Css.batch
@@ -49187,7 +46977,6 @@ rounded_t_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_none : Css.Style
 rounded_t_none =
     Css.batch
@@ -49201,7 +46990,6 @@ rounded_t_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_sm : Css.Style
 rounded_t_sm =
     Css.batch
@@ -49215,7 +47003,6 @@ rounded_t_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_t_xl : Css.Style
 rounded_t_xl =
     Css.batch
@@ -49229,7 +47016,6 @@ rounded_t_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl : Css.Style
 rounded_tl =
     Css.property "border-top-left-radius" "0.25rem"
@@ -49240,7 +47026,6 @@ rounded_tl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_2xl : Css.Style
 rounded_tl_2xl =
     Css.property "border-top-left-radius" "1rem"
@@ -49251,7 +47036,6 @@ rounded_tl_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_3xl : Css.Style
 rounded_tl_3xl =
     Css.property "border-top-left-radius" "1.5rem"
@@ -49262,7 +47046,6 @@ rounded_tl_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_full : Css.Style
 rounded_tl_full =
     Css.property "border-top-left-radius" "9999px"
@@ -49273,7 +47056,6 @@ rounded_tl_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_lg : Css.Style
 rounded_tl_lg =
     Css.property "border-top-left-radius" "0.5rem"
@@ -49284,7 +47066,6 @@ rounded_tl_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_md : Css.Style
 rounded_tl_md =
     Css.property "border-top-left-radius" "0.375rem"
@@ -49295,7 +47076,6 @@ rounded_tl_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_none : Css.Style
 rounded_tl_none =
     Css.property "border-top-left-radius" "0px"
@@ -49306,7 +47086,6 @@ rounded_tl_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_sm : Css.Style
 rounded_tl_sm =
     Css.property "border-top-left-radius" "0.125rem"
@@ -49317,7 +47096,6 @@ rounded_tl_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tl_xl : Css.Style
 rounded_tl_xl =
     Css.property "border-top-left-radius" "0.75rem"
@@ -49328,7 +47106,6 @@ rounded_tl_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr : Css.Style
 rounded_tr =
     Css.property "border-top-right-radius" "0.25rem"
@@ -49339,7 +47116,6 @@ rounded_tr =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_2xl : Css.Style
 rounded_tr_2xl =
     Css.property "border-top-right-radius" "1rem"
@@ -49350,7 +47126,6 @@ rounded_tr_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_3xl : Css.Style
 rounded_tr_3xl =
     Css.property "border-top-right-radius" "1.5rem"
@@ -49361,7 +47136,6 @@ rounded_tr_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_full : Css.Style
 rounded_tr_full =
     Css.property "border-top-right-radius" "9999px"
@@ -49372,7 +47146,6 @@ rounded_tr_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_lg : Css.Style
 rounded_tr_lg =
     Css.property "border-top-right-radius" "0.5rem"
@@ -49383,7 +47156,6 @@ rounded_tr_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_md : Css.Style
 rounded_tr_md =
     Css.property "border-top-right-radius" "0.375rem"
@@ -49394,7 +47166,6 @@ rounded_tr_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_none : Css.Style
 rounded_tr_none =
     Css.property "border-top-right-radius" "0px"
@@ -49405,7 +47176,6 @@ rounded_tr_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_sm : Css.Style
 rounded_tr_sm =
     Css.property "border-top-right-radius" "0.125rem"
@@ -49416,7 +47186,6 @@ rounded_tr_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_tr_xl : Css.Style
 rounded_tr_xl =
     Css.property "border-top-right-radius" "0.75rem"
@@ -49427,7 +47196,6 @@ rounded_tr_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 rounded_xl : Css.Style
 rounded_xl =
     Css.property "border-radius" "0.75rem"
@@ -49438,7 +47206,6 @@ rounded_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_auto : Css.Style
 row_auto =
     Css.property "grid-row" "auto"
@@ -49449,7 +47216,6 @@ row_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_1 : Css.Style
 row_end_1 =
     Css.property "grid-row-end" "1"
@@ -49460,7 +47226,6 @@ row_end_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_2 : Css.Style
 row_end_2 =
     Css.property "grid-row-end" "2"
@@ -49471,7 +47236,6 @@ row_end_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_3 : Css.Style
 row_end_3 =
     Css.property "grid-row-end" "3"
@@ -49482,7 +47246,6 @@ row_end_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_4 : Css.Style
 row_end_4 =
     Css.property "grid-row-end" "4"
@@ -49493,7 +47256,6 @@ row_end_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_5 : Css.Style
 row_end_5 =
     Css.property "grid-row-end" "5"
@@ -49504,7 +47266,6 @@ row_end_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_6 : Css.Style
 row_end_6 =
     Css.property "grid-row-end" "6"
@@ -49515,7 +47276,6 @@ row_end_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_7 : Css.Style
 row_end_7 =
     Css.property "grid-row-end" "7"
@@ -49526,7 +47286,6 @@ row_end_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_end_auto : Css.Style
 row_end_auto =
     Css.property "grid-row-end" "auto"
@@ -49537,7 +47296,6 @@ row_end_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_1 : Css.Style
 row_span_1 =
     Css.property "grid-row" "span 1 / span 1"
@@ -49548,7 +47306,6 @@ row_span_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_2 : Css.Style
 row_span_2 =
     Css.property "grid-row" "span 2 / span 2"
@@ -49559,7 +47316,6 @@ row_span_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_3 : Css.Style
 row_span_3 =
     Css.property "grid-row" "span 3 / span 3"
@@ -49570,7 +47326,6 @@ row_span_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_4 : Css.Style
 row_span_4 =
     Css.property "grid-row" "span 4 / span 4"
@@ -49581,7 +47336,6 @@ row_span_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_5 : Css.Style
 row_span_5 =
     Css.property "grid-row" "span 5 / span 5"
@@ -49592,7 +47346,6 @@ row_span_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_6 : Css.Style
 row_span_6 =
     Css.property "grid-row" "span 6 / span 6"
@@ -49603,7 +47356,6 @@ row_span_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_span_full : Css.Style
 row_span_full =
     Css.property "grid-row" "1 / -1"
@@ -49614,7 +47366,6 @@ row_span_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_1 : Css.Style
 row_start_1 =
     Css.property "grid-row-start" "1"
@@ -49625,7 +47376,6 @@ row_start_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_2 : Css.Style
 row_start_2 =
     Css.property "grid-row-start" "2"
@@ -49636,7 +47386,6 @@ row_start_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_3 : Css.Style
 row_start_3 =
     Css.property "grid-row-start" "3"
@@ -49647,7 +47396,6 @@ row_start_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_4 : Css.Style
 row_start_4 =
     Css.property "grid-row-start" "4"
@@ -49658,7 +47406,6 @@ row_start_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_5 : Css.Style
 row_start_5 =
     Css.property "grid-row-start" "5"
@@ -49669,7 +47416,6 @@ row_start_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_6 : Css.Style
 row_start_6 =
     Css.property "grid-row-start" "6"
@@ -49680,7 +47426,6 @@ row_start_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_7 : Css.Style
 row_start_7 =
     Css.property "grid-row-start" "7"
@@ -49691,7 +47436,6 @@ row_start_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 row_start_auto : Css.Style
 row_start_auto =
     Css.property "grid-row-start" "auto"
@@ -49702,7 +47446,6 @@ row_start_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 saturate_0 : Css.Style
 saturate_0 =
     Css.property "--tw-saturate" "saturate(0)"
@@ -49713,7 +47456,6 @@ saturate_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 saturate_100 : Css.Style
 saturate_100 =
     Css.property "--tw-saturate" "saturate(1)"
@@ -49724,7 +47466,6 @@ saturate_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 saturate_150 : Css.Style
 saturate_150 =
     Css.property "--tw-saturate" "saturate(1.5)"
@@ -49735,7 +47476,6 @@ saturate_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 saturate_200 : Css.Style
 saturate_200 =
     Css.property "--tw-saturate" "saturate(2)"
@@ -49746,7 +47486,6 @@ saturate_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 saturate_50 : Css.Style
 saturate_50 =
     Css.property "--tw-saturate" "saturate(.5)"
@@ -49757,7 +47496,6 @@ saturate_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_0 : Css.Style
 scale_0 =
     Css.batch
@@ -49771,7 +47509,6 @@ scale_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_100 : Css.Style
 scale_100 =
     Css.batch
@@ -49785,7 +47522,6 @@ scale_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_105 : Css.Style
 scale_105 =
     Css.batch
@@ -49799,7 +47535,6 @@ scale_105 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_110 : Css.Style
 scale_110 =
     Css.batch
@@ -49813,7 +47548,6 @@ scale_110 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_125 : Css.Style
 scale_125 =
     Css.batch
@@ -49827,7 +47561,6 @@ scale_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_150 : Css.Style
 scale_150 =
     Css.batch
@@ -49841,7 +47574,6 @@ scale_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_50 : Css.Style
 scale_50 =
     Css.batch
@@ -49855,7 +47587,6 @@ scale_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_75 : Css.Style
 scale_75 =
     Css.batch
@@ -49869,7 +47600,6 @@ scale_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_90 : Css.Style
 scale_90 =
     Css.batch
@@ -49883,7 +47613,6 @@ scale_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_95 : Css.Style
 scale_95 =
     Css.batch
@@ -49897,7 +47626,6 @@ scale_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_0 : Css.Style
 scale_x_0 =
     Css.property "--tw-scale-x" "0"
@@ -49908,7 +47636,6 @@ scale_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_100 : Css.Style
 scale_x_100 =
     Css.property "--tw-scale-x" "1"
@@ -49919,7 +47646,6 @@ scale_x_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_105 : Css.Style
 scale_x_105 =
     Css.property "--tw-scale-x" "1.05"
@@ -49930,7 +47656,6 @@ scale_x_105 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_110 : Css.Style
 scale_x_110 =
     Css.property "--tw-scale-x" "1.1"
@@ -49941,7 +47666,6 @@ scale_x_110 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_125 : Css.Style
 scale_x_125 =
     Css.property "--tw-scale-x" "1.25"
@@ -49952,7 +47676,6 @@ scale_x_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_150 : Css.Style
 scale_x_150 =
     Css.property "--tw-scale-x" "1.5"
@@ -49963,7 +47686,6 @@ scale_x_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_50 : Css.Style
 scale_x_50 =
     Css.property "--tw-scale-x" ".5"
@@ -49974,7 +47696,6 @@ scale_x_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_75 : Css.Style
 scale_x_75 =
     Css.property "--tw-scale-x" ".75"
@@ -49985,7 +47706,6 @@ scale_x_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_90 : Css.Style
 scale_x_90 =
     Css.property "--tw-scale-x" ".9"
@@ -49996,7 +47716,6 @@ scale_x_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_x_95 : Css.Style
 scale_x_95 =
     Css.property "--tw-scale-x" ".95"
@@ -50007,7 +47726,6 @@ scale_x_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_0 : Css.Style
 scale_y_0 =
     Css.property "--tw-scale-y" "0"
@@ -50018,7 +47736,6 @@ scale_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_100 : Css.Style
 scale_y_100 =
     Css.property "--tw-scale-y" "1"
@@ -50029,7 +47746,6 @@ scale_y_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_105 : Css.Style
 scale_y_105 =
     Css.property "--tw-scale-y" "1.05"
@@ -50040,7 +47756,6 @@ scale_y_105 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_110 : Css.Style
 scale_y_110 =
     Css.property "--tw-scale-y" "1.1"
@@ -50051,7 +47766,6 @@ scale_y_110 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_125 : Css.Style
 scale_y_125 =
     Css.property "--tw-scale-y" "1.25"
@@ -50062,7 +47776,6 @@ scale_y_125 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_150 : Css.Style
 scale_y_150 =
     Css.property "--tw-scale-y" "1.5"
@@ -50073,7 +47786,6 @@ scale_y_150 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_50 : Css.Style
 scale_y_50 =
     Css.property "--tw-scale-y" ".5"
@@ -50084,7 +47796,6 @@ scale_y_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_75 : Css.Style
 scale_y_75 =
     Css.property "--tw-scale-y" ".75"
@@ -50095,7 +47806,6 @@ scale_y_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_90 : Css.Style
 scale_y_90 =
     Css.property "--tw-scale-y" ".9"
@@ -50106,7 +47816,6 @@ scale_y_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 scale_y_95 : Css.Style
 scale_y_95 =
     Css.property "--tw-scale-y" ".95"
@@ -50117,7 +47826,6 @@ scale_y_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 select_all : Css.Style
 select_all =
     Css.batch
@@ -50132,7 +47840,6 @@ select_all =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 select_auto : Css.Style
 select_auto =
     Css.batch
@@ -50148,7 +47855,6 @@ select_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 select_none : Css.Style
 select_none =
     Css.batch
@@ -50164,7 +47870,6 @@ select_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 select_text : Css.Style
 select_text =
     Css.batch
@@ -50180,7 +47885,6 @@ select_text =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 self_auto : Css.Style
 self_auto =
     Css.property "align-self" "auto"
@@ -50191,7 +47895,6 @@ self_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 self_center : Css.Style
 self_center =
     Css.property "align-self" "center"
@@ -50202,7 +47905,6 @@ self_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 self_end : Css.Style
 self_end =
     Css.property "align-self" "flex-end"
@@ -50213,7 +47915,6 @@ self_end =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 self_start : Css.Style
 self_start =
     Css.property "align-self" "flex-start"
@@ -50224,7 +47925,6 @@ self_start =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 self_stretch : Css.Style
 self_stretch =
     Css.property "align-self" "stretch"
@@ -50235,7 +47935,6 @@ self_stretch =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 sepia : Css.Style
 sepia =
     Css.property "--tw-sepia" "sepia(100%)"
@@ -50246,7 +47945,6 @@ sepia =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 sepia_0 : Css.Style
 sepia_0 =
     Css.property "--tw-sepia" "sepia(0)"
@@ -50257,7 +47955,6 @@ sepia_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow : Css.Style
 shadow =
     Css.batch
@@ -50271,7 +47968,6 @@ shadow =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_2xl : Css.Style
 shadow_2xl =
     Css.batch
@@ -50285,7 +47981,6 @@ shadow_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_inner : Css.Style
 shadow_inner =
     Css.batch
@@ -50299,7 +47994,6 @@ shadow_inner =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_lg : Css.Style
 shadow_lg =
     Css.batch
@@ -50313,7 +48007,6 @@ shadow_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_md : Css.Style
 shadow_md =
     Css.batch
@@ -50327,7 +48020,6 @@ shadow_md =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_none : Css.Style
 shadow_none =
     Css.batch
@@ -50341,7 +48033,6 @@ shadow_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_sm : Css.Style
 shadow_sm =
     Css.batch
@@ -50355,7 +48046,6 @@ shadow_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 shadow_xl : Css.Style
 shadow_xl =
     Css.batch
@@ -50369,7 +48059,6 @@ shadow_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_0 : Css.Style
 skew_x_0 =
     Css.property "--tw-skew-x" "0deg"
@@ -50380,7 +48069,6 @@ skew_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_1 : Css.Style
 skew_x_1 =
     Css.property "--tw-skew-x" "1deg"
@@ -50391,7 +48079,6 @@ skew_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_12 : Css.Style
 skew_x_12 =
     Css.property "--tw-skew-x" "12deg"
@@ -50402,7 +48089,6 @@ skew_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_2 : Css.Style
 skew_x_2 =
     Css.property "--tw-skew-x" "2deg"
@@ -50413,7 +48099,6 @@ skew_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_3 : Css.Style
 skew_x_3 =
     Css.property "--tw-skew-x" "3deg"
@@ -50424,7 +48109,6 @@ skew_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_x_6 : Css.Style
 skew_x_6 =
     Css.property "--tw-skew-x" "6deg"
@@ -50435,7 +48119,6 @@ skew_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_0 : Css.Style
 skew_y_0 =
     Css.property "--tw-skew-y" "0deg"
@@ -50446,7 +48129,6 @@ skew_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_1 : Css.Style
 skew_y_1 =
     Css.property "--tw-skew-y" "1deg"
@@ -50457,7 +48139,6 @@ skew_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_12 : Css.Style
 skew_y_12 =
     Css.property "--tw-skew-y" "12deg"
@@ -50468,7 +48149,6 @@ skew_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_2 : Css.Style
 skew_y_2 =
     Css.property "--tw-skew-y" "2deg"
@@ -50479,7 +48159,6 @@ skew_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_3 : Css.Style
 skew_y_3 =
     Css.property "--tw-skew-y" "3deg"
@@ -50490,7 +48169,6 @@ skew_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 skew_y_6 : Css.Style
 skew_y_6 =
     Css.property "--tw-skew-y" "6deg"
@@ -50501,7 +48179,6 @@ skew_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 slashed_zero : Css.Style
 slashed_zero =
     Css.batch
@@ -50520,7 +48197,6 @@ slashed_zero =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_0 : Css.Style
 space_x_0 =
     Css.batch
@@ -50539,7 +48215,6 @@ space_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_0_dot_5 : Css.Style
 space_x_0_dot_5 =
     Css.batch
@@ -50558,7 +48233,6 @@ space_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_1 : Css.Style
 space_x_1 =
     Css.batch
@@ -50577,7 +48251,6 @@ space_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_10 : Css.Style
 space_x_10 =
     Css.batch
@@ -50596,7 +48269,6 @@ space_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_11 : Css.Style
 space_x_11 =
     Css.batch
@@ -50615,7 +48287,6 @@ space_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_12 : Css.Style
 space_x_12 =
     Css.batch
@@ -50634,7 +48305,6 @@ space_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_14 : Css.Style
 space_x_14 =
     Css.batch
@@ -50653,7 +48323,6 @@ space_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_16 : Css.Style
 space_x_16 =
     Css.batch
@@ -50672,7 +48341,6 @@ space_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_1_dot_5 : Css.Style
 space_x_1_dot_5 =
     Css.batch
@@ -50691,7 +48359,6 @@ space_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_2 : Css.Style
 space_x_2 =
     Css.batch
@@ -50710,7 +48377,6 @@ space_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_20 : Css.Style
 space_x_20 =
     Css.batch
@@ -50729,7 +48395,6 @@ space_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_24 : Css.Style
 space_x_24 =
     Css.batch
@@ -50748,7 +48413,6 @@ space_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_28 : Css.Style
 space_x_28 =
     Css.batch
@@ -50767,7 +48431,6 @@ space_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_2_dot_5 : Css.Style
 space_x_2_dot_5 =
     Css.batch
@@ -50786,7 +48449,6 @@ space_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_3 : Css.Style
 space_x_3 =
     Css.batch
@@ -50805,7 +48467,6 @@ space_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_32 : Css.Style
 space_x_32 =
     Css.batch
@@ -50824,7 +48485,6 @@ space_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_36 : Css.Style
 space_x_36 =
     Css.batch
@@ -50843,7 +48503,6 @@ space_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_3_dot_5 : Css.Style
 space_x_3_dot_5 =
     Css.batch
@@ -50862,7 +48521,6 @@ space_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_4 : Css.Style
 space_x_4 =
     Css.batch
@@ -50881,7 +48539,6 @@ space_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_40 : Css.Style
 space_x_40 =
     Css.batch
@@ -50900,7 +48557,6 @@ space_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_44 : Css.Style
 space_x_44 =
     Css.batch
@@ -50919,7 +48575,6 @@ space_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_48 : Css.Style
 space_x_48 =
     Css.batch
@@ -50938,7 +48593,6 @@ space_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_5 : Css.Style
 space_x_5 =
     Css.batch
@@ -50957,7 +48611,6 @@ space_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_52 : Css.Style
 space_x_52 =
     Css.batch
@@ -50976,7 +48629,6 @@ space_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_56 : Css.Style
 space_x_56 =
     Css.batch
@@ -50995,7 +48647,6 @@ space_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_6 : Css.Style
 space_x_6 =
     Css.batch
@@ -51014,7 +48665,6 @@ space_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_60 : Css.Style
 space_x_60 =
     Css.batch
@@ -51033,7 +48683,6 @@ space_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_64 : Css.Style
 space_x_64 =
     Css.batch
@@ -51052,7 +48701,6 @@ space_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_7 : Css.Style
 space_x_7 =
     Css.batch
@@ -51071,7 +48719,6 @@ space_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_72 : Css.Style
 space_x_72 =
     Css.batch
@@ -51090,7 +48737,6 @@ space_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_8 : Css.Style
 space_x_8 =
     Css.batch
@@ -51109,7 +48755,6 @@ space_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_80 : Css.Style
 space_x_80 =
     Css.batch
@@ -51128,7 +48773,6 @@ space_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_9 : Css.Style
 space_x_9 =
     Css.batch
@@ -51147,7 +48791,6 @@ space_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_96 : Css.Style
 space_x_96 =
     Css.batch
@@ -51166,7 +48809,6 @@ space_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_px : Css.Style
 space_x_px =
     Css.batch
@@ -51185,7 +48827,6 @@ space_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_x_reverse : Css.Style
 space_x_reverse =
     Css.batch
@@ -51202,7 +48843,6 @@ space_x_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_0 : Css.Style
 space_y_0 =
     Css.batch
@@ -51221,7 +48861,6 @@ space_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_0_dot_5 : Css.Style
 space_y_0_dot_5 =
     Css.batch
@@ -51240,7 +48879,6 @@ space_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_1 : Css.Style
 space_y_1 =
     Css.batch
@@ -51259,7 +48897,6 @@ space_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_10 : Css.Style
 space_y_10 =
     Css.batch
@@ -51278,7 +48915,6 @@ space_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_11 : Css.Style
 space_y_11 =
     Css.batch
@@ -51297,7 +48933,6 @@ space_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_12 : Css.Style
 space_y_12 =
     Css.batch
@@ -51316,7 +48951,6 @@ space_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_14 : Css.Style
 space_y_14 =
     Css.batch
@@ -51335,7 +48969,6 @@ space_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_16 : Css.Style
 space_y_16 =
     Css.batch
@@ -51354,7 +48987,6 @@ space_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_1_dot_5 : Css.Style
 space_y_1_dot_5 =
     Css.batch
@@ -51373,7 +49005,6 @@ space_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_2 : Css.Style
 space_y_2 =
     Css.batch
@@ -51392,7 +49023,6 @@ space_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_20 : Css.Style
 space_y_20 =
     Css.batch
@@ -51411,7 +49041,6 @@ space_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_24 : Css.Style
 space_y_24 =
     Css.batch
@@ -51430,7 +49059,6 @@ space_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_28 : Css.Style
 space_y_28 =
     Css.batch
@@ -51449,7 +49077,6 @@ space_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_2_dot_5 : Css.Style
 space_y_2_dot_5 =
     Css.batch
@@ -51468,7 +49095,6 @@ space_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_3 : Css.Style
 space_y_3 =
     Css.batch
@@ -51487,7 +49113,6 @@ space_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_32 : Css.Style
 space_y_32 =
     Css.batch
@@ -51506,7 +49131,6 @@ space_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_36 : Css.Style
 space_y_36 =
     Css.batch
@@ -51525,7 +49149,6 @@ space_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_3_dot_5 : Css.Style
 space_y_3_dot_5 =
     Css.batch
@@ -51544,7 +49167,6 @@ space_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_4 : Css.Style
 space_y_4 =
     Css.batch
@@ -51563,7 +49185,6 @@ space_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_40 : Css.Style
 space_y_40 =
     Css.batch
@@ -51582,7 +49203,6 @@ space_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_44 : Css.Style
 space_y_44 =
     Css.batch
@@ -51601,7 +49221,6 @@ space_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_48 : Css.Style
 space_y_48 =
     Css.batch
@@ -51620,7 +49239,6 @@ space_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_5 : Css.Style
 space_y_5 =
     Css.batch
@@ -51639,7 +49257,6 @@ space_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_52 : Css.Style
 space_y_52 =
     Css.batch
@@ -51658,7 +49275,6 @@ space_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_56 : Css.Style
 space_y_56 =
     Css.batch
@@ -51677,7 +49293,6 @@ space_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_6 : Css.Style
 space_y_6 =
     Css.batch
@@ -51696,7 +49311,6 @@ space_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_60 : Css.Style
 space_y_60 =
     Css.batch
@@ -51715,7 +49329,6 @@ space_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_64 : Css.Style
 space_y_64 =
     Css.batch
@@ -51734,7 +49347,6 @@ space_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_7 : Css.Style
 space_y_7 =
     Css.batch
@@ -51753,7 +49365,6 @@ space_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_72 : Css.Style
 space_y_72 =
     Css.batch
@@ -51772,7 +49383,6 @@ space_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_8 : Css.Style
 space_y_8 =
     Css.batch
@@ -51791,7 +49401,6 @@ space_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_80 : Css.Style
 space_y_80 =
     Css.batch
@@ -51810,7 +49419,6 @@ space_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_9 : Css.Style
 space_y_9 =
     Css.batch
@@ -51829,7 +49437,6 @@ space_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_96 : Css.Style
 space_y_96 =
     Css.batch
@@ -51848,7 +49455,6 @@ space_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_px : Css.Style
 space_y_px =
     Css.batch
@@ -51867,7 +49473,6 @@ space_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 space_y_reverse : Css.Style
 space_y_reverse =
     Css.batch
@@ -51884,7 +49489,6 @@ space_y_reverse =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 sr_only : Css.Style
 sr_only =
     Css.batch
@@ -51905,7 +49509,6 @@ sr_only =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 stacked_fractions : Css.Style
 stacked_fractions =
     Css.batch
@@ -51924,7 +49527,6 @@ stacked_fractions =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 static : Css.Style
 static =
     Css.property "position" "static"
@@ -51935,7 +49537,6 @@ static =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 sticky : Css.Style
 sticky =
     Css.property "position" "sticky"
@@ -51946,7 +49547,6 @@ sticky =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 stroke_0 : Css.Style
 stroke_0 =
     Css.property "stroke-width" "0"
@@ -51957,7 +49557,6 @@ stroke_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 stroke_1 : Css.Style
 stroke_1 =
     Css.property "stroke-width" "1"
@@ -51968,7 +49567,6 @@ stroke_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 stroke_2 : Css.Style
 stroke_2 =
     Css.property "stroke-width" "2"
@@ -51979,7 +49577,6 @@ stroke_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 stroke_current : Css.Style
 stroke_current =
     Css.property "stroke" "currentColor"
@@ -51990,7 +49587,6 @@ stroke_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 subpixel_antialiased : Css.Style
 subpixel_antialiased =
     Css.batch
@@ -52004,7 +49600,6 @@ subpixel_antialiased =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table : Css.Style
 table =
     Css.property "display" "table"
@@ -52015,7 +49610,6 @@ table =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_auto : Css.Style
 table_auto =
     Css.property "table-layout" "auto"
@@ -52026,7 +49620,6 @@ table_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_caption : Css.Style
 table_caption =
     Css.property "display" "table-caption"
@@ -52037,7 +49630,6 @@ table_caption =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_cell : Css.Style
 table_cell =
     Css.property "display" "table-cell"
@@ -52048,7 +49640,6 @@ table_cell =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_column : Css.Style
 table_column =
     Css.property "display" "table-column"
@@ -52059,7 +49650,6 @@ table_column =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_column_group : Css.Style
 table_column_group =
     Css.property "display" "table-column-group"
@@ -52070,7 +49660,6 @@ table_column_group =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_fixed : Css.Style
 table_fixed =
     Css.property "table-layout" "fixed"
@@ -52081,7 +49670,6 @@ table_fixed =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_footer_group : Css.Style
 table_footer_group =
     Css.property "display" "table-footer-group"
@@ -52092,7 +49680,6 @@ table_footer_group =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_header_group : Css.Style
 table_header_group =
     Css.property "display" "table-header-group"
@@ -52103,7 +49690,6 @@ table_header_group =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_row : Css.Style
 table_row =
     Css.property "display" "table-row"
@@ -52114,7 +49700,6 @@ table_row =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 table_row_group : Css.Style
 table_row_group =
     Css.property "display" "table-row-group"
@@ -52125,7 +49710,6 @@ table_row_group =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tabular_nums : Css.Style
 tabular_nums =
     Css.batch
@@ -52144,7 +49728,6 @@ tabular_nums =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_2xl : Css.Style
 text_2xl =
     Css.batch
@@ -52158,7 +49741,6 @@ text_2xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_3xl : Css.Style
 text_3xl =
     Css.batch
@@ -52172,7 +49754,6 @@ text_3xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_4xl : Css.Style
 text_4xl =
     Css.batch
@@ -52186,7 +49767,6 @@ text_4xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_5xl : Css.Style
 text_5xl =
     Css.batch
@@ -52200,7 +49780,6 @@ text_5xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_6xl : Css.Style
 text_6xl =
     Css.batch
@@ -52214,7 +49793,6 @@ text_6xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_7xl : Css.Style
 text_7xl =
     Css.batch
@@ -52228,7 +49806,6 @@ text_7xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_8xl : Css.Style
 text_8xl =
     Css.batch
@@ -52242,7 +49819,6 @@ text_8xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_9xl : Css.Style
 text_9xl =
     Css.batch
@@ -52256,7 +49832,6 @@ text_9xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_base : Css.Style
 text_base =
     Css.batch
@@ -52270,7 +49845,6 @@ text_base =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_black : Css.Style
 text_black =
     Css.batch
@@ -52284,7 +49858,6 @@ text_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_100 : Css.Style
 text_blue_100 =
     Css.batch
@@ -52298,7 +49871,6 @@ text_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_200 : Css.Style
 text_blue_200 =
     Css.batch
@@ -52312,7 +49884,6 @@ text_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_300 : Css.Style
 text_blue_300 =
     Css.batch
@@ -52326,7 +49897,6 @@ text_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_400 : Css.Style
 text_blue_400 =
     Css.batch
@@ -52340,7 +49910,6 @@ text_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_50 : Css.Style
 text_blue_50 =
     Css.batch
@@ -52354,7 +49923,6 @@ text_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_500 : Css.Style
 text_blue_500 =
     Css.batch
@@ -52368,7 +49936,6 @@ text_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_600 : Css.Style
 text_blue_600 =
     Css.batch
@@ -52382,7 +49949,6 @@ text_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_700 : Css.Style
 text_blue_700 =
     Css.batch
@@ -52396,7 +49962,6 @@ text_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_800 : Css.Style
 text_blue_800 =
     Css.batch
@@ -52410,7 +49975,6 @@ text_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_blue_900 : Css.Style
 text_blue_900 =
     Css.batch
@@ -52424,7 +49988,6 @@ text_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_center : Css.Style
 text_center =
     Css.property "text-align" "center"
@@ -52435,7 +49998,6 @@ text_center =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_current : Css.Style
 text_current =
     Css.property "color" "currentColor"
@@ -52446,7 +50008,6 @@ text_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_100 : Css.Style
 text_gray_100 =
     Css.batch
@@ -52460,7 +50021,6 @@ text_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_200 : Css.Style
 text_gray_200 =
     Css.batch
@@ -52474,7 +50034,6 @@ text_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_300 : Css.Style
 text_gray_300 =
     Css.batch
@@ -52488,7 +50047,6 @@ text_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_400 : Css.Style
 text_gray_400 =
     Css.batch
@@ -52502,7 +50060,6 @@ text_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_50 : Css.Style
 text_gray_50 =
     Css.batch
@@ -52516,7 +50073,6 @@ text_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_500 : Css.Style
 text_gray_500 =
     Css.batch
@@ -52530,7 +50086,6 @@ text_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_600 : Css.Style
 text_gray_600 =
     Css.batch
@@ -52544,7 +50099,6 @@ text_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_700 : Css.Style
 text_gray_700 =
     Css.batch
@@ -52558,7 +50112,6 @@ text_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_800 : Css.Style
 text_gray_800 =
     Css.batch
@@ -52572,7 +50125,6 @@ text_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_gray_900 : Css.Style
 text_gray_900 =
     Css.batch
@@ -52586,7 +50138,6 @@ text_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_100 : Css.Style
 text_green_100 =
     Css.batch
@@ -52600,7 +50151,6 @@ text_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_200 : Css.Style
 text_green_200 =
     Css.batch
@@ -52614,7 +50164,6 @@ text_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_300 : Css.Style
 text_green_300 =
     Css.batch
@@ -52628,7 +50177,6 @@ text_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_400 : Css.Style
 text_green_400 =
     Css.batch
@@ -52642,7 +50190,6 @@ text_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_50 : Css.Style
 text_green_50 =
     Css.batch
@@ -52656,7 +50203,6 @@ text_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_500 : Css.Style
 text_green_500 =
     Css.batch
@@ -52670,7 +50216,6 @@ text_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_600 : Css.Style
 text_green_600 =
     Css.batch
@@ -52684,7 +50229,6 @@ text_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_700 : Css.Style
 text_green_700 =
     Css.batch
@@ -52698,7 +50242,6 @@ text_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_800 : Css.Style
 text_green_800 =
     Css.batch
@@ -52712,7 +50255,6 @@ text_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_green_900 : Css.Style
 text_green_900 =
     Css.batch
@@ -52726,7 +50268,6 @@ text_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_100 : Css.Style
 text_indigo_100 =
     Css.batch
@@ -52740,7 +50281,6 @@ text_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_200 : Css.Style
 text_indigo_200 =
     Css.batch
@@ -52754,7 +50294,6 @@ text_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_300 : Css.Style
 text_indigo_300 =
     Css.batch
@@ -52768,7 +50307,6 @@ text_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_400 : Css.Style
 text_indigo_400 =
     Css.batch
@@ -52782,7 +50320,6 @@ text_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_50 : Css.Style
 text_indigo_50 =
     Css.batch
@@ -52796,7 +50333,6 @@ text_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_500 : Css.Style
 text_indigo_500 =
     Css.batch
@@ -52810,7 +50346,6 @@ text_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_600 : Css.Style
 text_indigo_600 =
     Css.batch
@@ -52824,7 +50359,6 @@ text_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_700 : Css.Style
 text_indigo_700 =
     Css.batch
@@ -52838,7 +50372,6 @@ text_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_800 : Css.Style
 text_indigo_800 =
     Css.batch
@@ -52852,7 +50385,6 @@ text_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_indigo_900 : Css.Style
 text_indigo_900 =
     Css.batch
@@ -52866,7 +50398,6 @@ text_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_justify : Css.Style
 text_justify =
     Css.property "text-align" "justify"
@@ -52877,7 +50408,6 @@ text_justify =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_left : Css.Style
 text_left =
     Css.property "text-align" "left"
@@ -52888,7 +50418,6 @@ text_left =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_lg : Css.Style
 text_lg =
     Css.batch
@@ -52902,7 +50431,6 @@ text_lg =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_0 : Css.Style
 text_opacity_0 =
     Css.property "--tw-text-opacity" "0"
@@ -52913,7 +50441,6 @@ text_opacity_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_10 : Css.Style
 text_opacity_10 =
     Css.property "--tw-text-opacity" "0.1"
@@ -52924,7 +50451,6 @@ text_opacity_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_100 : Css.Style
 text_opacity_100 =
     Css.property "--tw-text-opacity" "1"
@@ -52935,7 +50461,6 @@ text_opacity_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_20 : Css.Style
 text_opacity_20 =
     Css.property "--tw-text-opacity" "0.2"
@@ -52946,7 +50471,6 @@ text_opacity_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_25 : Css.Style
 text_opacity_25 =
     Css.property "--tw-text-opacity" "0.25"
@@ -52957,7 +50481,6 @@ text_opacity_25 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_30 : Css.Style
 text_opacity_30 =
     Css.property "--tw-text-opacity" "0.3"
@@ -52968,7 +50491,6 @@ text_opacity_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_40 : Css.Style
 text_opacity_40 =
     Css.property "--tw-text-opacity" "0.4"
@@ -52979,7 +50501,6 @@ text_opacity_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_5 : Css.Style
 text_opacity_5 =
     Css.property "--tw-text-opacity" "0.05"
@@ -52990,7 +50511,6 @@ text_opacity_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_50 : Css.Style
 text_opacity_50 =
     Css.property "--tw-text-opacity" "0.5"
@@ -53001,7 +50521,6 @@ text_opacity_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_60 : Css.Style
 text_opacity_60 =
     Css.property "--tw-text-opacity" "0.6"
@@ -53012,7 +50531,6 @@ text_opacity_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_70 : Css.Style
 text_opacity_70 =
     Css.property "--tw-text-opacity" "0.7"
@@ -53023,7 +50541,6 @@ text_opacity_70 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_75 : Css.Style
 text_opacity_75 =
     Css.property "--tw-text-opacity" "0.75"
@@ -53034,7 +50551,6 @@ text_opacity_75 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_80 : Css.Style
 text_opacity_80 =
     Css.property "--tw-text-opacity" "0.8"
@@ -53045,7 +50561,6 @@ text_opacity_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_90 : Css.Style
 text_opacity_90 =
     Css.property "--tw-text-opacity" "0.9"
@@ -53056,7 +50571,6 @@ text_opacity_90 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_opacity_95 : Css.Style
 text_opacity_95 =
     Css.property "--tw-text-opacity" "0.95"
@@ -53067,7 +50581,6 @@ text_opacity_95 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_100 : Css.Style
 text_pink_100 =
     Css.batch
@@ -53081,7 +50594,6 @@ text_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_200 : Css.Style
 text_pink_200 =
     Css.batch
@@ -53095,7 +50607,6 @@ text_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_300 : Css.Style
 text_pink_300 =
     Css.batch
@@ -53109,7 +50620,6 @@ text_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_400 : Css.Style
 text_pink_400 =
     Css.batch
@@ -53123,7 +50633,6 @@ text_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_50 : Css.Style
 text_pink_50 =
     Css.batch
@@ -53137,7 +50646,6 @@ text_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_500 : Css.Style
 text_pink_500 =
     Css.batch
@@ -53151,7 +50659,6 @@ text_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_600 : Css.Style
 text_pink_600 =
     Css.batch
@@ -53165,7 +50672,6 @@ text_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_700 : Css.Style
 text_pink_700 =
     Css.batch
@@ -53179,7 +50685,6 @@ text_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_800 : Css.Style
 text_pink_800 =
     Css.batch
@@ -53193,7 +50698,6 @@ text_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_pink_900 : Css.Style
 text_pink_900 =
     Css.batch
@@ -53207,7 +50711,6 @@ text_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_100 : Css.Style
 text_purple_100 =
     Css.batch
@@ -53221,7 +50724,6 @@ text_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_200 : Css.Style
 text_purple_200 =
     Css.batch
@@ -53235,7 +50737,6 @@ text_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_300 : Css.Style
 text_purple_300 =
     Css.batch
@@ -53249,7 +50750,6 @@ text_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_400 : Css.Style
 text_purple_400 =
     Css.batch
@@ -53263,7 +50763,6 @@ text_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_50 : Css.Style
 text_purple_50 =
     Css.batch
@@ -53277,7 +50776,6 @@ text_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_500 : Css.Style
 text_purple_500 =
     Css.batch
@@ -53291,7 +50789,6 @@ text_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_600 : Css.Style
 text_purple_600 =
     Css.batch
@@ -53305,7 +50802,6 @@ text_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_700 : Css.Style
 text_purple_700 =
     Css.batch
@@ -53319,7 +50815,6 @@ text_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_800 : Css.Style
 text_purple_800 =
     Css.batch
@@ -53333,7 +50828,6 @@ text_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_purple_900 : Css.Style
 text_purple_900 =
     Css.batch
@@ -53347,7 +50841,6 @@ text_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_100 : Css.Style
 text_red_100 =
     Css.batch
@@ -53361,7 +50854,6 @@ text_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_200 : Css.Style
 text_red_200 =
     Css.batch
@@ -53375,7 +50867,6 @@ text_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_300 : Css.Style
 text_red_300 =
     Css.batch
@@ -53389,7 +50880,6 @@ text_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_400 : Css.Style
 text_red_400 =
     Css.batch
@@ -53403,7 +50893,6 @@ text_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_50 : Css.Style
 text_red_50 =
     Css.batch
@@ -53417,7 +50906,6 @@ text_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_500 : Css.Style
 text_red_500 =
     Css.batch
@@ -53431,7 +50919,6 @@ text_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_600 : Css.Style
 text_red_600 =
     Css.batch
@@ -53445,7 +50932,6 @@ text_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_700 : Css.Style
 text_red_700 =
     Css.batch
@@ -53459,7 +50945,6 @@ text_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_800 : Css.Style
 text_red_800 =
     Css.batch
@@ -53473,7 +50958,6 @@ text_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_red_900 : Css.Style
 text_red_900 =
     Css.batch
@@ -53487,7 +50971,6 @@ text_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_right : Css.Style
 text_right =
     Css.property "text-align" "right"
@@ -53498,7 +50981,6 @@ text_right =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_sm : Css.Style
 text_sm =
     Css.batch
@@ -53512,7 +50994,6 @@ text_sm =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_transparent : Css.Style
 text_transparent =
     Css.property "color" "transparent"
@@ -53523,7 +51004,6 @@ text_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_white : Css.Style
 text_white =
     Css.batch
@@ -53537,7 +51017,6 @@ text_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_xl : Css.Style
 text_xl =
     Css.batch
@@ -53551,7 +51030,6 @@ text_xl =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_xs : Css.Style
 text_xs =
     Css.batch
@@ -53565,7 +51043,6 @@ text_xs =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_100 : Css.Style
 text_yellow_100 =
     Css.batch
@@ -53579,7 +51056,6 @@ text_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_200 : Css.Style
 text_yellow_200 =
     Css.batch
@@ -53593,7 +51069,6 @@ text_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_300 : Css.Style
 text_yellow_300 =
     Css.batch
@@ -53607,7 +51082,6 @@ text_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_400 : Css.Style
 text_yellow_400 =
     Css.batch
@@ -53621,7 +51095,6 @@ text_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_50 : Css.Style
 text_yellow_50 =
     Css.batch
@@ -53635,7 +51108,6 @@ text_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_500 : Css.Style
 text_yellow_500 =
     Css.batch
@@ -53649,7 +51121,6 @@ text_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_600 : Css.Style
 text_yellow_600 =
     Css.batch
@@ -53663,7 +51134,6 @@ text_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_700 : Css.Style
 text_yellow_700 =
     Css.batch
@@ -53677,7 +51147,6 @@ text_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_800 : Css.Style
 text_yellow_800 =
     Css.batch
@@ -53691,7 +51160,6 @@ text_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 text_yellow_900 : Css.Style
 text_yellow_900 =
     Css.batch
@@ -53705,7 +51173,6 @@ text_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_black : Css.Style
 to_black =
     Css.property "--tw-gradient-to" "#000"
@@ -53716,7 +51183,6 @@ to_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_100 : Css.Style
 to_blue_100 =
     Css.property "--tw-gradient-to" "#dbeafe"
@@ -53727,7 +51193,6 @@ to_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_200 : Css.Style
 to_blue_200 =
     Css.property "--tw-gradient-to" "#bfdbfe"
@@ -53738,7 +51203,6 @@ to_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_300 : Css.Style
 to_blue_300 =
     Css.property "--tw-gradient-to" "#93c5fd"
@@ -53749,7 +51213,6 @@ to_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_400 : Css.Style
 to_blue_400 =
     Css.property "--tw-gradient-to" "#60a5fa"
@@ -53760,7 +51223,6 @@ to_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_50 : Css.Style
 to_blue_50 =
     Css.property "--tw-gradient-to" "#eff6ff"
@@ -53771,7 +51233,6 @@ to_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_500 : Css.Style
 to_blue_500 =
     Css.property "--tw-gradient-to" "#3b82f6"
@@ -53782,7 +51243,6 @@ to_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_600 : Css.Style
 to_blue_600 =
     Css.property "--tw-gradient-to" "#2563eb"
@@ -53793,7 +51253,6 @@ to_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_700 : Css.Style
 to_blue_700 =
     Css.property "--tw-gradient-to" "#1d4ed8"
@@ -53804,7 +51263,6 @@ to_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_800 : Css.Style
 to_blue_800 =
     Css.property "--tw-gradient-to" "#1e40af"
@@ -53815,7 +51273,6 @@ to_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_blue_900 : Css.Style
 to_blue_900 =
     Css.property "--tw-gradient-to" "#1e3a8a"
@@ -53826,7 +51283,6 @@ to_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_current : Css.Style
 to_current =
     Css.property "--tw-gradient-to" "currentColor"
@@ -53837,7 +51293,6 @@ to_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_100 : Css.Style
 to_gray_100 =
     Css.property "--tw-gradient-to" "#f3f4f6"
@@ -53848,7 +51303,6 @@ to_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_200 : Css.Style
 to_gray_200 =
     Css.property "--tw-gradient-to" "#e5e7eb"
@@ -53859,7 +51313,6 @@ to_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_300 : Css.Style
 to_gray_300 =
     Css.property "--tw-gradient-to" "#d1d5db"
@@ -53870,7 +51323,6 @@ to_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_400 : Css.Style
 to_gray_400 =
     Css.property "--tw-gradient-to" "#9ca3af"
@@ -53881,7 +51333,6 @@ to_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_50 : Css.Style
 to_gray_50 =
     Css.property "--tw-gradient-to" "#f9fafb"
@@ -53892,7 +51343,6 @@ to_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_500 : Css.Style
 to_gray_500 =
     Css.property "--tw-gradient-to" "#6b7280"
@@ -53903,7 +51353,6 @@ to_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_600 : Css.Style
 to_gray_600 =
     Css.property "--tw-gradient-to" "#4b5563"
@@ -53914,7 +51363,6 @@ to_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_700 : Css.Style
 to_gray_700 =
     Css.property "--tw-gradient-to" "#374151"
@@ -53925,7 +51373,6 @@ to_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_800 : Css.Style
 to_gray_800 =
     Css.property "--tw-gradient-to" "#1f2937"
@@ -53936,7 +51383,6 @@ to_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_gray_900 : Css.Style
 to_gray_900 =
     Css.property "--tw-gradient-to" "#111827"
@@ -53947,7 +51393,6 @@ to_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_100 : Css.Style
 to_green_100 =
     Css.property "--tw-gradient-to" "#d1fae5"
@@ -53958,7 +51403,6 @@ to_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_200 : Css.Style
 to_green_200 =
     Css.property "--tw-gradient-to" "#a7f3d0"
@@ -53969,7 +51413,6 @@ to_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_300 : Css.Style
 to_green_300 =
     Css.property "--tw-gradient-to" "#6ee7b7"
@@ -53980,7 +51423,6 @@ to_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_400 : Css.Style
 to_green_400 =
     Css.property "--tw-gradient-to" "#34d399"
@@ -53991,7 +51433,6 @@ to_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_50 : Css.Style
 to_green_50 =
     Css.property "--tw-gradient-to" "#ecfdf5"
@@ -54002,7 +51443,6 @@ to_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_500 : Css.Style
 to_green_500 =
     Css.property "--tw-gradient-to" "#10b981"
@@ -54013,7 +51453,6 @@ to_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_600 : Css.Style
 to_green_600 =
     Css.property "--tw-gradient-to" "#059669"
@@ -54024,7 +51463,6 @@ to_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_700 : Css.Style
 to_green_700 =
     Css.property "--tw-gradient-to" "#047857"
@@ -54035,7 +51473,6 @@ to_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_800 : Css.Style
 to_green_800 =
     Css.property "--tw-gradient-to" "#065f46"
@@ -54046,7 +51483,6 @@ to_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_green_900 : Css.Style
 to_green_900 =
     Css.property "--tw-gradient-to" "#064e3b"
@@ -54057,7 +51493,6 @@ to_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_100 : Css.Style
 to_indigo_100 =
     Css.property "--tw-gradient-to" "#e0e7ff"
@@ -54068,7 +51503,6 @@ to_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_200 : Css.Style
 to_indigo_200 =
     Css.property "--tw-gradient-to" "#c7d2fe"
@@ -54079,7 +51513,6 @@ to_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_300 : Css.Style
 to_indigo_300 =
     Css.property "--tw-gradient-to" "#a5b4fc"
@@ -54090,7 +51523,6 @@ to_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_400 : Css.Style
 to_indigo_400 =
     Css.property "--tw-gradient-to" "#818cf8"
@@ -54101,7 +51533,6 @@ to_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_50 : Css.Style
 to_indigo_50 =
     Css.property "--tw-gradient-to" "#eef2ff"
@@ -54112,7 +51543,6 @@ to_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_500 : Css.Style
 to_indigo_500 =
     Css.property "--tw-gradient-to" "#6366f1"
@@ -54123,7 +51553,6 @@ to_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_600 : Css.Style
 to_indigo_600 =
     Css.property "--tw-gradient-to" "#4f46e5"
@@ -54134,7 +51563,6 @@ to_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_700 : Css.Style
 to_indigo_700 =
     Css.property "--tw-gradient-to" "#4338ca"
@@ -54145,7 +51573,6 @@ to_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_800 : Css.Style
 to_indigo_800 =
     Css.property "--tw-gradient-to" "#3730a3"
@@ -54156,7 +51583,6 @@ to_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_indigo_900 : Css.Style
 to_indigo_900 =
     Css.property "--tw-gradient-to" "#312e81"
@@ -54167,7 +51593,6 @@ to_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_100 : Css.Style
 to_pink_100 =
     Css.property "--tw-gradient-to" "#fce7f3"
@@ -54178,7 +51603,6 @@ to_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_200 : Css.Style
 to_pink_200 =
     Css.property "--tw-gradient-to" "#fbcfe8"
@@ -54189,7 +51613,6 @@ to_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_300 : Css.Style
 to_pink_300 =
     Css.property "--tw-gradient-to" "#f9a8d4"
@@ -54200,7 +51623,6 @@ to_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_400 : Css.Style
 to_pink_400 =
     Css.property "--tw-gradient-to" "#f472b6"
@@ -54211,7 +51633,6 @@ to_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_50 : Css.Style
 to_pink_50 =
     Css.property "--tw-gradient-to" "#fdf2f8"
@@ -54222,7 +51643,6 @@ to_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_500 : Css.Style
 to_pink_500 =
     Css.property "--tw-gradient-to" "#ec4899"
@@ -54233,7 +51653,6 @@ to_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_600 : Css.Style
 to_pink_600 =
     Css.property "--tw-gradient-to" "#db2777"
@@ -54244,7 +51663,6 @@ to_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_700 : Css.Style
 to_pink_700 =
     Css.property "--tw-gradient-to" "#be185d"
@@ -54255,7 +51673,6 @@ to_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_800 : Css.Style
 to_pink_800 =
     Css.property "--tw-gradient-to" "#9d174d"
@@ -54266,7 +51683,6 @@ to_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_pink_900 : Css.Style
 to_pink_900 =
     Css.property "--tw-gradient-to" "#831843"
@@ -54277,7 +51693,6 @@ to_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_100 : Css.Style
 to_purple_100 =
     Css.property "--tw-gradient-to" "#ede9fe"
@@ -54288,7 +51703,6 @@ to_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_200 : Css.Style
 to_purple_200 =
     Css.property "--tw-gradient-to" "#ddd6fe"
@@ -54299,7 +51713,6 @@ to_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_300 : Css.Style
 to_purple_300 =
     Css.property "--tw-gradient-to" "#c4b5fd"
@@ -54310,7 +51723,6 @@ to_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_400 : Css.Style
 to_purple_400 =
     Css.property "--tw-gradient-to" "#a78bfa"
@@ -54321,7 +51733,6 @@ to_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_50 : Css.Style
 to_purple_50 =
     Css.property "--tw-gradient-to" "#f5f3ff"
@@ -54332,7 +51743,6 @@ to_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_500 : Css.Style
 to_purple_500 =
     Css.property "--tw-gradient-to" "#8b5cf6"
@@ -54343,7 +51753,6 @@ to_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_600 : Css.Style
 to_purple_600 =
     Css.property "--tw-gradient-to" "#7c3aed"
@@ -54354,7 +51763,6 @@ to_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_700 : Css.Style
 to_purple_700 =
     Css.property "--tw-gradient-to" "#6d28d9"
@@ -54365,7 +51773,6 @@ to_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_800 : Css.Style
 to_purple_800 =
     Css.property "--tw-gradient-to" "#5b21b6"
@@ -54376,7 +51783,6 @@ to_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_purple_900 : Css.Style
 to_purple_900 =
     Css.property "--tw-gradient-to" "#4c1d95"
@@ -54387,7 +51793,6 @@ to_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_100 : Css.Style
 to_red_100 =
     Css.property "--tw-gradient-to" "#fee2e2"
@@ -54398,7 +51803,6 @@ to_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_200 : Css.Style
 to_red_200 =
     Css.property "--tw-gradient-to" "#fecaca"
@@ -54409,7 +51813,6 @@ to_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_300 : Css.Style
 to_red_300 =
     Css.property "--tw-gradient-to" "#fca5a5"
@@ -54420,7 +51823,6 @@ to_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_400 : Css.Style
 to_red_400 =
     Css.property "--tw-gradient-to" "#f87171"
@@ -54431,7 +51833,6 @@ to_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_50 : Css.Style
 to_red_50 =
     Css.property "--tw-gradient-to" "#fef2f2"
@@ -54442,7 +51843,6 @@ to_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_500 : Css.Style
 to_red_500 =
     Css.property "--tw-gradient-to" "#ef4444"
@@ -54453,7 +51853,6 @@ to_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_600 : Css.Style
 to_red_600 =
     Css.property "--tw-gradient-to" "#dc2626"
@@ -54464,7 +51863,6 @@ to_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_700 : Css.Style
 to_red_700 =
     Css.property "--tw-gradient-to" "#b91c1c"
@@ -54475,7 +51873,6 @@ to_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_800 : Css.Style
 to_red_800 =
     Css.property "--tw-gradient-to" "#991b1b"
@@ -54486,7 +51883,6 @@ to_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_red_900 : Css.Style
 to_red_900 =
     Css.property "--tw-gradient-to" "#7f1d1d"
@@ -54497,7 +51893,6 @@ to_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_transparent : Css.Style
 to_transparent =
     Css.property "--tw-gradient-to" "transparent"
@@ -54508,7 +51903,6 @@ to_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_white : Css.Style
 to_white =
     Css.property "--tw-gradient-to" "#fff"
@@ -54519,7 +51913,6 @@ to_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_100 : Css.Style
 to_yellow_100 =
     Css.property "--tw-gradient-to" "#fef3c7"
@@ -54530,7 +51923,6 @@ to_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_200 : Css.Style
 to_yellow_200 =
     Css.property "--tw-gradient-to" "#fde68a"
@@ -54541,7 +51933,6 @@ to_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_300 : Css.Style
 to_yellow_300 =
     Css.property "--tw-gradient-to" "#fcd34d"
@@ -54552,7 +51943,6 @@ to_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_400 : Css.Style
 to_yellow_400 =
     Css.property "--tw-gradient-to" "#fbbf24"
@@ -54563,7 +51953,6 @@ to_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_50 : Css.Style
 to_yellow_50 =
     Css.property "--tw-gradient-to" "#fffbeb"
@@ -54574,7 +51963,6 @@ to_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_500 : Css.Style
 to_yellow_500 =
     Css.property "--tw-gradient-to" "#f59e0b"
@@ -54585,7 +51973,6 @@ to_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_600 : Css.Style
 to_yellow_600 =
     Css.property "--tw-gradient-to" "#d97706"
@@ -54596,7 +51983,6 @@ to_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_700 : Css.Style
 to_yellow_700 =
     Css.property "--tw-gradient-to" "#b45309"
@@ -54607,7 +51993,6 @@ to_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_800 : Css.Style
 to_yellow_800 =
     Css.property "--tw-gradient-to" "#92400e"
@@ -54618,7 +52003,6 @@ to_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 to_yellow_900 : Css.Style
 to_yellow_900 =
     Css.property "--tw-gradient-to" "#78350f"
@@ -54629,7 +52013,6 @@ to_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_0 : Css.Style
 top_0 =
     Css.property "top" "0px"
@@ -54640,7 +52023,6 @@ top_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_0_dot_5 : Css.Style
 top_0_dot_5 =
     Css.property "top" "0.125rem"
@@ -54651,7 +52033,6 @@ top_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_1 : Css.Style
 top_1 =
     Css.property "top" "0.25rem"
@@ -54662,7 +52043,6 @@ top_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_10 : Css.Style
 top_10 =
     Css.property "top" "2.5rem"
@@ -54673,7 +52053,6 @@ top_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_11 : Css.Style
 top_11 =
     Css.property "top" "2.75rem"
@@ -54684,7 +52063,6 @@ top_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_12 : Css.Style
 top_12 =
     Css.property "top" "3rem"
@@ -54695,7 +52073,6 @@ top_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_14 : Css.Style
 top_14 =
     Css.property "top" "3.5rem"
@@ -54706,7 +52083,6 @@ top_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_16 : Css.Style
 top_16 =
     Css.property "top" "4rem"
@@ -54717,7 +52093,6 @@ top_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_1_dot_5 : Css.Style
 top_1_dot_5 =
     Css.property "top" "0.375rem"
@@ -54728,7 +52103,6 @@ top_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_1over2 : Css.Style
 top_1over2 =
     Css.property "top" "50%"
@@ -54739,7 +52113,6 @@ top_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_1over3 : Css.Style
 top_1over3 =
     Css.property "top" "33.333333%"
@@ -54750,7 +52123,6 @@ top_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_1over4 : Css.Style
 top_1over4 =
     Css.property "top" "25%"
@@ -54761,7 +52133,6 @@ top_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_2 : Css.Style
 top_2 =
     Css.property "top" "0.5rem"
@@ -54772,7 +52143,6 @@ top_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_20 : Css.Style
 top_20 =
     Css.property "top" "5rem"
@@ -54783,7 +52153,6 @@ top_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_24 : Css.Style
 top_24 =
     Css.property "top" "6rem"
@@ -54794,7 +52163,6 @@ top_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_28 : Css.Style
 top_28 =
     Css.property "top" "7rem"
@@ -54805,7 +52173,6 @@ top_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_2_dot_5 : Css.Style
 top_2_dot_5 =
     Css.property "top" "0.625rem"
@@ -54816,7 +52183,6 @@ top_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_2over3 : Css.Style
 top_2over3 =
     Css.property "top" "66.666667%"
@@ -54827,7 +52193,6 @@ top_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_2over4 : Css.Style
 top_2over4 =
     Css.property "top" "50%"
@@ -54838,7 +52203,6 @@ top_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_3 : Css.Style
 top_3 =
     Css.property "top" "0.75rem"
@@ -54849,7 +52213,6 @@ top_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_32 : Css.Style
 top_32 =
     Css.property "top" "8rem"
@@ -54860,7 +52223,6 @@ top_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_36 : Css.Style
 top_36 =
     Css.property "top" "9rem"
@@ -54871,7 +52233,6 @@ top_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_3_dot_5 : Css.Style
 top_3_dot_5 =
     Css.property "top" "0.875rem"
@@ -54882,7 +52243,6 @@ top_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_3over4 : Css.Style
 top_3over4 =
     Css.property "top" "75%"
@@ -54893,7 +52253,6 @@ top_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_4 : Css.Style
 top_4 =
     Css.property "top" "1rem"
@@ -54904,7 +52263,6 @@ top_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_40 : Css.Style
 top_40 =
     Css.property "top" "10rem"
@@ -54915,7 +52273,6 @@ top_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_44 : Css.Style
 top_44 =
     Css.property "top" "11rem"
@@ -54926,7 +52283,6 @@ top_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_48 : Css.Style
 top_48 =
     Css.property "top" "12rem"
@@ -54937,7 +52293,6 @@ top_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_5 : Css.Style
 top_5 =
     Css.property "top" "1.25rem"
@@ -54948,7 +52303,6 @@ top_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_52 : Css.Style
 top_52 =
     Css.property "top" "13rem"
@@ -54959,7 +52313,6 @@ top_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_56 : Css.Style
 top_56 =
     Css.property "top" "14rem"
@@ -54970,7 +52323,6 @@ top_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_6 : Css.Style
 top_6 =
     Css.property "top" "1.5rem"
@@ -54981,7 +52333,6 @@ top_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_60 : Css.Style
 top_60 =
     Css.property "top" "15rem"
@@ -54992,7 +52343,6 @@ top_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_64 : Css.Style
 top_64 =
     Css.property "top" "16rem"
@@ -55003,7 +52353,6 @@ top_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_7 : Css.Style
 top_7 =
     Css.property "top" "1.75rem"
@@ -55014,7 +52363,6 @@ top_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_72 : Css.Style
 top_72 =
     Css.property "top" "18rem"
@@ -55025,7 +52373,6 @@ top_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_8 : Css.Style
 top_8 =
     Css.property "top" "2rem"
@@ -55036,7 +52383,6 @@ top_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_80 : Css.Style
 top_80 =
     Css.property "top" "20rem"
@@ -55047,7 +52393,6 @@ top_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_9 : Css.Style
 top_9 =
     Css.property "top" "2.25rem"
@@ -55058,7 +52403,6 @@ top_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_96 : Css.Style
 top_96 =
     Css.property "top" "24rem"
@@ -55069,7 +52413,6 @@ top_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_auto : Css.Style
 top_auto =
     Css.property "top" "auto"
@@ -55080,7 +52423,6 @@ top_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_full : Css.Style
 top_full =
     Css.property "top" "100%"
@@ -55091,7 +52433,6 @@ top_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 top_px : Css.Style
 top_px =
     Css.property "top" "1px"
@@ -55102,7 +52443,6 @@ top_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_normal : Css.Style
 tracking_normal =
     Css.property "letter-spacing" "0em"
@@ -55113,7 +52453,6 @@ tracking_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_tight : Css.Style
 tracking_tight =
     Css.property "letter-spacing" "-0.025em"
@@ -55124,7 +52463,6 @@ tracking_tight =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_tighter : Css.Style
 tracking_tighter =
     Css.property "letter-spacing" "-0.05em"
@@ -55135,7 +52473,6 @@ tracking_tighter =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_wide : Css.Style
 tracking_wide =
     Css.property "letter-spacing" "0.025em"
@@ -55146,7 +52483,6 @@ tracking_wide =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_wider : Css.Style
 tracking_wider =
     Css.property "letter-spacing" "0.05em"
@@ -55157,7 +52493,6 @@ tracking_wider =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 tracking_widest : Css.Style
 tracking_widest =
     Css.property "letter-spacing" "0.1em"
@@ -55168,7 +52503,6 @@ tracking_widest =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transform : Css.Style
 transform =
     Css.batch
@@ -55188,7 +52522,6 @@ transform =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transform_gpu : Css.Style
 transform_gpu =
     Css.batch
@@ -55208,7 +52541,6 @@ transform_gpu =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transform_none : Css.Style
 transform_none =
     Css.property "transform" "none"
@@ -55219,7 +52551,6 @@ transform_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition : Css.Style
 transition =
     Css.batch
@@ -55236,7 +52567,6 @@ transition =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_all : Css.Style
 transition_all =
     Css.batch
@@ -55251,7 +52581,6 @@ transition_all =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_colors : Css.Style
 transition_colors =
     Css.batch
@@ -55266,7 +52595,6 @@ transition_colors =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_none : Css.Style
 transition_none =
     Css.property "transition-property" "none"
@@ -55277,7 +52605,6 @@ transition_none =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_opacity : Css.Style
 transition_opacity =
     Css.batch
@@ -55292,7 +52619,6 @@ transition_opacity =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_shadow : Css.Style
 transition_shadow =
     Css.batch
@@ -55307,7 +52633,6 @@ transition_shadow =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 transition_transform : Css.Style
 transition_transform =
     Css.batch
@@ -55322,7 +52647,6 @@ transition_transform =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_0 : Css.Style
 translate_x_0 =
     Css.property "--tw-translate-x" "0px"
@@ -55333,7 +52657,6 @@ translate_x_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_0_dot_5 : Css.Style
 translate_x_0_dot_5 =
     Css.property "--tw-translate-x" "0.125rem"
@@ -55344,7 +52667,6 @@ translate_x_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_1 : Css.Style
 translate_x_1 =
     Css.property "--tw-translate-x" "0.25rem"
@@ -55355,7 +52677,6 @@ translate_x_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_10 : Css.Style
 translate_x_10 =
     Css.property "--tw-translate-x" "2.5rem"
@@ -55366,7 +52687,6 @@ translate_x_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_11 : Css.Style
 translate_x_11 =
     Css.property "--tw-translate-x" "2.75rem"
@@ -55377,7 +52697,6 @@ translate_x_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_12 : Css.Style
 translate_x_12 =
     Css.property "--tw-translate-x" "3rem"
@@ -55388,7 +52707,6 @@ translate_x_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_14 : Css.Style
 translate_x_14 =
     Css.property "--tw-translate-x" "3.5rem"
@@ -55399,7 +52717,6 @@ translate_x_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_16 : Css.Style
 translate_x_16 =
     Css.property "--tw-translate-x" "4rem"
@@ -55410,7 +52727,6 @@ translate_x_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_1_dot_5 : Css.Style
 translate_x_1_dot_5 =
     Css.property "--tw-translate-x" "0.375rem"
@@ -55421,7 +52737,6 @@ translate_x_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_1over2 : Css.Style
 translate_x_1over2 =
     Css.property "--tw-translate-x" "50%"
@@ -55432,7 +52747,6 @@ translate_x_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_1over3 : Css.Style
 translate_x_1over3 =
     Css.property "--tw-translate-x" "33.333333%"
@@ -55443,7 +52757,6 @@ translate_x_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_1over4 : Css.Style
 translate_x_1over4 =
     Css.property "--tw-translate-x" "25%"
@@ -55454,7 +52767,6 @@ translate_x_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_2 : Css.Style
 translate_x_2 =
     Css.property "--tw-translate-x" "0.5rem"
@@ -55465,7 +52777,6 @@ translate_x_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_20 : Css.Style
 translate_x_20 =
     Css.property "--tw-translate-x" "5rem"
@@ -55476,7 +52787,6 @@ translate_x_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_24 : Css.Style
 translate_x_24 =
     Css.property "--tw-translate-x" "6rem"
@@ -55487,7 +52797,6 @@ translate_x_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_28 : Css.Style
 translate_x_28 =
     Css.property "--tw-translate-x" "7rem"
@@ -55498,7 +52807,6 @@ translate_x_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_2_dot_5 : Css.Style
 translate_x_2_dot_5 =
     Css.property "--tw-translate-x" "0.625rem"
@@ -55509,7 +52817,6 @@ translate_x_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_2over3 : Css.Style
 translate_x_2over3 =
     Css.property "--tw-translate-x" "66.666667%"
@@ -55520,7 +52827,6 @@ translate_x_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_2over4 : Css.Style
 translate_x_2over4 =
     Css.property "--tw-translate-x" "50%"
@@ -55531,7 +52837,6 @@ translate_x_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_3 : Css.Style
 translate_x_3 =
     Css.property "--tw-translate-x" "0.75rem"
@@ -55542,7 +52847,6 @@ translate_x_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_32 : Css.Style
 translate_x_32 =
     Css.property "--tw-translate-x" "8rem"
@@ -55553,7 +52857,6 @@ translate_x_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_36 : Css.Style
 translate_x_36 =
     Css.property "--tw-translate-x" "9rem"
@@ -55564,7 +52867,6 @@ translate_x_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_3_dot_5 : Css.Style
 translate_x_3_dot_5 =
     Css.property "--tw-translate-x" "0.875rem"
@@ -55575,7 +52877,6 @@ translate_x_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_3over4 : Css.Style
 translate_x_3over4 =
     Css.property "--tw-translate-x" "75%"
@@ -55586,7 +52887,6 @@ translate_x_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_4 : Css.Style
 translate_x_4 =
     Css.property "--tw-translate-x" "1rem"
@@ -55597,7 +52897,6 @@ translate_x_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_40 : Css.Style
 translate_x_40 =
     Css.property "--tw-translate-x" "10rem"
@@ -55608,7 +52907,6 @@ translate_x_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_44 : Css.Style
 translate_x_44 =
     Css.property "--tw-translate-x" "11rem"
@@ -55619,7 +52917,6 @@ translate_x_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_48 : Css.Style
 translate_x_48 =
     Css.property "--tw-translate-x" "12rem"
@@ -55630,7 +52927,6 @@ translate_x_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_5 : Css.Style
 translate_x_5 =
     Css.property "--tw-translate-x" "1.25rem"
@@ -55641,7 +52937,6 @@ translate_x_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_52 : Css.Style
 translate_x_52 =
     Css.property "--tw-translate-x" "13rem"
@@ -55652,7 +52947,6 @@ translate_x_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_56 : Css.Style
 translate_x_56 =
     Css.property "--tw-translate-x" "14rem"
@@ -55663,7 +52957,6 @@ translate_x_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_6 : Css.Style
 translate_x_6 =
     Css.property "--tw-translate-x" "1.5rem"
@@ -55674,7 +52967,6 @@ translate_x_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_60 : Css.Style
 translate_x_60 =
     Css.property "--tw-translate-x" "15rem"
@@ -55685,7 +52977,6 @@ translate_x_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_64 : Css.Style
 translate_x_64 =
     Css.property "--tw-translate-x" "16rem"
@@ -55696,7 +52987,6 @@ translate_x_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_7 : Css.Style
 translate_x_7 =
     Css.property "--tw-translate-x" "1.75rem"
@@ -55707,7 +52997,6 @@ translate_x_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_72 : Css.Style
 translate_x_72 =
     Css.property "--tw-translate-x" "18rem"
@@ -55718,7 +53007,6 @@ translate_x_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_8 : Css.Style
 translate_x_8 =
     Css.property "--tw-translate-x" "2rem"
@@ -55729,7 +53017,6 @@ translate_x_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_80 : Css.Style
 translate_x_80 =
     Css.property "--tw-translate-x" "20rem"
@@ -55740,7 +53027,6 @@ translate_x_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_9 : Css.Style
 translate_x_9 =
     Css.property "--tw-translate-x" "2.25rem"
@@ -55751,7 +53037,6 @@ translate_x_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_96 : Css.Style
 translate_x_96 =
     Css.property "--tw-translate-x" "24rem"
@@ -55762,7 +53047,6 @@ translate_x_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_full : Css.Style
 translate_x_full =
     Css.property "--tw-translate-x" "100%"
@@ -55773,7 +53057,6 @@ translate_x_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_x_px : Css.Style
 translate_x_px =
     Css.property "--tw-translate-x" "1px"
@@ -55784,7 +53067,6 @@ translate_x_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_0 : Css.Style
 translate_y_0 =
     Css.property "--tw-translate-y" "0px"
@@ -55795,7 +53077,6 @@ translate_y_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_0_dot_5 : Css.Style
 translate_y_0_dot_5 =
     Css.property "--tw-translate-y" "0.125rem"
@@ -55806,7 +53087,6 @@ translate_y_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_1 : Css.Style
 translate_y_1 =
     Css.property "--tw-translate-y" "0.25rem"
@@ -55817,7 +53097,6 @@ translate_y_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_10 : Css.Style
 translate_y_10 =
     Css.property "--tw-translate-y" "2.5rem"
@@ -55828,7 +53107,6 @@ translate_y_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_11 : Css.Style
 translate_y_11 =
     Css.property "--tw-translate-y" "2.75rem"
@@ -55839,7 +53117,6 @@ translate_y_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_12 : Css.Style
 translate_y_12 =
     Css.property "--tw-translate-y" "3rem"
@@ -55850,7 +53127,6 @@ translate_y_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_14 : Css.Style
 translate_y_14 =
     Css.property "--tw-translate-y" "3.5rem"
@@ -55861,7 +53137,6 @@ translate_y_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_16 : Css.Style
 translate_y_16 =
     Css.property "--tw-translate-y" "4rem"
@@ -55872,7 +53147,6 @@ translate_y_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_1_dot_5 : Css.Style
 translate_y_1_dot_5 =
     Css.property "--tw-translate-y" "0.375rem"
@@ -55883,7 +53157,6 @@ translate_y_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_1over2 : Css.Style
 translate_y_1over2 =
     Css.property "--tw-translate-y" "50%"
@@ -55894,7 +53167,6 @@ translate_y_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_1over3 : Css.Style
 translate_y_1over3 =
     Css.property "--tw-translate-y" "33.333333%"
@@ -55905,7 +53177,6 @@ translate_y_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_1over4 : Css.Style
 translate_y_1over4 =
     Css.property "--tw-translate-y" "25%"
@@ -55916,7 +53187,6 @@ translate_y_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_2 : Css.Style
 translate_y_2 =
     Css.property "--tw-translate-y" "0.5rem"
@@ -55927,7 +53197,6 @@ translate_y_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_20 : Css.Style
 translate_y_20 =
     Css.property "--tw-translate-y" "5rem"
@@ -55938,7 +53207,6 @@ translate_y_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_24 : Css.Style
 translate_y_24 =
     Css.property "--tw-translate-y" "6rem"
@@ -55949,7 +53217,6 @@ translate_y_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_28 : Css.Style
 translate_y_28 =
     Css.property "--tw-translate-y" "7rem"
@@ -55960,7 +53227,6 @@ translate_y_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_2_dot_5 : Css.Style
 translate_y_2_dot_5 =
     Css.property "--tw-translate-y" "0.625rem"
@@ -55971,7 +53237,6 @@ translate_y_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_2over3 : Css.Style
 translate_y_2over3 =
     Css.property "--tw-translate-y" "66.666667%"
@@ -55982,7 +53247,6 @@ translate_y_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_2over4 : Css.Style
 translate_y_2over4 =
     Css.property "--tw-translate-y" "50%"
@@ -55993,7 +53257,6 @@ translate_y_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_3 : Css.Style
 translate_y_3 =
     Css.property "--tw-translate-y" "0.75rem"
@@ -56004,7 +53267,6 @@ translate_y_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_32 : Css.Style
 translate_y_32 =
     Css.property "--tw-translate-y" "8rem"
@@ -56015,7 +53277,6 @@ translate_y_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_36 : Css.Style
 translate_y_36 =
     Css.property "--tw-translate-y" "9rem"
@@ -56026,7 +53287,6 @@ translate_y_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_3_dot_5 : Css.Style
 translate_y_3_dot_5 =
     Css.property "--tw-translate-y" "0.875rem"
@@ -56037,7 +53297,6 @@ translate_y_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_3over4 : Css.Style
 translate_y_3over4 =
     Css.property "--tw-translate-y" "75%"
@@ -56048,7 +53307,6 @@ translate_y_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_4 : Css.Style
 translate_y_4 =
     Css.property "--tw-translate-y" "1rem"
@@ -56059,7 +53317,6 @@ translate_y_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_40 : Css.Style
 translate_y_40 =
     Css.property "--tw-translate-y" "10rem"
@@ -56070,7 +53327,6 @@ translate_y_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_44 : Css.Style
 translate_y_44 =
     Css.property "--tw-translate-y" "11rem"
@@ -56081,7 +53337,6 @@ translate_y_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_48 : Css.Style
 translate_y_48 =
     Css.property "--tw-translate-y" "12rem"
@@ -56092,7 +53347,6 @@ translate_y_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_5 : Css.Style
 translate_y_5 =
     Css.property "--tw-translate-y" "1.25rem"
@@ -56103,7 +53357,6 @@ translate_y_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_52 : Css.Style
 translate_y_52 =
     Css.property "--tw-translate-y" "13rem"
@@ -56114,7 +53367,6 @@ translate_y_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_56 : Css.Style
 translate_y_56 =
     Css.property "--tw-translate-y" "14rem"
@@ -56125,7 +53377,6 @@ translate_y_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_6 : Css.Style
 translate_y_6 =
     Css.property "--tw-translate-y" "1.5rem"
@@ -56136,7 +53387,6 @@ translate_y_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_60 : Css.Style
 translate_y_60 =
     Css.property "--tw-translate-y" "15rem"
@@ -56147,7 +53397,6 @@ translate_y_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_64 : Css.Style
 translate_y_64 =
     Css.property "--tw-translate-y" "16rem"
@@ -56158,7 +53407,6 @@ translate_y_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_7 : Css.Style
 translate_y_7 =
     Css.property "--tw-translate-y" "1.75rem"
@@ -56169,7 +53417,6 @@ translate_y_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_72 : Css.Style
 translate_y_72 =
     Css.property "--tw-translate-y" "18rem"
@@ -56180,7 +53427,6 @@ translate_y_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_8 : Css.Style
 translate_y_8 =
     Css.property "--tw-translate-y" "2rem"
@@ -56191,7 +53437,6 @@ translate_y_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_80 : Css.Style
 translate_y_80 =
     Css.property "--tw-translate-y" "20rem"
@@ -56202,7 +53447,6 @@ translate_y_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_9 : Css.Style
 translate_y_9 =
     Css.property "--tw-translate-y" "2.25rem"
@@ -56213,7 +53457,6 @@ translate_y_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_96 : Css.Style
 translate_y_96 =
     Css.property "--tw-translate-y" "24rem"
@@ -56224,7 +53467,6 @@ translate_y_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_full : Css.Style
 translate_y_full =
     Css.property "--tw-translate-y" "100%"
@@ -56235,7 +53477,6 @@ translate_y_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 translate_y_px : Css.Style
 translate_y_px =
     Css.property "--tw-translate-y" "1px"
@@ -56246,7 +53487,6 @@ translate_y_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 truncate : Css.Style
 truncate =
     Css.batch
@@ -56261,7 +53501,6 @@ truncate =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 underline : Css.Style
 underline =
     Css.property "text-decoration" "underline"
@@ -56272,7 +53511,6 @@ underline =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 uppercase : Css.Style
 uppercase =
     Css.property "text-transform" "uppercase"
@@ -56283,7 +53521,6 @@ uppercase =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_black : Css.Style
 via_black =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #000, var(--tw-gradient-to, rgba(0, 0, 0, 0))"
@@ -56294,7 +53531,6 @@ via_black =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_100 : Css.Style
 via_blue_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #dbeafe, var(--tw-gradient-to, rgba(219, 234, 254, 0))"
@@ -56305,7 +53541,6 @@ via_blue_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_200 : Css.Style
 via_blue_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bfdbfe, var(--tw-gradient-to, rgba(191, 219, 254, 0))"
@@ -56316,7 +53551,6 @@ via_blue_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_300 : Css.Style
 via_blue_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #93c5fd, var(--tw-gradient-to, rgba(147, 197, 253, 0))"
@@ -56327,7 +53561,6 @@ via_blue_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_400 : Css.Style
 via_blue_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #60a5fa, var(--tw-gradient-to, rgba(96, 165, 250, 0))"
@@ -56338,7 +53571,6 @@ via_blue_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_50 : Css.Style
 via_blue_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eff6ff, var(--tw-gradient-to, rgba(239, 246, 255, 0))"
@@ -56349,7 +53581,6 @@ via_blue_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_500 : Css.Style
 via_blue_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3b82f6, var(--tw-gradient-to, rgba(59, 130, 246, 0))"
@@ -56360,7 +53591,6 @@ via_blue_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_600 : Css.Style
 via_blue_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #2563eb, var(--tw-gradient-to, rgba(37, 99, 235, 0))"
@@ -56371,7 +53601,6 @@ via_blue_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_700 : Css.Style
 via_blue_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1d4ed8, var(--tw-gradient-to, rgba(29, 78, 216, 0))"
@@ -56382,7 +53611,6 @@ via_blue_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_800 : Css.Style
 via_blue_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e40af, var(--tw-gradient-to, rgba(30, 64, 175, 0))"
@@ -56393,7 +53621,6 @@ via_blue_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_blue_900 : Css.Style
 via_blue_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e3a8a, var(--tw-gradient-to, rgba(30, 58, 138, 0))"
@@ -56404,7 +53631,6 @@ via_blue_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_current : Css.Style
 via_current =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0))"
@@ -56415,7 +53641,6 @@ via_current =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_100 : Css.Style
 via_gray_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f3f4f6, var(--tw-gradient-to, rgba(243, 244, 246, 0))"
@@ -56426,7 +53651,6 @@ via_gray_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_200 : Css.Style
 via_gray_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e5e7eb, var(--tw-gradient-to, rgba(229, 231, 235, 0))"
@@ -56437,7 +53661,6 @@ via_gray_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_300 : Css.Style
 via_gray_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d1d5db, var(--tw-gradient-to, rgba(209, 213, 219, 0))"
@@ -56448,7 +53671,6 @@ via_gray_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_400 : Css.Style
 via_gray_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9ca3af, var(--tw-gradient-to, rgba(156, 163, 175, 0))"
@@ -56459,7 +53681,6 @@ via_gray_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_50 : Css.Style
 via_gray_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9fafb, var(--tw-gradient-to, rgba(249, 250, 251, 0))"
@@ -56470,7 +53691,6 @@ via_gray_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_500 : Css.Style
 via_gray_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6b7280, var(--tw-gradient-to, rgba(107, 114, 128, 0))"
@@ -56481,7 +53701,6 @@ via_gray_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_600 : Css.Style
 via_gray_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4b5563, var(--tw-gradient-to, rgba(75, 85, 99, 0))"
@@ -56492,7 +53711,6 @@ via_gray_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_700 : Css.Style
 via_gray_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #374151, var(--tw-gradient-to, rgba(55, 65, 81, 0))"
@@ -56503,7 +53721,6 @@ via_gray_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_800 : Css.Style
 via_gray_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1f2937, var(--tw-gradient-to, rgba(31, 41, 55, 0))"
@@ -56514,7 +53731,6 @@ via_gray_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_gray_900 : Css.Style
 via_gray_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #111827, var(--tw-gradient-to, rgba(17, 24, 39, 0))"
@@ -56525,7 +53741,6 @@ via_gray_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_100 : Css.Style
 via_green_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d1fae5, var(--tw-gradient-to, rgba(209, 250, 229, 0))"
@@ -56536,7 +53751,6 @@ via_green_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_200 : Css.Style
 via_green_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a7f3d0, var(--tw-gradient-to, rgba(167, 243, 208, 0))"
@@ -56547,7 +53761,6 @@ via_green_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_300 : Css.Style
 via_green_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6ee7b7, var(--tw-gradient-to, rgba(110, 231, 183, 0))"
@@ -56558,7 +53771,6 @@ via_green_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_400 : Css.Style
 via_green_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #34d399, var(--tw-gradient-to, rgba(52, 211, 153, 0))"
@@ -56569,7 +53781,6 @@ via_green_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_50 : Css.Style
 via_green_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ecfdf5, var(--tw-gradient-to, rgba(236, 253, 245, 0))"
@@ -56580,7 +53791,6 @@ via_green_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_500 : Css.Style
 via_green_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #10b981, var(--tw-gradient-to, rgba(16, 185, 129, 0))"
@@ -56591,7 +53801,6 @@ via_green_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_600 : Css.Style
 via_green_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #059669, var(--tw-gradient-to, rgba(5, 150, 105, 0))"
@@ -56602,7 +53811,6 @@ via_green_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_700 : Css.Style
 via_green_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #047857, var(--tw-gradient-to, rgba(4, 120, 87, 0))"
@@ -56613,7 +53821,6 @@ via_green_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_800 : Css.Style
 via_green_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #065f46, var(--tw-gradient-to, rgba(6, 95, 70, 0))"
@@ -56624,7 +53831,6 @@ via_green_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_green_900 : Css.Style
 via_green_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #064e3b, var(--tw-gradient-to, rgba(6, 78, 59, 0))"
@@ -56635,7 +53841,6 @@ via_green_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_100 : Css.Style
 via_indigo_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e0e7ff, var(--tw-gradient-to, rgba(224, 231, 255, 0))"
@@ -56646,7 +53851,6 @@ via_indigo_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_200 : Css.Style
 via_indigo_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c7d2fe, var(--tw-gradient-to, rgba(199, 210, 254, 0))"
@@ -56657,7 +53861,6 @@ via_indigo_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_300 : Css.Style
 via_indigo_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a5b4fc, var(--tw-gradient-to, rgba(165, 180, 252, 0))"
@@ -56668,7 +53871,6 @@ via_indigo_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_400 : Css.Style
 via_indigo_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #818cf8, var(--tw-gradient-to, rgba(129, 140, 248, 0))"
@@ -56679,7 +53881,6 @@ via_indigo_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_50 : Css.Style
 via_indigo_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eef2ff, var(--tw-gradient-to, rgba(238, 242, 255, 0))"
@@ -56690,7 +53891,6 @@ via_indigo_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_500 : Css.Style
 via_indigo_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6366f1, var(--tw-gradient-to, rgba(99, 102, 241, 0))"
@@ -56701,7 +53901,6 @@ via_indigo_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_600 : Css.Style
 via_indigo_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4f46e5, var(--tw-gradient-to, rgba(79, 70, 229, 0))"
@@ -56712,7 +53911,6 @@ via_indigo_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_700 : Css.Style
 via_indigo_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4338ca, var(--tw-gradient-to, rgba(67, 56, 202, 0))"
@@ -56723,7 +53921,6 @@ via_indigo_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_800 : Css.Style
 via_indigo_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3730a3, var(--tw-gradient-to, rgba(55, 48, 163, 0))"
@@ -56734,7 +53931,6 @@ via_indigo_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_indigo_900 : Css.Style
 via_indigo_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #312e81, var(--tw-gradient-to, rgba(49, 46, 129, 0))"
@@ -56745,7 +53941,6 @@ via_indigo_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_100 : Css.Style
 via_pink_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fce7f3, var(--tw-gradient-to, rgba(252, 231, 243, 0))"
@@ -56756,7 +53951,6 @@ via_pink_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_200 : Css.Style
 via_pink_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fbcfe8, var(--tw-gradient-to, rgba(251, 207, 232, 0))"
@@ -56767,7 +53961,6 @@ via_pink_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_300 : Css.Style
 via_pink_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9a8d4, var(--tw-gradient-to, rgba(249, 168, 212, 0))"
@@ -56778,7 +53971,6 @@ via_pink_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_400 : Css.Style
 via_pink_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f472b6, var(--tw-gradient-to, rgba(244, 114, 182, 0))"
@@ -56789,7 +53981,6 @@ via_pink_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_50 : Css.Style
 via_pink_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fdf2f8, var(--tw-gradient-to, rgba(253, 242, 248, 0))"
@@ -56800,7 +53991,6 @@ via_pink_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_500 : Css.Style
 via_pink_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ec4899, var(--tw-gradient-to, rgba(236, 72, 153, 0))"
@@ -56811,7 +54001,6 @@ via_pink_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_600 : Css.Style
 via_pink_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #db2777, var(--tw-gradient-to, rgba(219, 39, 119, 0))"
@@ -56822,7 +54011,6 @@ via_pink_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_700 : Css.Style
 via_pink_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #be185d, var(--tw-gradient-to, rgba(190, 24, 93, 0))"
@@ -56833,7 +54021,6 @@ via_pink_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_800 : Css.Style
 via_pink_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9d174d, var(--tw-gradient-to, rgba(157, 23, 77, 0))"
@@ -56844,7 +54031,6 @@ via_pink_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_pink_900 : Css.Style
 via_pink_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #831843, var(--tw-gradient-to, rgba(131, 24, 67, 0))"
@@ -56855,7 +54041,6 @@ via_pink_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_100 : Css.Style
 via_purple_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ede9fe, var(--tw-gradient-to, rgba(237, 233, 254, 0))"
@@ -56866,7 +54051,6 @@ via_purple_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_200 : Css.Style
 via_purple_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ddd6fe, var(--tw-gradient-to, rgba(221, 214, 254, 0))"
@@ -56877,7 +54061,6 @@ via_purple_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_300 : Css.Style
 via_purple_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c4b5fd, var(--tw-gradient-to, rgba(196, 181, 253, 0))"
@@ -56888,7 +54071,6 @@ via_purple_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_400 : Css.Style
 via_purple_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a78bfa, var(--tw-gradient-to, rgba(167, 139, 250, 0))"
@@ -56899,7 +54081,6 @@ via_purple_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_50 : Css.Style
 via_purple_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5f3ff, var(--tw-gradient-to, rgba(245, 243, 255, 0))"
@@ -56910,7 +54091,6 @@ via_purple_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_500 : Css.Style
 via_purple_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #8b5cf6, var(--tw-gradient-to, rgba(139, 92, 246, 0))"
@@ -56921,7 +54101,6 @@ via_purple_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_600 : Css.Style
 via_purple_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7c3aed, var(--tw-gradient-to, rgba(124, 58, 237, 0))"
@@ -56932,7 +54111,6 @@ via_purple_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_700 : Css.Style
 via_purple_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6d28d9, var(--tw-gradient-to, rgba(109, 40, 217, 0))"
@@ -56943,7 +54121,6 @@ via_purple_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_800 : Css.Style
 via_purple_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #5b21b6, var(--tw-gradient-to, rgba(91, 33, 182, 0))"
@@ -56954,7 +54131,6 @@ via_purple_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_purple_900 : Css.Style
 via_purple_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4c1d95, var(--tw-gradient-to, rgba(76, 29, 149, 0))"
@@ -56965,7 +54141,6 @@ via_purple_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_100 : Css.Style
 via_red_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fee2e2, var(--tw-gradient-to, rgba(254, 226, 226, 0))"
@@ -56976,7 +54151,6 @@ via_red_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_200 : Css.Style
 via_red_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fecaca, var(--tw-gradient-to, rgba(254, 202, 202, 0))"
@@ -56987,7 +54161,6 @@ via_red_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_300 : Css.Style
 via_red_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fca5a5, var(--tw-gradient-to, rgba(252, 165, 165, 0))"
@@ -56998,7 +54171,6 @@ via_red_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_400 : Css.Style
 via_red_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f87171, var(--tw-gradient-to, rgba(248, 113, 113, 0))"
@@ -57009,7 +54181,6 @@ via_red_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_50 : Css.Style
 via_red_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef2f2, var(--tw-gradient-to, rgba(254, 242, 242, 0))"
@@ -57020,7 +54191,6 @@ via_red_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_500 : Css.Style
 via_red_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ef4444, var(--tw-gradient-to, rgba(239, 68, 68, 0))"
@@ -57031,7 +54201,6 @@ via_red_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_600 : Css.Style
 via_red_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #dc2626, var(--tw-gradient-to, rgba(220, 38, 38, 0))"
@@ -57042,7 +54211,6 @@ via_red_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_700 : Css.Style
 via_red_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #b91c1c, var(--tw-gradient-to, rgba(185, 28, 28, 0))"
@@ -57053,7 +54221,6 @@ via_red_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_800 : Css.Style
 via_red_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #991b1b, var(--tw-gradient-to, rgba(153, 27, 27, 0))"
@@ -57064,7 +54231,6 @@ via_red_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_red_900 : Css.Style
 via_red_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7f1d1d, var(--tw-gradient-to, rgba(127, 29, 29, 0))"
@@ -57075,7 +54241,6 @@ via_red_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_transparent : Css.Style
 via_transparent =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0))"
@@ -57086,7 +54251,6 @@ via_transparent =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_white : Css.Style
 via_white =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fff, var(--tw-gradient-to, rgba(255, 255, 255, 0))"
@@ -57097,7 +54261,6 @@ via_white =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_100 : Css.Style
 via_yellow_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef3c7, var(--tw-gradient-to, rgba(254, 243, 199, 0))"
@@ -57108,7 +54271,6 @@ via_yellow_100 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_200 : Css.Style
 via_yellow_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fde68a, var(--tw-gradient-to, rgba(253, 230, 138, 0))"
@@ -57119,7 +54281,6 @@ via_yellow_200 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_300 : Css.Style
 via_yellow_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fcd34d, var(--tw-gradient-to, rgba(252, 211, 77, 0))"
@@ -57130,7 +54291,6 @@ via_yellow_300 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_400 : Css.Style
 via_yellow_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fbbf24, var(--tw-gradient-to, rgba(251, 191, 36, 0))"
@@ -57141,7 +54301,6 @@ via_yellow_400 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_50 : Css.Style
 via_yellow_50 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fffbeb, var(--tw-gradient-to, rgba(255, 251, 235, 0))"
@@ -57152,7 +54311,6 @@ via_yellow_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_500 : Css.Style
 via_yellow_500 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f59e0b, var(--tw-gradient-to, rgba(245, 158, 11, 0))"
@@ -57163,7 +54321,6 @@ via_yellow_500 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_600 : Css.Style
 via_yellow_600 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d97706, var(--tw-gradient-to, rgba(217, 119, 6, 0))"
@@ -57174,7 +54331,6 @@ via_yellow_600 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_700 : Css.Style
 via_yellow_700 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #b45309, var(--tw-gradient-to, rgba(180, 83, 9, 0))"
@@ -57185,7 +54341,6 @@ via_yellow_700 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_800 : Css.Style
 via_yellow_800 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #92400e, var(--tw-gradient-to, rgba(146, 64, 14, 0))"
@@ -57196,7 +54351,6 @@ via_yellow_800 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 via_yellow_900 : Css.Style
 via_yellow_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #78350f, var(--tw-gradient-to, rgba(120, 53, 15, 0))"
@@ -57207,7 +54361,6 @@ via_yellow_900 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 visible : Css.Style
 visible =
     Css.property "visibility" "visible"
@@ -57218,7 +54371,6 @@ visible =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_0 : Css.Style
 w_0 =
     Css.property "width" "0px"
@@ -57229,7 +54381,6 @@ w_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_0_dot_5 : Css.Style
 w_0_dot_5 =
     Css.property "width" "0.125rem"
@@ -57240,7 +54391,6 @@ w_0_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1 : Css.Style
 w_1 =
     Css.property "width" "0.25rem"
@@ -57251,7 +54401,6 @@ w_1 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_10 : Css.Style
 w_10 =
     Css.property "width" "2.5rem"
@@ -57262,7 +54411,6 @@ w_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_10over12 : Css.Style
 w_10over12 =
     Css.property "width" "83.333333%"
@@ -57273,7 +54421,6 @@ w_10over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_11 : Css.Style
 w_11 =
     Css.property "width" "2.75rem"
@@ -57284,7 +54431,6 @@ w_11 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_11over12 : Css.Style
 w_11over12 =
     Css.property "width" "91.666667%"
@@ -57295,7 +54441,6 @@ w_11over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_12 : Css.Style
 w_12 =
     Css.property "width" "3rem"
@@ -57306,7 +54451,6 @@ w_12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_14 : Css.Style
 w_14 =
     Css.property "width" "3.5rem"
@@ -57317,7 +54461,6 @@ w_14 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_16 : Css.Style
 w_16 =
     Css.property "width" "4rem"
@@ -57328,7 +54471,6 @@ w_16 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1_dot_5 : Css.Style
 w_1_dot_5 =
     Css.property "width" "0.375rem"
@@ -57339,7 +54481,6 @@ w_1_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over12 : Css.Style
 w_1over12 =
     Css.property "width" "8.333333%"
@@ -57350,7 +54491,6 @@ w_1over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over2 : Css.Style
 w_1over2 =
     Css.property "width" "50%"
@@ -57361,7 +54501,6 @@ w_1over2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over3 : Css.Style
 w_1over3 =
     Css.property "width" "33.333333%"
@@ -57372,7 +54511,6 @@ w_1over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over4 : Css.Style
 w_1over4 =
     Css.property "width" "25%"
@@ -57383,7 +54521,6 @@ w_1over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over5 : Css.Style
 w_1over5 =
     Css.property "width" "20%"
@@ -57394,7 +54531,6 @@ w_1over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_1over6 : Css.Style
 w_1over6 =
     Css.property "width" "16.666667%"
@@ -57405,7 +54541,6 @@ w_1over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2 : Css.Style
 w_2 =
     Css.property "width" "0.5rem"
@@ -57416,7 +54551,6 @@ w_2 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_20 : Css.Style
 w_20 =
     Css.property "width" "5rem"
@@ -57427,7 +54561,6 @@ w_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_24 : Css.Style
 w_24 =
     Css.property "width" "6rem"
@@ -57438,7 +54571,6 @@ w_24 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_28 : Css.Style
 w_28 =
     Css.property "width" "7rem"
@@ -57449,7 +54581,6 @@ w_28 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2_dot_5 : Css.Style
 w_2_dot_5 =
     Css.property "width" "0.625rem"
@@ -57460,7 +54591,6 @@ w_2_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2over12 : Css.Style
 w_2over12 =
     Css.property "width" "16.666667%"
@@ -57471,7 +54601,6 @@ w_2over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2over3 : Css.Style
 w_2over3 =
     Css.property "width" "66.666667%"
@@ -57482,7 +54611,6 @@ w_2over3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2over4 : Css.Style
 w_2over4 =
     Css.property "width" "50%"
@@ -57493,7 +54621,6 @@ w_2over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2over5 : Css.Style
 w_2over5 =
     Css.property "width" "40%"
@@ -57504,7 +54631,6 @@ w_2over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_2over6 : Css.Style
 w_2over6 =
     Css.property "width" "33.333333%"
@@ -57515,7 +54641,6 @@ w_2over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3 : Css.Style
 w_3 =
     Css.property "width" "0.75rem"
@@ -57526,7 +54651,6 @@ w_3 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_32 : Css.Style
 w_32 =
     Css.property "width" "8rem"
@@ -57537,7 +54661,6 @@ w_32 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_36 : Css.Style
 w_36 =
     Css.property "width" "9rem"
@@ -57548,7 +54671,6 @@ w_36 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3_dot_5 : Css.Style
 w_3_dot_5 =
     Css.property "width" "0.875rem"
@@ -57559,7 +54681,6 @@ w_3_dot_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3over12 : Css.Style
 w_3over12 =
     Css.property "width" "25%"
@@ -57570,7 +54691,6 @@ w_3over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3over4 : Css.Style
 w_3over4 =
     Css.property "width" "75%"
@@ -57581,7 +54701,6 @@ w_3over4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3over5 : Css.Style
 w_3over5 =
     Css.property "width" "60%"
@@ -57592,7 +54711,6 @@ w_3over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_3over6 : Css.Style
 w_3over6 =
     Css.property "width" "50%"
@@ -57603,7 +54721,6 @@ w_3over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_4 : Css.Style
 w_4 =
     Css.property "width" "1rem"
@@ -57614,7 +54731,6 @@ w_4 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_40 : Css.Style
 w_40 =
     Css.property "width" "10rem"
@@ -57625,7 +54741,6 @@ w_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_44 : Css.Style
 w_44 =
     Css.property "width" "11rem"
@@ -57636,7 +54751,6 @@ w_44 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_48 : Css.Style
 w_48 =
     Css.property "width" "12rem"
@@ -57647,7 +54761,6 @@ w_48 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_4over12 : Css.Style
 w_4over12 =
     Css.property "width" "33.333333%"
@@ -57658,7 +54771,6 @@ w_4over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_4over5 : Css.Style
 w_4over5 =
     Css.property "width" "80%"
@@ -57669,7 +54781,6 @@ w_4over5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_4over6 : Css.Style
 w_4over6 =
     Css.property "width" "66.666667%"
@@ -57680,7 +54791,6 @@ w_4over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_5 : Css.Style
 w_5 =
     Css.property "width" "1.25rem"
@@ -57691,7 +54801,6 @@ w_5 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_52 : Css.Style
 w_52 =
     Css.property "width" "13rem"
@@ -57702,7 +54811,6 @@ w_52 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_56 : Css.Style
 w_56 =
     Css.property "width" "14rem"
@@ -57713,7 +54821,6 @@ w_56 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_5over12 : Css.Style
 w_5over12 =
     Css.property "width" "41.666667%"
@@ -57724,7 +54831,6 @@ w_5over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_5over6 : Css.Style
 w_5over6 =
     Css.property "width" "83.333333%"
@@ -57735,7 +54841,6 @@ w_5over6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_6 : Css.Style
 w_6 =
     Css.property "width" "1.5rem"
@@ -57746,7 +54851,6 @@ w_6 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_60 : Css.Style
 w_60 =
     Css.property "width" "15rem"
@@ -57757,7 +54861,6 @@ w_60 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_64 : Css.Style
 w_64 =
     Css.property "width" "16rem"
@@ -57768,7 +54871,6 @@ w_64 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_6over12 : Css.Style
 w_6over12 =
     Css.property "width" "50%"
@@ -57779,7 +54881,6 @@ w_6over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_7 : Css.Style
 w_7 =
     Css.property "width" "1.75rem"
@@ -57790,7 +54891,6 @@ w_7 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_72 : Css.Style
 w_72 =
     Css.property "width" "18rem"
@@ -57801,7 +54901,6 @@ w_72 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_7over12 : Css.Style
 w_7over12 =
     Css.property "width" "58.333333%"
@@ -57812,7 +54911,6 @@ w_7over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_8 : Css.Style
 w_8 =
     Css.property "width" "2rem"
@@ -57823,7 +54921,6 @@ w_8 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_80 : Css.Style
 w_80 =
     Css.property "width" "20rem"
@@ -57834,7 +54931,6 @@ w_80 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_8over12 : Css.Style
 w_8over12 =
     Css.property "width" "66.666667%"
@@ -57845,7 +54941,6 @@ w_8over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_9 : Css.Style
 w_9 =
     Css.property "width" "2.25rem"
@@ -57856,7 +54951,6 @@ w_9 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_96 : Css.Style
 w_96 =
     Css.property "width" "24rem"
@@ -57867,7 +54961,6 @@ w_96 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_9over12 : Css.Style
 w_9over12 =
     Css.property "width" "75%"
@@ -57878,7 +54971,6 @@ w_9over12 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_auto : Css.Style
 w_auto =
     Css.property "width" "auto"
@@ -57889,7 +54981,6 @@ w_auto =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_full : Css.Style
 w_full =
     Css.property "width" "100%"
@@ -57900,7 +54991,6 @@ w_full =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_max : Css.Style
 w_max =
     Css.batch
@@ -57915,7 +55005,6 @@ w_max =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_min : Css.Style
 w_min =
     Css.batch
@@ -57930,7 +55019,6 @@ w_min =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_px : Css.Style
 w_px =
     Css.property "width" "1px"
@@ -57941,7 +55029,6 @@ w_px =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 w_screen : Css.Style
 w_screen =
     Css.property "width" "100vw"
@@ -57952,7 +55039,6 @@ w_screen =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 whitespace_normal : Css.Style
 whitespace_normal =
     Css.property "white-space" "normal"
@@ -57963,7 +55049,6 @@ whitespace_normal =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 whitespace_nowrap : Css.Style
 whitespace_nowrap =
     Css.property "white-space" "nowrap"
@@ -57974,7 +55059,6 @@ whitespace_nowrap =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 whitespace_pre : Css.Style
 whitespace_pre =
     Css.property "white-space" "pre"
@@ -57985,7 +55069,6 @@ whitespace_pre =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 whitespace_pre_line : Css.Style
 whitespace_pre_line =
     Css.property "white-space" "pre-line"
@@ -57996,7 +55079,6 @@ whitespace_pre_line =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 whitespace_pre_wrap : Css.Style
 whitespace_pre_wrap =
     Css.property "white-space" "pre-wrap"
@@ -58007,7 +55089,6 @@ whitespace_pre_wrap =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_0 : Css.Style
 z_0 =
     Css.property "z-index" "0"
@@ -58018,7 +55099,6 @@ z_0 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_10 : Css.Style
 z_10 =
     Css.property "z-index" "10"
@@ -58029,7 +55109,6 @@ z_10 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_20 : Css.Style
 z_20 =
     Css.property "z-index" "20"
@@ -58040,7 +55119,6 @@ z_20 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_30 : Css.Style
 z_30 =
     Css.property "z-index" "30"
@@ -58051,7 +55129,6 @@ z_30 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_40 : Css.Style
 z_40 =
     Css.property "z-index" "40"
@@ -58062,7 +55139,6 @@ z_40 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_50 : Css.Style
 z_50 =
     Css.property "z-index" "50"
@@ -58073,7 +55149,6030 @@ z_50 =
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-
 z_auto : Css.Style
 z_auto =
     Css.property "z-index" "auto"
+
+
+
+-- CODE ADDITIONS
+
+
+{-| The tailwind class `bg-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_50 : Css.Style
+bg_slate_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(248, 250, 252, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_100 : Css.Style
+bg_slate_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(241, 245, 249, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_200 : Css.Style
+bg_slate_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(226, 232, 240, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_300 : Css.Style
+bg_slate_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(203, 213, 225, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_400 : Css.Style
+bg_slate_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(148, 163, 184, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_500 : Css.Style
+bg_slate_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(100, 116, 139, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_600 : Css.Style
+bg_slate_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(71, 85, 105, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_700 : Css.Style
+bg_slate_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(51, 65, 85, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_800 : Css.Style
+bg_slate_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(30, 41, 59, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_slate_900 : Css.Style
+bg_slate_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(15, 23, 42, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_50 : Css.Style
+bg_zinc_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(250, 250, 250, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_100 : Css.Style
+bg_zinc_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(244, 244, 245, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_200 : Css.Style
+bg_zinc_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(228, 228, 231, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_300 : Css.Style
+bg_zinc_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(212, 212, 216, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_400 : Css.Style
+bg_zinc_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(161, 161, 170, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_500 : Css.Style
+bg_zinc_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(113, 113, 122, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_600 : Css.Style
+bg_zinc_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(82, 82, 91, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_700 : Css.Style
+bg_zinc_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(63, 63, 70, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_800 : Css.Style
+bg_zinc_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(39, 39, 42, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_zinc_900 : Css.Style
+bg_zinc_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(24, 24, 27, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_50 : Css.Style
+bg_neutral_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(250, 250, 250, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_100 : Css.Style
+bg_neutral_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(245, 245, 245, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_200 : Css.Style
+bg_neutral_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(229, 229, 229, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_300 : Css.Style
+bg_neutral_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(212, 212, 212, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_400 : Css.Style
+bg_neutral_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(163, 163, 163, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_500 : Css.Style
+bg_neutral_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(115, 115, 115, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_600 : Css.Style
+bg_neutral_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(82, 82, 82, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_700 : Css.Style
+bg_neutral_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(64, 64, 64, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_800 : Css.Style
+bg_neutral_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(38, 38, 38, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_neutral_900 : Css.Style
+bg_neutral_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(23, 23, 23, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_50 : Css.Style
+bg_stone_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(250, 250, 249, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_100 : Css.Style
+bg_stone_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(245, 245, 244, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_200 : Css.Style
+bg_stone_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(231, 229, 228, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_300 : Css.Style
+bg_stone_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(214, 211, 209, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_400 : Css.Style
+bg_stone_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(168, 162, 158, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_500 : Css.Style
+bg_stone_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(120, 113, 108, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_600 : Css.Style
+bg_stone_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(87, 83, 78, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_700 : Css.Style
+bg_stone_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(68, 64, 60, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_800 : Css.Style
+bg_stone_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(41, 37, 36, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_stone_900 : Css.Style
+bg_stone_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(28, 25, 23, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_50 : Css.Style
+bg_orange_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(255, 247, 237, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_100 : Css.Style
+bg_orange_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(255, 237, 213, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_200 : Css.Style
+bg_orange_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(254, 215, 170, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_300 : Css.Style
+bg_orange_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(253, 186, 116, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_400 : Css.Style
+bg_orange_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(251, 146, 60, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_500 : Css.Style
+bg_orange_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(249, 115, 22, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_600 : Css.Style
+bg_orange_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(234, 88, 12, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_700 : Css.Style
+bg_orange_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(194, 65, 12, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_800 : Css.Style
+bg_orange_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(154, 52, 18, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_orange_900 : Css.Style
+bg_orange_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(124, 45, 18, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_50 : Css.Style
+bg_amber_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(255, 251, 235, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_100 : Css.Style
+bg_amber_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(254, 243, 199, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_200 : Css.Style
+bg_amber_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(253, 230, 138, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_300 : Css.Style
+bg_amber_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(252, 211, 77, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_400 : Css.Style
+bg_amber_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(251, 191, 36, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_500 : Css.Style
+bg_amber_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(245, 158, 11, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_600 : Css.Style
+bg_amber_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(217, 119, 6, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_700 : Css.Style
+bg_amber_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(180, 83, 9, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_800 : Css.Style
+bg_amber_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(146, 64, 14, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_amber_900 : Css.Style
+bg_amber_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(120, 53, 15, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_50 : Css.Style
+bg_lime_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(247, 254, 231, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_100 : Css.Style
+bg_lime_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(236, 252, 203, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_200 : Css.Style
+bg_lime_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(217, 249, 157, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_300 : Css.Style
+bg_lime_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(190, 242, 100, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_400 : Css.Style
+bg_lime_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(163, 230, 53, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_500 : Css.Style
+bg_lime_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(132, 204, 22, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_600 : Css.Style
+bg_lime_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(101, 163, 13, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_700 : Css.Style
+bg_lime_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(77, 124, 15, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_800 : Css.Style
+bg_lime_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(63, 98, 18, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_lime_900 : Css.Style
+bg_lime_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(54, 83, 20, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_50 : Css.Style
+bg_emerald_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(236, 253, 245, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_100 : Css.Style
+bg_emerald_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(209, 250, 229, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_200 : Css.Style
+bg_emerald_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(167, 243, 208, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_300 : Css.Style
+bg_emerald_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(110, 231, 183, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_400 : Css.Style
+bg_emerald_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(52, 211, 153, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_500 : Css.Style
+bg_emerald_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(16, 185, 129, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_600 : Css.Style
+bg_emerald_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(5, 150, 105, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_700 : Css.Style
+bg_emerald_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(4, 120, 87, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_800 : Css.Style
+bg_emerald_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(6, 95, 70, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_emerald_900 : Css.Style
+bg_emerald_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(6, 78, 59, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_50 : Css.Style
+bg_teal_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(240, 253, 250, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_100 : Css.Style
+bg_teal_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(204, 251, 241, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_200 : Css.Style
+bg_teal_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(153, 246, 228, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_300 : Css.Style
+bg_teal_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(94, 234, 212, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_400 : Css.Style
+bg_teal_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(45, 212, 191, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_500 : Css.Style
+bg_teal_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(20, 184, 166, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_600 : Css.Style
+bg_teal_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(13, 148, 136, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_700 : Css.Style
+bg_teal_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(15, 118, 110, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_800 : Css.Style
+bg_teal_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(17, 94, 89, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_teal_900 : Css.Style
+bg_teal_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(19, 78, 74, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_50 : Css.Style
+bg_cyan_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(236, 254, 255, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_100 : Css.Style
+bg_cyan_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(207, 250, 254, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_200 : Css.Style
+bg_cyan_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(165, 243, 252, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_300 : Css.Style
+bg_cyan_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(103, 232, 249, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_400 : Css.Style
+bg_cyan_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(34, 211, 238, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_500 : Css.Style
+bg_cyan_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(6, 182, 212, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_600 : Css.Style
+bg_cyan_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(8, 145, 178, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_700 : Css.Style
+bg_cyan_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(14, 116, 144, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_800 : Css.Style
+bg_cyan_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(21, 94, 117, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_cyan_900 : Css.Style
+bg_cyan_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(22, 78, 99, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_50 : Css.Style
+bg_sky_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(240, 249, 255, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_100 : Css.Style
+bg_sky_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(224, 242, 254, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_200 : Css.Style
+bg_sky_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(186, 230, 253, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_300 : Css.Style
+bg_sky_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(125, 211, 252, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_400 : Css.Style
+bg_sky_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(56, 189, 248, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_500 : Css.Style
+bg_sky_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(14, 165, 233, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_600 : Css.Style
+bg_sky_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(2, 132, 199, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_700 : Css.Style
+bg_sky_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(3, 105, 161, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_800 : Css.Style
+bg_sky_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(7, 89, 133, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_sky_900 : Css.Style
+bg_sky_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(12, 74, 110, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_50 : Css.Style
+bg_violet_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(245, 243, 255, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_100 : Css.Style
+bg_violet_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(237, 233, 254, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_200 : Css.Style
+bg_violet_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(221, 214, 254, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_300 : Css.Style
+bg_violet_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(196, 181, 253, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_400 : Css.Style
+bg_violet_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(167, 139, 250, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_500 : Css.Style
+bg_violet_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(139, 92, 246, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_600 : Css.Style
+bg_violet_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(124, 58, 237, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_700 : Css.Style
+bg_violet_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(109, 40, 217, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_800 : Css.Style
+bg_violet_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(91, 33, 182, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_violet_900 : Css.Style
+bg_violet_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(76, 29, 149, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_50 : Css.Style
+bg_fuchsia_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(253, 244, 255, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_100 : Css.Style
+bg_fuchsia_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(250, 232, 255, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_200 : Css.Style
+bg_fuchsia_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(245, 208, 254, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_300 : Css.Style
+bg_fuchsia_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(240, 171, 252, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_400 : Css.Style
+bg_fuchsia_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(232, 121, 249, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_500 : Css.Style
+bg_fuchsia_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(217, 70, 239, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_600 : Css.Style
+bg_fuchsia_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(192, 38, 211, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_700 : Css.Style
+bg_fuchsia_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(162, 28, 175, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_800 : Css.Style
+bg_fuchsia_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(134, 25, 143, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_fuchsia_900 : Css.Style
+bg_fuchsia_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(112, 26, 117, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_50 : Css.Style
+bg_rose_50 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(255, 241, 242, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_100 : Css.Style
+bg_rose_100 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(255, 228, 230, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_200 : Css.Style
+bg_rose_200 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(254, 205, 211, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_300 : Css.Style
+bg_rose_300 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(253, 164, 175, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_400 : Css.Style
+bg_rose_400 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(251, 113, 133, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_500 : Css.Style
+bg_rose_500 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(244, 63, 94, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_600 : Css.Style
+bg_rose_600 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(225, 29, 72, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_700 : Css.Style
+bg_rose_700 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(190, 18, 60, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_800 : Css.Style
+bg_rose_800 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(159, 18, 57, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `bg-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+bg_rose_900 : Css.Style
+bg_rose_900 =
+    Css.batch
+        [ Css.property "--tw-bg-opacity" "1"
+        , Css.property "background-color" "rgba(136, 19, 55, var(--tw-bg-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_50 : Css.Style
+border_slate_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(248, 250, 252, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_100 : Css.Style
+border_slate_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(241, 245, 249, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_200 : Css.Style
+border_slate_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(226, 232, 240, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_300 : Css.Style
+border_slate_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(203, 213, 225, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_400 : Css.Style
+border_slate_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(148, 163, 184, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_500 : Css.Style
+border_slate_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(100, 116, 139, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_600 : Css.Style
+border_slate_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(71, 85, 105, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_700 : Css.Style
+border_slate_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(51, 65, 85, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_800 : Css.Style
+border_slate_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(30, 41, 59, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_slate_900 : Css.Style
+border_slate_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(15, 23, 42, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_50 : Css.Style
+border_zinc_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(250, 250, 250, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_100 : Css.Style
+border_zinc_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(244, 244, 245, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_200 : Css.Style
+border_zinc_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(228, 228, 231, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_300 : Css.Style
+border_zinc_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(212, 212, 216, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_400 : Css.Style
+border_zinc_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(161, 161, 170, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_500 : Css.Style
+border_zinc_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(113, 113, 122, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_600 : Css.Style
+border_zinc_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(82, 82, 91, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_700 : Css.Style
+border_zinc_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(63, 63, 70, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_800 : Css.Style
+border_zinc_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(39, 39, 42, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_zinc_900 : Css.Style
+border_zinc_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(24, 24, 27, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_50 : Css.Style
+border_neutral_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(250, 250, 250, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_100 : Css.Style
+border_neutral_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(245, 245, 245, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_200 : Css.Style
+border_neutral_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(229, 229, 229, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_300 : Css.Style
+border_neutral_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(212, 212, 212, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_400 : Css.Style
+border_neutral_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(163, 163, 163, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_500 : Css.Style
+border_neutral_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(115, 115, 115, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_600 : Css.Style
+border_neutral_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(82, 82, 82, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_700 : Css.Style
+border_neutral_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(64, 64, 64, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_800 : Css.Style
+border_neutral_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(38, 38, 38, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_neutral_900 : Css.Style
+border_neutral_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(23, 23, 23, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_50 : Css.Style
+border_stone_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(250, 250, 249, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_100 : Css.Style
+border_stone_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(245, 245, 244, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_200 : Css.Style
+border_stone_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(231, 229, 228, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_300 : Css.Style
+border_stone_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(214, 211, 209, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_400 : Css.Style
+border_stone_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(168, 162, 158, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_500 : Css.Style
+border_stone_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(120, 113, 108, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_600 : Css.Style
+border_stone_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(87, 83, 78, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_700 : Css.Style
+border_stone_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(68, 64, 60, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_800 : Css.Style
+border_stone_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(41, 37, 36, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_stone_900 : Css.Style
+border_stone_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(28, 25, 23, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_50 : Css.Style
+border_orange_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(255, 247, 237, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_100 : Css.Style
+border_orange_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(255, 237, 213, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_200 : Css.Style
+border_orange_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(254, 215, 170, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_300 : Css.Style
+border_orange_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(253, 186, 116, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_400 : Css.Style
+border_orange_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(251, 146, 60, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_500 : Css.Style
+border_orange_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(249, 115, 22, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_600 : Css.Style
+border_orange_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(234, 88, 12, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_700 : Css.Style
+border_orange_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(194, 65, 12, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_800 : Css.Style
+border_orange_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(154, 52, 18, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_orange_900 : Css.Style
+border_orange_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(124, 45, 18, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_50 : Css.Style
+border_amber_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(255, 251, 235, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_100 : Css.Style
+border_amber_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(254, 243, 199, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_200 : Css.Style
+border_amber_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(253, 230, 138, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_300 : Css.Style
+border_amber_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(252, 211, 77, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_400 : Css.Style
+border_amber_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(251, 191, 36, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_500 : Css.Style
+border_amber_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(245, 158, 11, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_600 : Css.Style
+border_amber_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(217, 119, 6, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_700 : Css.Style
+border_amber_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(180, 83, 9, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_800 : Css.Style
+border_amber_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(146, 64, 14, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_amber_900 : Css.Style
+border_amber_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(120, 53, 15, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_50 : Css.Style
+border_lime_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(247, 254, 231, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_100 : Css.Style
+border_lime_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(236, 252, 203, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_200 : Css.Style
+border_lime_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(217, 249, 157, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_300 : Css.Style
+border_lime_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(190, 242, 100, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_400 : Css.Style
+border_lime_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(163, 230, 53, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_500 : Css.Style
+border_lime_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(132, 204, 22, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_600 : Css.Style
+border_lime_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(101, 163, 13, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_700 : Css.Style
+border_lime_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(77, 124, 15, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_800 : Css.Style
+border_lime_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(63, 98, 18, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_lime_900 : Css.Style
+border_lime_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(54, 83, 20, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_50 : Css.Style
+border_emerald_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(236, 253, 245, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_100 : Css.Style
+border_emerald_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(209, 250, 229, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_200 : Css.Style
+border_emerald_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(167, 243, 208, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_300 : Css.Style
+border_emerald_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(110, 231, 183, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_400 : Css.Style
+border_emerald_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(52, 211, 153, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_500 : Css.Style
+border_emerald_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(16, 185, 129, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_600 : Css.Style
+border_emerald_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(5, 150, 105, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_700 : Css.Style
+border_emerald_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(4, 120, 87, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_800 : Css.Style
+border_emerald_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(6, 95, 70, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_emerald_900 : Css.Style
+border_emerald_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(6, 78, 59, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_50 : Css.Style
+border_teal_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(240, 253, 250, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_100 : Css.Style
+border_teal_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(204, 251, 241, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_200 : Css.Style
+border_teal_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(153, 246, 228, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_300 : Css.Style
+border_teal_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(94, 234, 212, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_400 : Css.Style
+border_teal_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(45, 212, 191, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_500 : Css.Style
+border_teal_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(20, 184, 166, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_600 : Css.Style
+border_teal_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(13, 148, 136, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_700 : Css.Style
+border_teal_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(15, 118, 110, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_800 : Css.Style
+border_teal_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(17, 94, 89, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_teal_900 : Css.Style
+border_teal_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(19, 78, 74, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_50 : Css.Style
+border_cyan_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(236, 254, 255, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_100 : Css.Style
+border_cyan_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(207, 250, 254, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_200 : Css.Style
+border_cyan_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(165, 243, 252, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_300 : Css.Style
+border_cyan_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(103, 232, 249, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_400 : Css.Style
+border_cyan_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(34, 211, 238, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_500 : Css.Style
+border_cyan_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(6, 182, 212, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_600 : Css.Style
+border_cyan_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(8, 145, 178, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_700 : Css.Style
+border_cyan_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(14, 116, 144, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_800 : Css.Style
+border_cyan_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(21, 94, 117, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_cyan_900 : Css.Style
+border_cyan_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(22, 78, 99, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_50 : Css.Style
+border_sky_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(240, 249, 255, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_100 : Css.Style
+border_sky_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(224, 242, 254, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_200 : Css.Style
+border_sky_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(186, 230, 253, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_300 : Css.Style
+border_sky_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(125, 211, 252, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_400 : Css.Style
+border_sky_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(56, 189, 248, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_500 : Css.Style
+border_sky_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(14, 165, 233, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_600 : Css.Style
+border_sky_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(2, 132, 199, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_700 : Css.Style
+border_sky_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(3, 105, 161, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_800 : Css.Style
+border_sky_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(7, 89, 133, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_sky_900 : Css.Style
+border_sky_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(12, 74, 110, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_50 : Css.Style
+border_violet_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(245, 243, 255, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_100 : Css.Style
+border_violet_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(237, 233, 254, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_200 : Css.Style
+border_violet_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(221, 214, 254, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_300 : Css.Style
+border_violet_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(196, 181, 253, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_400 : Css.Style
+border_violet_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(167, 139, 250, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_500 : Css.Style
+border_violet_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(139, 92, 246, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_600 : Css.Style
+border_violet_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(124, 58, 237, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_700 : Css.Style
+border_violet_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(109, 40, 217, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_800 : Css.Style
+border_violet_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(91, 33, 182, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_violet_900 : Css.Style
+border_violet_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(76, 29, 149, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_50 : Css.Style
+border_fuchsia_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(253, 244, 255, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_100 : Css.Style
+border_fuchsia_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(250, 232, 255, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_200 : Css.Style
+border_fuchsia_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(245, 208, 254, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_300 : Css.Style
+border_fuchsia_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(240, 171, 252, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_400 : Css.Style
+border_fuchsia_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(232, 121, 249, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_500 : Css.Style
+border_fuchsia_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(217, 70, 239, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_600 : Css.Style
+border_fuchsia_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(192, 38, 211, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_700 : Css.Style
+border_fuchsia_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(162, 28, 175, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_800 : Css.Style
+border_fuchsia_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(134, 25, 143, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_fuchsia_900 : Css.Style
+border_fuchsia_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(112, 26, 117, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_50 : Css.Style
+border_rose_50 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(255, 241, 242, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_100 : Css.Style
+border_rose_100 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(255, 228, 230, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_200 : Css.Style
+border_rose_200 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(254, 205, 211, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_300 : Css.Style
+border_rose_300 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(253, 164, 175, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_400 : Css.Style
+border_rose_400 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(251, 113, 133, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_500 : Css.Style
+border_rose_500 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(244, 63, 94, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_600 : Css.Style
+border_rose_600 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(225, 29, 72, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_700 : Css.Style
+border_rose_700 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(190, 18, 60, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_800 : Css.Style
+border_rose_800 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(159, 18, 57, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `border-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+border_rose_900 : Css.Style
+border_rose_900 =
+    Css.batch
+        [ Css.property "--tw-border-opacity" "1"
+        , Css.property "border-color" "rgba(136, 19, 55, var(--tw-border-opacity))"
+        ]
+
+
+{-| The tailwind class `divide-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_50 : Css.Style
+divide_slate_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(248, 250, 252, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_100 : Css.Style
+divide_slate_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(241, 245, 249, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_200 : Css.Style
+divide_slate_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(226, 232, 240, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_300 : Css.Style
+divide_slate_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(203, 213, 225, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_400 : Css.Style
+divide_slate_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(148, 163, 184, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_500 : Css.Style
+divide_slate_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(100, 116, 139, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_600 : Css.Style
+divide_slate_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(71, 85, 105, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_700 : Css.Style
+divide_slate_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(51, 65, 85, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_800 : Css.Style
+divide_slate_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(30, 41, 59, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_slate_900 : Css.Style
+divide_slate_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(15, 23, 42, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_50 : Css.Style
+divide_zinc_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(250, 250, 250, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_100 : Css.Style
+divide_zinc_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(244, 244, 245, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_200 : Css.Style
+divide_zinc_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(228, 228, 231, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_300 : Css.Style
+divide_zinc_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(212, 212, 216, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_400 : Css.Style
+divide_zinc_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(161, 161, 170, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_500 : Css.Style
+divide_zinc_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(113, 113, 122, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_600 : Css.Style
+divide_zinc_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(82, 82, 91, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_700 : Css.Style
+divide_zinc_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(63, 63, 70, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_800 : Css.Style
+divide_zinc_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(39, 39, 42, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_zinc_900 : Css.Style
+divide_zinc_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(24, 24, 27, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_50 : Css.Style
+divide_neutral_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(250, 250, 250, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_100 : Css.Style
+divide_neutral_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(245, 245, 245, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_200 : Css.Style
+divide_neutral_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(229, 229, 229, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_300 : Css.Style
+divide_neutral_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(212, 212, 212, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_400 : Css.Style
+divide_neutral_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(163, 163, 163, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_500 : Css.Style
+divide_neutral_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(115, 115, 115, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_600 : Css.Style
+divide_neutral_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(82, 82, 82, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_700 : Css.Style
+divide_neutral_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(64, 64, 64, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_800 : Css.Style
+divide_neutral_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(38, 38, 38, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_neutral_900 : Css.Style
+divide_neutral_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(23, 23, 23, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_50 : Css.Style
+divide_stone_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(250, 250, 249, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_100 : Css.Style
+divide_stone_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(245, 245, 244, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_200 : Css.Style
+divide_stone_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(231, 229, 228, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_300 : Css.Style
+divide_stone_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(214, 211, 209, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_400 : Css.Style
+divide_stone_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(168, 162, 158, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_500 : Css.Style
+divide_stone_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(120, 113, 108, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_600 : Css.Style
+divide_stone_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(87, 83, 78, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_700 : Css.Style
+divide_stone_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(68, 64, 60, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_800 : Css.Style
+divide_stone_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(41, 37, 36, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_stone_900 : Css.Style
+divide_stone_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(28, 25, 23, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_50 : Css.Style
+divide_orange_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(255, 247, 237, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_100 : Css.Style
+divide_orange_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(255, 237, 213, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_200 : Css.Style
+divide_orange_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(254, 215, 170, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_300 : Css.Style
+divide_orange_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(253, 186, 116, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_400 : Css.Style
+divide_orange_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(251, 146, 60, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_500 : Css.Style
+divide_orange_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(249, 115, 22, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_600 : Css.Style
+divide_orange_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(234, 88, 12, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_700 : Css.Style
+divide_orange_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(194, 65, 12, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_800 : Css.Style
+divide_orange_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(154, 52, 18, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_orange_900 : Css.Style
+divide_orange_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(124, 45, 18, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_50 : Css.Style
+divide_amber_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(255, 251, 235, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_100 : Css.Style
+divide_amber_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(254, 243, 199, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_200 : Css.Style
+divide_amber_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(253, 230, 138, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_300 : Css.Style
+divide_amber_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(252, 211, 77, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_400 : Css.Style
+divide_amber_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(251, 191, 36, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_500 : Css.Style
+divide_amber_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(245, 158, 11, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_600 : Css.Style
+divide_amber_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(217, 119, 6, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_700 : Css.Style
+divide_amber_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(180, 83, 9, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_800 : Css.Style
+divide_amber_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(146, 64, 14, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_amber_900 : Css.Style
+divide_amber_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(120, 53, 15, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_50 : Css.Style
+divide_lime_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(247, 254, 231, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_100 : Css.Style
+divide_lime_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(236, 252, 203, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_200 : Css.Style
+divide_lime_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(217, 249, 157, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_300 : Css.Style
+divide_lime_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(190, 242, 100, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_400 : Css.Style
+divide_lime_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(163, 230, 53, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_500 : Css.Style
+divide_lime_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(132, 204, 22, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_600 : Css.Style
+divide_lime_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(101, 163, 13, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_700 : Css.Style
+divide_lime_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(77, 124, 15, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_800 : Css.Style
+divide_lime_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(63, 98, 18, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_lime_900 : Css.Style
+divide_lime_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(54, 83, 20, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_50 : Css.Style
+divide_emerald_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(236, 253, 245, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_100 : Css.Style
+divide_emerald_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(209, 250, 229, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_200 : Css.Style
+divide_emerald_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(167, 243, 208, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_300 : Css.Style
+divide_emerald_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(110, 231, 183, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_400 : Css.Style
+divide_emerald_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(52, 211, 153, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_500 : Css.Style
+divide_emerald_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(16, 185, 129, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_600 : Css.Style
+divide_emerald_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(5, 150, 105, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_700 : Css.Style
+divide_emerald_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(4, 120, 87, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_800 : Css.Style
+divide_emerald_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(6, 95, 70, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_emerald_900 : Css.Style
+divide_emerald_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(6, 78, 59, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_50 : Css.Style
+divide_teal_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(240, 253, 250, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_100 : Css.Style
+divide_teal_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(204, 251, 241, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_200 : Css.Style
+divide_teal_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(153, 246, 228, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_300 : Css.Style
+divide_teal_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(94, 234, 212, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_400 : Css.Style
+divide_teal_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(45, 212, 191, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_500 : Css.Style
+divide_teal_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(20, 184, 166, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_600 : Css.Style
+divide_teal_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(13, 148, 136, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_700 : Css.Style
+divide_teal_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(15, 118, 110, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_800 : Css.Style
+divide_teal_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(17, 94, 89, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_teal_900 : Css.Style
+divide_teal_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(19, 78, 74, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_50 : Css.Style
+divide_cyan_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(236, 254, 255, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_100 : Css.Style
+divide_cyan_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(207, 250, 254, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_200 : Css.Style
+divide_cyan_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(165, 243, 252, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_300 : Css.Style
+divide_cyan_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(103, 232, 249, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_400 : Css.Style
+divide_cyan_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(34, 211, 238, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_500 : Css.Style
+divide_cyan_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(6, 182, 212, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_600 : Css.Style
+divide_cyan_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(8, 145, 178, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_700 : Css.Style
+divide_cyan_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(14, 116, 144, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_800 : Css.Style
+divide_cyan_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(21, 94, 117, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_cyan_900 : Css.Style
+divide_cyan_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(22, 78, 99, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_50 : Css.Style
+divide_sky_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(240, 249, 255, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_100 : Css.Style
+divide_sky_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(224, 242, 254, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_200 : Css.Style
+divide_sky_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(186, 230, 253, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_300 : Css.Style
+divide_sky_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(125, 211, 252, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_400 : Css.Style
+divide_sky_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(56, 189, 248, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_500 : Css.Style
+divide_sky_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(14, 165, 233, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_600 : Css.Style
+divide_sky_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(2, 132, 199, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_700 : Css.Style
+divide_sky_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(3, 105, 161, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_800 : Css.Style
+divide_sky_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(7, 89, 133, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_sky_900 : Css.Style
+divide_sky_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(12, 74, 110, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_50 : Css.Style
+divide_violet_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(245, 243, 255, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_100 : Css.Style
+divide_violet_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(237, 233, 254, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_200 : Css.Style
+divide_violet_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(221, 214, 254, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_300 : Css.Style
+divide_violet_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(196, 181, 253, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_400 : Css.Style
+divide_violet_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(167, 139, 250, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_500 : Css.Style
+divide_violet_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(139, 92, 246, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_600 : Css.Style
+divide_violet_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(124, 58, 237, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_700 : Css.Style
+divide_violet_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(109, 40, 217, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_800 : Css.Style
+divide_violet_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(91, 33, 182, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_violet_900 : Css.Style
+divide_violet_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(76, 29, 149, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_50 : Css.Style
+divide_fuchsia_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(253, 244, 255, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_100 : Css.Style
+divide_fuchsia_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(250, 232, 255, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_200 : Css.Style
+divide_fuchsia_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(245, 208, 254, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_300 : Css.Style
+divide_fuchsia_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(240, 171, 252, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_400 : Css.Style
+divide_fuchsia_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(232, 121, 249, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_500 : Css.Style
+divide_fuchsia_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(217, 70, 239, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_600 : Css.Style
+divide_fuchsia_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(192, 38, 211, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_700 : Css.Style
+divide_fuchsia_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(162, 28, 175, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_800 : Css.Style
+divide_fuchsia_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(134, 25, 143, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_fuchsia_900 : Css.Style
+divide_fuchsia_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(112, 26, 117, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_50 : Css.Style
+divide_rose_50 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(255, 241, 242, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_100 : Css.Style
+divide_rose_100 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(255, 228, 230, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_200 : Css.Style
+divide_rose_200 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(254, 205, 211, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_300 : Css.Style
+divide_rose_300 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(253, 164, 175, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_400 : Css.Style
+divide_rose_400 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(251, 113, 133, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_500 : Css.Style
+divide_rose_500 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(244, 63, 94, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_600 : Css.Style
+divide_rose_600 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(225, 29, 72, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_700 : Css.Style
+divide_rose_700 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(190, 18, 60, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_800 : Css.Style
+divide_rose_800 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(159, 18, 57, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]
+
+
+{-| The tailwind class `divide-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+divide_rose_900 : Css.Style
+divide_rose_900 =
+    Css.batch
+        [ Css.Global.children
+            [ Css.Global.selector ":not([hidden]) ~ :not([hidden])"
+                [ Css.property "--tw-divide-opacity" "1"
+                , Css.property "border-color" "rgba(136, 19, 55, var(--tw-divide-opacity))"
+                ]
+            ]
+        ]

--- a/src/Tailwind/Utilities.elm
+++ b/src/Tailwind/Utilities.elm
@@ -722,89 +722,9 @@ module Tailwind.Utilities exposing
     , form_select
     , form_textarea
     , from_black
-    , from_blue_100
-    , from_blue_200
-    , from_blue_300
-    , from_blue_400
-    , from_blue_50
-    , from_blue_500
-    , from_blue_600
-    , from_blue_700
-    , from_blue_800
-    , from_blue_900
     , from_current
-    , from_gray_100
-    , from_gray_200
-    , from_gray_300
-    , from_gray_400
-    , from_gray_50
-    , from_gray_500
-    , from_gray_600
-    , from_gray_700
-    , from_gray_800
-    , from_gray_900
-    , from_green_100
-    , from_green_200
-    , from_green_300
-    , from_green_400
-    , from_green_50
-    , from_green_500
-    , from_green_600
-    , from_green_700
-    , from_green_800
-    , from_green_900
-    , from_indigo_100
-    , from_indigo_200
-    , from_indigo_300
-    , from_indigo_400
-    , from_indigo_50
-    , from_indigo_500
-    , from_indigo_600
-    , from_indigo_700
-    , from_indigo_800
-    , from_indigo_900
-    , from_pink_100
-    , from_pink_200
-    , from_pink_300
-    , from_pink_400
-    , from_pink_50
-    , from_pink_500
-    , from_pink_600
-    , from_pink_700
-    , from_pink_800
-    , from_pink_900
-    , from_purple_100
-    , from_purple_200
-    , from_purple_300
-    , from_purple_400
-    , from_purple_50
-    , from_purple_500
-    , from_purple_600
-    , from_purple_700
-    , from_purple_800
-    , from_purple_900
-    , from_red_100
-    , from_red_200
-    , from_red_300
-    , from_red_400
-    , from_red_50
-    , from_red_500
-    , from_red_600
-    , from_red_700
-    , from_red_800
-    , from_red_900
     , from_transparent
     , from_white
-    , from_yellow_100
-    , from_yellow_200
-    , from_yellow_300
-    , from_yellow_400
-    , from_yellow_50
-    , from_yellow_500
-    , from_yellow_600
-    , from_yellow_700
-    , from_yellow_800
-    , from_yellow_900
     , gap_0
     , gap_0_dot_5
     , gap_1
@@ -3373,89 +3293,9 @@ module Tailwind.Utilities exposing
     , text_yellow_800
     , text_yellow_900
     , to_black
-    , to_blue_100
-    , to_blue_200
-    , to_blue_300
-    , to_blue_400
-    , to_blue_50
-    , to_blue_500
-    , to_blue_600
-    , to_blue_700
-    , to_blue_800
-    , to_blue_900
     , to_current
-    , to_gray_100
-    , to_gray_200
-    , to_gray_300
-    , to_gray_400
-    , to_gray_50
-    , to_gray_500
-    , to_gray_600
-    , to_gray_700
-    , to_gray_800
-    , to_gray_900
-    , to_green_100
-    , to_green_200
-    , to_green_300
-    , to_green_400
-    , to_green_50
-    , to_green_500
-    , to_green_600
-    , to_green_700
-    , to_green_800
-    , to_green_900
-    , to_indigo_100
-    , to_indigo_200
-    , to_indigo_300
-    , to_indigo_400
-    , to_indigo_50
-    , to_indigo_500
-    , to_indigo_600
-    , to_indigo_700
-    , to_indigo_800
-    , to_indigo_900
-    , to_pink_100
-    , to_pink_200
-    , to_pink_300
-    , to_pink_400
-    , to_pink_50
-    , to_pink_500
-    , to_pink_600
-    , to_pink_700
-    , to_pink_800
-    , to_pink_900
-    , to_purple_100
-    , to_purple_200
-    , to_purple_300
-    , to_purple_400
-    , to_purple_50
-    , to_purple_500
-    , to_purple_600
-    , to_purple_700
-    , to_purple_800
-    , to_purple_900
-    , to_red_100
-    , to_red_200
-    , to_red_300
-    , to_red_400
-    , to_red_50
-    , to_red_500
-    , to_red_600
-    , to_red_700
-    , to_red_800
-    , to_red_900
     , to_transparent
     , to_white
-    , to_yellow_100
-    , to_yellow_200
-    , to_yellow_300
-    , to_yellow_400
-    , to_yellow_50
-    , to_yellow_500
-    , to_yellow_600
-    , to_yellow_700
-    , to_yellow_800
-    , to_yellow_900
     , top_0
     , top_0_dot_5
     , top_1
@@ -3603,89 +3443,9 @@ module Tailwind.Utilities exposing
     , underline
     , uppercase
     , via_black
-    , via_blue_100
-    , via_blue_200
-    , via_blue_300
-    , via_blue_400
-    , via_blue_50
-    , via_blue_500
-    , via_blue_600
-    , via_blue_700
-    , via_blue_800
-    , via_blue_900
     , via_current
-    , via_gray_100
-    , via_gray_200
-    , via_gray_300
-    , via_gray_400
-    , via_gray_50
-    , via_gray_500
-    , via_gray_600
-    , via_gray_700
-    , via_gray_800
-    , via_gray_900
-    , via_green_100
-    , via_green_200
-    , via_green_300
-    , via_green_400
-    , via_green_50
-    , via_green_500
-    , via_green_600
-    , via_green_700
-    , via_green_800
-    , via_green_900
-    , via_indigo_100
-    , via_indigo_200
-    , via_indigo_300
-    , via_indigo_400
-    , via_indigo_50
-    , via_indigo_500
-    , via_indigo_600
-    , via_indigo_700
-    , via_indigo_800
-    , via_indigo_900
-    , via_pink_100
-    , via_pink_200
-    , via_pink_300
-    , via_pink_400
-    , via_pink_50
-    , via_pink_500
-    , via_pink_600
-    , via_pink_700
-    , via_pink_800
-    , via_pink_900
-    , via_purple_100
-    , via_purple_200
-    , via_purple_300
-    , via_purple_400
-    , via_purple_50
-    , via_purple_500
-    , via_purple_600
-    , via_purple_700
-    , via_purple_800
-    , via_purple_900
-    , via_red_100
-    , via_red_200
-    , via_red_300
-    , via_red_400
-    , via_red_50
-    , via_red_500
-    , via_red_600
-    , via_red_700
-    , via_red_800
-    , via_red_900
     , via_transparent
     , via_white
-    , via_yellow_100
-    , via_yellow_200
-    , via_yellow_300
-    , via_yellow_400
-    , via_yellow_50
-    , via_yellow_500
-    , via_yellow_600
-    , via_yellow_700
-    , via_yellow_800
-    , via_yellow_900
     , visible
     , w_0
     , w_0_dot_5
@@ -4185,6 +3945,666 @@ module Tailwind.Utilities exposing
     , divide_rose_700
     , divide_rose_800
     , divide_rose_900
+    , from_slate_50
+    , from_slate_100
+    , from_slate_200
+    , from_slate_300
+    , from_slate_400
+    , from_slate_500
+    , from_slate_600
+    , from_slate_700
+    , from_slate_800
+    , from_slate_900
+    , from_gray_50
+    , from_gray_100
+    , from_gray_200
+    , from_gray_300
+    , from_gray_400
+    , from_gray_500
+    , from_gray_600
+    , from_gray_700
+    , from_gray_800
+    , from_gray_900
+    , from_zinc_50
+    , from_zinc_100
+    , from_zinc_200
+    , from_zinc_300
+    , from_zinc_400
+    , from_zinc_500
+    , from_zinc_600
+    , from_zinc_700
+    , from_zinc_800
+    , from_zinc_900
+    , from_neutral_50
+    , from_neutral_100
+    , from_neutral_200
+    , from_neutral_300
+    , from_neutral_400
+    , from_neutral_500
+    , from_neutral_600
+    , from_neutral_700
+    , from_neutral_800
+    , from_neutral_900
+    , from_stone_50
+    , from_stone_100
+    , from_stone_200
+    , from_stone_300
+    , from_stone_400
+    , from_stone_500
+    , from_stone_600
+    , from_stone_700
+    , from_stone_800
+    , from_stone_900
+    , from_red_50
+    , from_red_100
+    , from_red_200
+    , from_red_300
+    , from_red_400
+    , from_red_500
+    , from_red_600
+    , from_red_700
+    , from_red_800
+    , from_red_900
+    , from_orange_50
+    , from_orange_100
+    , from_orange_200
+    , from_orange_300
+    , from_orange_400
+    , from_orange_500
+    , from_orange_600
+    , from_orange_700
+    , from_orange_800
+    , from_orange_900
+    , from_amber_50
+    , from_amber_100
+    , from_amber_200
+    , from_amber_300
+    , from_amber_400
+    , from_amber_500
+    , from_amber_600
+    , from_amber_700
+    , from_amber_800
+    , from_amber_900
+    , from_yellow_50
+    , from_yellow_100
+    , from_yellow_200
+    , from_yellow_300
+    , from_yellow_400
+    , from_yellow_500
+    , from_yellow_600
+    , from_yellow_700
+    , from_yellow_800
+    , from_yellow_900
+    , from_lime_50
+    , from_lime_100
+    , from_lime_200
+    , from_lime_300
+    , from_lime_400
+    , from_lime_500
+    , from_lime_600
+    , from_lime_700
+    , from_lime_800
+    , from_lime_900
+    , from_green_50
+    , from_green_100
+    , from_green_200
+    , from_green_300
+    , from_green_400
+    , from_green_500
+    , from_green_600
+    , from_green_700
+    , from_green_800
+    , from_green_900
+    , from_emerald_50
+    , from_emerald_100
+    , from_emerald_200
+    , from_emerald_300
+    , from_emerald_400
+    , from_emerald_500
+    , from_emerald_600
+    , from_emerald_700
+    , from_emerald_800
+    , from_emerald_900
+    , from_teal_50
+    , from_teal_100
+    , from_teal_200
+    , from_teal_300
+    , from_teal_400
+    , from_teal_500
+    , from_teal_600
+    , from_teal_700
+    , from_teal_800
+    , from_teal_900
+    , from_cyan_50
+    , from_cyan_100
+    , from_cyan_200
+    , from_cyan_300
+    , from_cyan_400
+    , from_cyan_500
+    , from_cyan_600
+    , from_cyan_700
+    , from_cyan_800
+    , from_cyan_900
+    , from_sky_50
+    , from_sky_100
+    , from_sky_200
+    , from_sky_300
+    , from_sky_400
+    , from_sky_500
+    , from_sky_600
+    , from_sky_700
+    , from_sky_800
+    , from_sky_900
+    , from_blue_50
+    , from_blue_100
+    , from_blue_200
+    , from_blue_300
+    , from_blue_400
+    , from_blue_500
+    , from_blue_600
+    , from_blue_700
+    , from_blue_800
+    , from_blue_900
+    , from_indigo_50
+    , from_indigo_100
+    , from_indigo_200
+    , from_indigo_300
+    , from_indigo_400
+    , from_indigo_500
+    , from_indigo_600
+    , from_indigo_700
+    , from_indigo_800
+    , from_indigo_900
+    , from_violet_50
+    , from_violet_100
+    , from_violet_200
+    , from_violet_300
+    , from_violet_400
+    , from_violet_500
+    , from_violet_600
+    , from_violet_700
+    , from_violet_800
+    , from_violet_900
+    , from_purple_50
+    , from_purple_100
+    , from_purple_200
+    , from_purple_300
+    , from_purple_400
+    , from_purple_500
+    , from_purple_600
+    , from_purple_700
+    , from_purple_800
+    , from_purple_900
+    , from_fuchsia_50
+    , from_fuchsia_100
+    , from_fuchsia_200
+    , from_fuchsia_300
+    , from_fuchsia_400
+    , from_fuchsia_500
+    , from_fuchsia_600
+    , from_fuchsia_700
+    , from_fuchsia_800
+    , from_fuchsia_900
+    , from_pink_50
+    , from_pink_100
+    , from_pink_200
+    , from_pink_300
+    , from_pink_400
+    , from_pink_500
+    , from_pink_600
+    , from_pink_700
+    , from_pink_800
+    , from_pink_900
+    , from_rose_50
+    , from_rose_100
+    , from_rose_200
+    , from_rose_300
+    , from_rose_400
+    , from_rose_500
+    , from_rose_600
+    , from_rose_700
+    , from_rose_800
+    , from_rose_900
+    , via_slate_50
+    , via_slate_100
+    , via_slate_200
+    , via_slate_300
+    , via_slate_400
+    , via_slate_500
+    , via_slate_600
+    , via_slate_700
+    , via_slate_800
+    , via_slate_900
+    , via_gray_50
+    , via_gray_100
+    , via_gray_200
+    , via_gray_300
+    , via_gray_400
+    , via_gray_500
+    , via_gray_600
+    , via_gray_700
+    , via_gray_800
+    , via_gray_900
+    , via_zinc_50
+    , via_zinc_100
+    , via_zinc_200
+    , via_zinc_300
+    , via_zinc_400
+    , via_zinc_500
+    , via_zinc_600
+    , via_zinc_700
+    , via_zinc_800
+    , via_zinc_900
+    , via_neutral_50
+    , via_neutral_100
+    , via_neutral_200
+    , via_neutral_300
+    , via_neutral_400
+    , via_neutral_500
+    , via_neutral_600
+    , via_neutral_700
+    , via_neutral_800
+    , via_neutral_900
+    , via_stone_50
+    , via_stone_100
+    , via_stone_200
+    , via_stone_300
+    , via_stone_400
+    , via_stone_500
+    , via_stone_600
+    , via_stone_700
+    , via_stone_800
+    , via_stone_900
+    , via_red_50
+    , via_red_100
+    , via_red_200
+    , via_red_300
+    , via_red_400
+    , via_red_500
+    , via_red_600
+    , via_red_700
+    , via_red_800
+    , via_red_900
+    , via_orange_50
+    , via_orange_100
+    , via_orange_200
+    , via_orange_300
+    , via_orange_400
+    , via_orange_500
+    , via_orange_600
+    , via_orange_700
+    , via_orange_800
+    , via_orange_900
+    , via_amber_50
+    , via_amber_100
+    , via_amber_200
+    , via_amber_300
+    , via_amber_400
+    , via_amber_500
+    , via_amber_600
+    , via_amber_700
+    , via_amber_800
+    , via_amber_900
+    , via_yellow_50
+    , via_yellow_100
+    , via_yellow_200
+    , via_yellow_300
+    , via_yellow_400
+    , via_yellow_500
+    , via_yellow_600
+    , via_yellow_700
+    , via_yellow_800
+    , via_yellow_900
+    , via_lime_50
+    , via_lime_100
+    , via_lime_200
+    , via_lime_300
+    , via_lime_400
+    , via_lime_500
+    , via_lime_600
+    , via_lime_700
+    , via_lime_800
+    , via_lime_900
+    , via_green_50
+    , via_green_100
+    , via_green_200
+    , via_green_300
+    , via_green_400
+    , via_green_500
+    , via_green_600
+    , via_green_700
+    , via_green_800
+    , via_green_900
+    , via_emerald_50
+    , via_emerald_100
+    , via_emerald_200
+    , via_emerald_300
+    , via_emerald_400
+    , via_emerald_500
+    , via_emerald_600
+    , via_emerald_700
+    , via_emerald_800
+    , via_emerald_900
+    , via_teal_50
+    , via_teal_100
+    , via_teal_200
+    , via_teal_300
+    , via_teal_400
+    , via_teal_500
+    , via_teal_600
+    , via_teal_700
+    , via_teal_800
+    , via_teal_900
+    , via_cyan_50
+    , via_cyan_100
+    , via_cyan_200
+    , via_cyan_300
+    , via_cyan_400
+    , via_cyan_500
+    , via_cyan_600
+    , via_cyan_700
+    , via_cyan_800
+    , via_cyan_900
+    , via_sky_50
+    , via_sky_100
+    , via_sky_200
+    , via_sky_300
+    , via_sky_400
+    , via_sky_500
+    , via_sky_600
+    , via_sky_700
+    , via_sky_800
+    , via_sky_900
+    , via_blue_50
+    , via_blue_100
+    , via_blue_200
+    , via_blue_300
+    , via_blue_400
+    , via_blue_500
+    , via_blue_600
+    , via_blue_700
+    , via_blue_800
+    , via_blue_900
+    , via_indigo_50
+    , via_indigo_100
+    , via_indigo_200
+    , via_indigo_300
+    , via_indigo_400
+    , via_indigo_500
+    , via_indigo_600
+    , via_indigo_700
+    , via_indigo_800
+    , via_indigo_900
+    , via_violet_50
+    , via_violet_100
+    , via_violet_200
+    , via_violet_300
+    , via_violet_400
+    , via_violet_500
+    , via_violet_600
+    , via_violet_700
+    , via_violet_800
+    , via_violet_900
+    , via_purple_50
+    , via_purple_100
+    , via_purple_200
+    , via_purple_300
+    , via_purple_400
+    , via_purple_500
+    , via_purple_600
+    , via_purple_700
+    , via_purple_800
+    , via_purple_900
+    , via_fuchsia_50
+    , via_fuchsia_100
+    , via_fuchsia_200
+    , via_fuchsia_300
+    , via_fuchsia_400
+    , via_fuchsia_500
+    , via_fuchsia_600
+    , via_fuchsia_700
+    , via_fuchsia_800
+    , via_fuchsia_900
+    , via_pink_50
+    , via_pink_100
+    , via_pink_200
+    , via_pink_300
+    , via_pink_400
+    , via_pink_500
+    , via_pink_600
+    , via_pink_700
+    , via_pink_800
+    , via_pink_900
+    , via_rose_50
+    , via_rose_100
+    , via_rose_200
+    , via_rose_300
+    , via_rose_400
+    , via_rose_500
+    , via_rose_600
+    , via_rose_700
+    , via_rose_800
+    , via_rose_900
+    , to_slate_50
+    , to_slate_100
+    , to_slate_200
+    , to_slate_300
+    , to_slate_400
+    , to_slate_500
+    , to_slate_600
+    , to_slate_700
+    , to_slate_800
+    , to_slate_900
+    , to_gray_50
+    , to_gray_100
+    , to_gray_200
+    , to_gray_300
+    , to_gray_400
+    , to_gray_500
+    , to_gray_600
+    , to_gray_700
+    , to_gray_800
+    , to_gray_900
+    , to_zinc_50
+    , to_zinc_100
+    , to_zinc_200
+    , to_zinc_300
+    , to_zinc_400
+    , to_zinc_500
+    , to_zinc_600
+    , to_zinc_700
+    , to_zinc_800
+    , to_zinc_900
+    , to_neutral_50
+    , to_neutral_100
+    , to_neutral_200
+    , to_neutral_300
+    , to_neutral_400
+    , to_neutral_500
+    , to_neutral_600
+    , to_neutral_700
+    , to_neutral_800
+    , to_neutral_900
+    , to_stone_50
+    , to_stone_100
+    , to_stone_200
+    , to_stone_300
+    , to_stone_400
+    , to_stone_500
+    , to_stone_600
+    , to_stone_700
+    , to_stone_800
+    , to_stone_900
+    , to_red_50
+    , to_red_100
+    , to_red_200
+    , to_red_300
+    , to_red_400
+    , to_red_500
+    , to_red_600
+    , to_red_700
+    , to_red_800
+    , to_red_900
+    , to_orange_50
+    , to_orange_100
+    , to_orange_200
+    , to_orange_300
+    , to_orange_400
+    , to_orange_500
+    , to_orange_600
+    , to_orange_700
+    , to_orange_800
+    , to_orange_900
+    , to_amber_50
+    , to_amber_100
+    , to_amber_200
+    , to_amber_300
+    , to_amber_400
+    , to_amber_500
+    , to_amber_600
+    , to_amber_700
+    , to_amber_800
+    , to_amber_900
+    , to_yellow_50
+    , to_yellow_100
+    , to_yellow_200
+    , to_yellow_300
+    , to_yellow_400
+    , to_yellow_500
+    , to_yellow_600
+    , to_yellow_700
+    , to_yellow_800
+    , to_yellow_900
+    , to_lime_50
+    , to_lime_100
+    , to_lime_200
+    , to_lime_300
+    , to_lime_400
+    , to_lime_500
+    , to_lime_600
+    , to_lime_700
+    , to_lime_800
+    , to_lime_900
+    , to_green_50
+    , to_green_100
+    , to_green_200
+    , to_green_300
+    , to_green_400
+    , to_green_500
+    , to_green_600
+    , to_green_700
+    , to_green_800
+    , to_green_900
+    , to_emerald_50
+    , to_emerald_100
+    , to_emerald_200
+    , to_emerald_300
+    , to_emerald_400
+    , to_emerald_500
+    , to_emerald_600
+    , to_emerald_700
+    , to_emerald_800
+    , to_emerald_900
+    , to_teal_50
+    , to_teal_100
+    , to_teal_200
+    , to_teal_300
+    , to_teal_400
+    , to_teal_500
+    , to_teal_600
+    , to_teal_700
+    , to_teal_800
+    , to_teal_900
+    , to_cyan_50
+    , to_cyan_100
+    , to_cyan_200
+    , to_cyan_300
+    , to_cyan_400
+    , to_cyan_500
+    , to_cyan_600
+    , to_cyan_700
+    , to_cyan_800
+    , to_cyan_900
+    , to_sky_50
+    , to_sky_100
+    , to_sky_200
+    , to_sky_300
+    , to_sky_400
+    , to_sky_500
+    , to_sky_600
+    , to_sky_700
+    , to_sky_800
+    , to_sky_900
+    , to_blue_50
+    , to_blue_100
+    , to_blue_200
+    , to_blue_300
+    , to_blue_400
+    , to_blue_500
+    , to_blue_600
+    , to_blue_700
+    , to_blue_800
+    , to_blue_900
+    , to_indigo_50
+    , to_indigo_100
+    , to_indigo_200
+    , to_indigo_300
+    , to_indigo_400
+    , to_indigo_500
+    , to_indigo_600
+    , to_indigo_700
+    , to_indigo_800
+    , to_indigo_900
+    , to_violet_50
+    , to_violet_100
+    , to_violet_200
+    , to_violet_300
+    , to_violet_400
+    , to_violet_500
+    , to_violet_600
+    , to_violet_700
+    , to_violet_800
+    , to_violet_900
+    , to_purple_50
+    , to_purple_100
+    , to_purple_200
+    , to_purple_300
+    , to_purple_400
+    , to_purple_500
+    , to_purple_600
+    , to_purple_700
+    , to_purple_800
+    , to_purple_900
+    , to_fuchsia_50
+    , to_fuchsia_100
+    , to_fuchsia_200
+    , to_fuchsia_300
+    , to_fuchsia_400
+    , to_fuchsia_500
+    , to_fuchsia_600
+    , to_fuchsia_700
+    , to_fuchsia_800
+    , to_fuchsia_900
+    , to_pink_50
+    , to_pink_100
+    , to_pink_200
+    , to_pink_300
+    , to_pink_400
+    , to_pink_500
+    , to_pink_600
+    , to_pink_700
+    , to_pink_800
+    , to_pink_900
+    , to_rose_50
+    , to_rose_100
+    , to_rose_200
+    , to_rose_300
+    , to_rose_400
+    , to_rose_500
+    , to_rose_600
+    , to_rose_700
+    , to_rose_800
+    , to_rose_900
     )
 
 {-|
@@ -4923,89 +5343,9 @@ This module contains
 @docs form_select
 @docs form_textarea
 @docs from_black
-@docs from_blue_100
-@docs from_blue_200
-@docs from_blue_300
-@docs from_blue_400
-@docs from_blue_50
-@docs from_blue_500
-@docs from_blue_600
-@docs from_blue_700
-@docs from_blue_800
-@docs from_blue_900
 @docs from_current
-@docs from_gray_100
-@docs from_gray_200
-@docs from_gray_300
-@docs from_gray_400
-@docs from_gray_50
-@docs from_gray_500
-@docs from_gray_600
-@docs from_gray_700
-@docs from_gray_800
-@docs from_gray_900
-@docs from_green_100
-@docs from_green_200
-@docs from_green_300
-@docs from_green_400
-@docs from_green_50
-@docs from_green_500
-@docs from_green_600
-@docs from_green_700
-@docs from_green_800
-@docs from_green_900
-@docs from_indigo_100
-@docs from_indigo_200
-@docs from_indigo_300
-@docs from_indigo_400
-@docs from_indigo_50
-@docs from_indigo_500
-@docs from_indigo_600
-@docs from_indigo_700
-@docs from_indigo_800
-@docs from_indigo_900
-@docs from_pink_100
-@docs from_pink_200
-@docs from_pink_300
-@docs from_pink_400
-@docs from_pink_50
-@docs from_pink_500
-@docs from_pink_600
-@docs from_pink_700
-@docs from_pink_800
-@docs from_pink_900
-@docs from_purple_100
-@docs from_purple_200
-@docs from_purple_300
-@docs from_purple_400
-@docs from_purple_50
-@docs from_purple_500
-@docs from_purple_600
-@docs from_purple_700
-@docs from_purple_800
-@docs from_purple_900
-@docs from_red_100
-@docs from_red_200
-@docs from_red_300
-@docs from_red_400
-@docs from_red_50
-@docs from_red_500
-@docs from_red_600
-@docs from_red_700
-@docs from_red_800
-@docs from_red_900
 @docs from_transparent
 @docs from_white
-@docs from_yellow_100
-@docs from_yellow_200
-@docs from_yellow_300
-@docs from_yellow_400
-@docs from_yellow_50
-@docs from_yellow_500
-@docs from_yellow_600
-@docs from_yellow_700
-@docs from_yellow_800
-@docs from_yellow_900
 @docs gap_0
 @docs gap_0_dot_5
 @docs gap_1
@@ -7574,89 +7914,9 @@ This module contains
 @docs text_yellow_800
 @docs text_yellow_900
 @docs to_black
-@docs to_blue_100
-@docs to_blue_200
-@docs to_blue_300
-@docs to_blue_400
-@docs to_blue_50
-@docs to_blue_500
-@docs to_blue_600
-@docs to_blue_700
-@docs to_blue_800
-@docs to_blue_900
 @docs to_current
-@docs to_gray_100
-@docs to_gray_200
-@docs to_gray_300
-@docs to_gray_400
-@docs to_gray_50
-@docs to_gray_500
-@docs to_gray_600
-@docs to_gray_700
-@docs to_gray_800
-@docs to_gray_900
-@docs to_green_100
-@docs to_green_200
-@docs to_green_300
-@docs to_green_400
-@docs to_green_50
-@docs to_green_500
-@docs to_green_600
-@docs to_green_700
-@docs to_green_800
-@docs to_green_900
-@docs to_indigo_100
-@docs to_indigo_200
-@docs to_indigo_300
-@docs to_indigo_400
-@docs to_indigo_50
-@docs to_indigo_500
-@docs to_indigo_600
-@docs to_indigo_700
-@docs to_indigo_800
-@docs to_indigo_900
-@docs to_pink_100
-@docs to_pink_200
-@docs to_pink_300
-@docs to_pink_400
-@docs to_pink_50
-@docs to_pink_500
-@docs to_pink_600
-@docs to_pink_700
-@docs to_pink_800
-@docs to_pink_900
-@docs to_purple_100
-@docs to_purple_200
-@docs to_purple_300
-@docs to_purple_400
-@docs to_purple_50
-@docs to_purple_500
-@docs to_purple_600
-@docs to_purple_700
-@docs to_purple_800
-@docs to_purple_900
-@docs to_red_100
-@docs to_red_200
-@docs to_red_300
-@docs to_red_400
-@docs to_red_50
-@docs to_red_500
-@docs to_red_600
-@docs to_red_700
-@docs to_red_800
-@docs to_red_900
 @docs to_transparent
 @docs to_white
-@docs to_yellow_100
-@docs to_yellow_200
-@docs to_yellow_300
-@docs to_yellow_400
-@docs to_yellow_50
-@docs to_yellow_500
-@docs to_yellow_600
-@docs to_yellow_700
-@docs to_yellow_800
-@docs to_yellow_900
 @docs top_0
 @docs top_0_dot_5
 @docs top_1
@@ -7804,89 +8064,9 @@ This module contains
 @docs underline
 @docs uppercase
 @docs via_black
-@docs via_blue_100
-@docs via_blue_200
-@docs via_blue_300
-@docs via_blue_400
-@docs via_blue_50
-@docs via_blue_500
-@docs via_blue_600
-@docs via_blue_700
-@docs via_blue_800
-@docs via_blue_900
 @docs via_current
-@docs via_gray_100
-@docs via_gray_200
-@docs via_gray_300
-@docs via_gray_400
-@docs via_gray_50
-@docs via_gray_500
-@docs via_gray_600
-@docs via_gray_700
-@docs via_gray_800
-@docs via_gray_900
-@docs via_green_100
-@docs via_green_200
-@docs via_green_300
-@docs via_green_400
-@docs via_green_50
-@docs via_green_500
-@docs via_green_600
-@docs via_green_700
-@docs via_green_800
-@docs via_green_900
-@docs via_indigo_100
-@docs via_indigo_200
-@docs via_indigo_300
-@docs via_indigo_400
-@docs via_indigo_50
-@docs via_indigo_500
-@docs via_indigo_600
-@docs via_indigo_700
-@docs via_indigo_800
-@docs via_indigo_900
-@docs via_pink_100
-@docs via_pink_200
-@docs via_pink_300
-@docs via_pink_400
-@docs via_pink_50
-@docs via_pink_500
-@docs via_pink_600
-@docs via_pink_700
-@docs via_pink_800
-@docs via_pink_900
-@docs via_purple_100
-@docs via_purple_200
-@docs via_purple_300
-@docs via_purple_400
-@docs via_purple_50
-@docs via_purple_500
-@docs via_purple_600
-@docs via_purple_700
-@docs via_purple_800
-@docs via_purple_900
-@docs via_red_100
-@docs via_red_200
-@docs via_red_300
-@docs via_red_400
-@docs via_red_50
-@docs via_red_500
-@docs via_red_600
-@docs via_red_700
-@docs via_red_800
-@docs via_red_900
 @docs via_transparent
 @docs via_white
-@docs via_yellow_100
-@docs via_yellow_200
-@docs via_yellow_300
-@docs via_yellow_400
-@docs via_yellow_50
-@docs via_yellow_500
-@docs via_yellow_600
-@docs via_yellow_700
-@docs via_yellow_800
-@docs via_yellow_900
 @docs visible
 @docs w_0
 @docs w_0_dot_5
@@ -8386,6 +8566,666 @@ This module contains
 @docs divide_rose_700
 @docs divide_rose_800
 @docs divide_rose_900
+@docs from_slate_50
+@docs from_slate_100
+@docs from_slate_200
+@docs from_slate_300
+@docs from_slate_400
+@docs from_slate_500
+@docs from_slate_600
+@docs from_slate_700
+@docs from_slate_800
+@docs from_slate_900
+@docs from_gray_50
+@docs from_gray_100
+@docs from_gray_200
+@docs from_gray_300
+@docs from_gray_400
+@docs from_gray_500
+@docs from_gray_600
+@docs from_gray_700
+@docs from_gray_800
+@docs from_gray_900
+@docs from_zinc_50
+@docs from_zinc_100
+@docs from_zinc_200
+@docs from_zinc_300
+@docs from_zinc_400
+@docs from_zinc_500
+@docs from_zinc_600
+@docs from_zinc_700
+@docs from_zinc_800
+@docs from_zinc_900
+@docs from_neutral_50
+@docs from_neutral_100
+@docs from_neutral_200
+@docs from_neutral_300
+@docs from_neutral_400
+@docs from_neutral_500
+@docs from_neutral_600
+@docs from_neutral_700
+@docs from_neutral_800
+@docs from_neutral_900
+@docs from_stone_50
+@docs from_stone_100
+@docs from_stone_200
+@docs from_stone_300
+@docs from_stone_400
+@docs from_stone_500
+@docs from_stone_600
+@docs from_stone_700
+@docs from_stone_800
+@docs from_stone_900
+@docs from_red_50
+@docs from_red_100
+@docs from_red_200
+@docs from_red_300
+@docs from_red_400
+@docs from_red_500
+@docs from_red_600
+@docs from_red_700
+@docs from_red_800
+@docs from_red_900
+@docs from_orange_50
+@docs from_orange_100
+@docs from_orange_200
+@docs from_orange_300
+@docs from_orange_400
+@docs from_orange_500
+@docs from_orange_600
+@docs from_orange_700
+@docs from_orange_800
+@docs from_orange_900
+@docs from_amber_50
+@docs from_amber_100
+@docs from_amber_200
+@docs from_amber_300
+@docs from_amber_400
+@docs from_amber_500
+@docs from_amber_600
+@docs from_amber_700
+@docs from_amber_800
+@docs from_amber_900
+@docs from_yellow_50
+@docs from_yellow_100
+@docs from_yellow_200
+@docs from_yellow_300
+@docs from_yellow_400
+@docs from_yellow_500
+@docs from_yellow_600
+@docs from_yellow_700
+@docs from_yellow_800
+@docs from_yellow_900
+@docs from_lime_50
+@docs from_lime_100
+@docs from_lime_200
+@docs from_lime_300
+@docs from_lime_400
+@docs from_lime_500
+@docs from_lime_600
+@docs from_lime_700
+@docs from_lime_800
+@docs from_lime_900
+@docs from_green_50
+@docs from_green_100
+@docs from_green_200
+@docs from_green_300
+@docs from_green_400
+@docs from_green_500
+@docs from_green_600
+@docs from_green_700
+@docs from_green_800
+@docs from_green_900
+@docs from_emerald_50
+@docs from_emerald_100
+@docs from_emerald_200
+@docs from_emerald_300
+@docs from_emerald_400
+@docs from_emerald_500
+@docs from_emerald_600
+@docs from_emerald_700
+@docs from_emerald_800
+@docs from_emerald_900
+@docs from_teal_50
+@docs from_teal_100
+@docs from_teal_200
+@docs from_teal_300
+@docs from_teal_400
+@docs from_teal_500
+@docs from_teal_600
+@docs from_teal_700
+@docs from_teal_800
+@docs from_teal_900
+@docs from_cyan_50
+@docs from_cyan_100
+@docs from_cyan_200
+@docs from_cyan_300
+@docs from_cyan_400
+@docs from_cyan_500
+@docs from_cyan_600
+@docs from_cyan_700
+@docs from_cyan_800
+@docs from_cyan_900
+@docs from_sky_50
+@docs from_sky_100
+@docs from_sky_200
+@docs from_sky_300
+@docs from_sky_400
+@docs from_sky_500
+@docs from_sky_600
+@docs from_sky_700
+@docs from_sky_800
+@docs from_sky_900
+@docs from_blue_50
+@docs from_blue_100
+@docs from_blue_200
+@docs from_blue_300
+@docs from_blue_400
+@docs from_blue_500
+@docs from_blue_600
+@docs from_blue_700
+@docs from_blue_800
+@docs from_blue_900
+@docs from_indigo_50
+@docs from_indigo_100
+@docs from_indigo_200
+@docs from_indigo_300
+@docs from_indigo_400
+@docs from_indigo_500
+@docs from_indigo_600
+@docs from_indigo_700
+@docs from_indigo_800
+@docs from_indigo_900
+@docs from_violet_50
+@docs from_violet_100
+@docs from_violet_200
+@docs from_violet_300
+@docs from_violet_400
+@docs from_violet_500
+@docs from_violet_600
+@docs from_violet_700
+@docs from_violet_800
+@docs from_violet_900
+@docs from_purple_50
+@docs from_purple_100
+@docs from_purple_200
+@docs from_purple_300
+@docs from_purple_400
+@docs from_purple_500
+@docs from_purple_600
+@docs from_purple_700
+@docs from_purple_800
+@docs from_purple_900
+@docs from_fuchsia_50
+@docs from_fuchsia_100
+@docs from_fuchsia_200
+@docs from_fuchsia_300
+@docs from_fuchsia_400
+@docs from_fuchsia_500
+@docs from_fuchsia_600
+@docs from_fuchsia_700
+@docs from_fuchsia_800
+@docs from_fuchsia_900
+@docs from_pink_50
+@docs from_pink_100
+@docs from_pink_200
+@docs from_pink_300
+@docs from_pink_400
+@docs from_pink_500
+@docs from_pink_600
+@docs from_pink_700
+@docs from_pink_800
+@docs from_pink_900
+@docs from_rose_50
+@docs from_rose_100
+@docs from_rose_200
+@docs from_rose_300
+@docs from_rose_400
+@docs from_rose_500
+@docs from_rose_600
+@docs from_rose_700
+@docs from_rose_800
+@docs from_rose_900
+@docs via_slate_50
+@docs via_slate_100
+@docs via_slate_200
+@docs via_slate_300
+@docs via_slate_400
+@docs via_slate_500
+@docs via_slate_600
+@docs via_slate_700
+@docs via_slate_800
+@docs via_slate_900
+@docs via_gray_50
+@docs via_gray_100
+@docs via_gray_200
+@docs via_gray_300
+@docs via_gray_400
+@docs via_gray_500
+@docs via_gray_600
+@docs via_gray_700
+@docs via_gray_800
+@docs via_gray_900
+@docs via_zinc_50
+@docs via_zinc_100
+@docs via_zinc_200
+@docs via_zinc_300
+@docs via_zinc_400
+@docs via_zinc_500
+@docs via_zinc_600
+@docs via_zinc_700
+@docs via_zinc_800
+@docs via_zinc_900
+@docs via_neutral_50
+@docs via_neutral_100
+@docs via_neutral_200
+@docs via_neutral_300
+@docs via_neutral_400
+@docs via_neutral_500
+@docs via_neutral_600
+@docs via_neutral_700
+@docs via_neutral_800
+@docs via_neutral_900
+@docs via_stone_50
+@docs via_stone_100
+@docs via_stone_200
+@docs via_stone_300
+@docs via_stone_400
+@docs via_stone_500
+@docs via_stone_600
+@docs via_stone_700
+@docs via_stone_800
+@docs via_stone_900
+@docs via_red_50
+@docs via_red_100
+@docs via_red_200
+@docs via_red_300
+@docs via_red_400
+@docs via_red_500
+@docs via_red_600
+@docs via_red_700
+@docs via_red_800
+@docs via_red_900
+@docs via_orange_50
+@docs via_orange_100
+@docs via_orange_200
+@docs via_orange_300
+@docs via_orange_400
+@docs via_orange_500
+@docs via_orange_600
+@docs via_orange_700
+@docs via_orange_800
+@docs via_orange_900
+@docs via_amber_50
+@docs via_amber_100
+@docs via_amber_200
+@docs via_amber_300
+@docs via_amber_400
+@docs via_amber_500
+@docs via_amber_600
+@docs via_amber_700
+@docs via_amber_800
+@docs via_amber_900
+@docs via_yellow_50
+@docs via_yellow_100
+@docs via_yellow_200
+@docs via_yellow_300
+@docs via_yellow_400
+@docs via_yellow_500
+@docs via_yellow_600
+@docs via_yellow_700
+@docs via_yellow_800
+@docs via_yellow_900
+@docs via_lime_50
+@docs via_lime_100
+@docs via_lime_200
+@docs via_lime_300
+@docs via_lime_400
+@docs via_lime_500
+@docs via_lime_600
+@docs via_lime_700
+@docs via_lime_800
+@docs via_lime_900
+@docs via_green_50
+@docs via_green_100
+@docs via_green_200
+@docs via_green_300
+@docs via_green_400
+@docs via_green_500
+@docs via_green_600
+@docs via_green_700
+@docs via_green_800
+@docs via_green_900
+@docs via_emerald_50
+@docs via_emerald_100
+@docs via_emerald_200
+@docs via_emerald_300
+@docs via_emerald_400
+@docs via_emerald_500
+@docs via_emerald_600
+@docs via_emerald_700
+@docs via_emerald_800
+@docs via_emerald_900
+@docs via_teal_50
+@docs via_teal_100
+@docs via_teal_200
+@docs via_teal_300
+@docs via_teal_400
+@docs via_teal_500
+@docs via_teal_600
+@docs via_teal_700
+@docs via_teal_800
+@docs via_teal_900
+@docs via_cyan_50
+@docs via_cyan_100
+@docs via_cyan_200
+@docs via_cyan_300
+@docs via_cyan_400
+@docs via_cyan_500
+@docs via_cyan_600
+@docs via_cyan_700
+@docs via_cyan_800
+@docs via_cyan_900
+@docs via_sky_50
+@docs via_sky_100
+@docs via_sky_200
+@docs via_sky_300
+@docs via_sky_400
+@docs via_sky_500
+@docs via_sky_600
+@docs via_sky_700
+@docs via_sky_800
+@docs via_sky_900
+@docs via_blue_50
+@docs via_blue_100
+@docs via_blue_200
+@docs via_blue_300
+@docs via_blue_400
+@docs via_blue_500
+@docs via_blue_600
+@docs via_blue_700
+@docs via_blue_800
+@docs via_blue_900
+@docs via_indigo_50
+@docs via_indigo_100
+@docs via_indigo_200
+@docs via_indigo_300
+@docs via_indigo_400
+@docs via_indigo_500
+@docs via_indigo_600
+@docs via_indigo_700
+@docs via_indigo_800
+@docs via_indigo_900
+@docs via_violet_50
+@docs via_violet_100
+@docs via_violet_200
+@docs via_violet_300
+@docs via_violet_400
+@docs via_violet_500
+@docs via_violet_600
+@docs via_violet_700
+@docs via_violet_800
+@docs via_violet_900
+@docs via_purple_50
+@docs via_purple_100
+@docs via_purple_200
+@docs via_purple_300
+@docs via_purple_400
+@docs via_purple_500
+@docs via_purple_600
+@docs via_purple_700
+@docs via_purple_800
+@docs via_purple_900
+@docs via_fuchsia_50
+@docs via_fuchsia_100
+@docs via_fuchsia_200
+@docs via_fuchsia_300
+@docs via_fuchsia_400
+@docs via_fuchsia_500
+@docs via_fuchsia_600
+@docs via_fuchsia_700
+@docs via_fuchsia_800
+@docs via_fuchsia_900
+@docs via_pink_50
+@docs via_pink_100
+@docs via_pink_200
+@docs via_pink_300
+@docs via_pink_400
+@docs via_pink_500
+@docs via_pink_600
+@docs via_pink_700
+@docs via_pink_800
+@docs via_pink_900
+@docs via_rose_50
+@docs via_rose_100
+@docs via_rose_200
+@docs via_rose_300
+@docs via_rose_400
+@docs via_rose_500
+@docs via_rose_600
+@docs via_rose_700
+@docs via_rose_800
+@docs via_rose_900
+@docs to_slate_50
+@docs to_slate_100
+@docs to_slate_200
+@docs to_slate_300
+@docs to_slate_400
+@docs to_slate_500
+@docs to_slate_600
+@docs to_slate_700
+@docs to_slate_800
+@docs to_slate_900
+@docs to_gray_50
+@docs to_gray_100
+@docs to_gray_200
+@docs to_gray_300
+@docs to_gray_400
+@docs to_gray_500
+@docs to_gray_600
+@docs to_gray_700
+@docs to_gray_800
+@docs to_gray_900
+@docs to_zinc_50
+@docs to_zinc_100
+@docs to_zinc_200
+@docs to_zinc_300
+@docs to_zinc_400
+@docs to_zinc_500
+@docs to_zinc_600
+@docs to_zinc_700
+@docs to_zinc_800
+@docs to_zinc_900
+@docs to_neutral_50
+@docs to_neutral_100
+@docs to_neutral_200
+@docs to_neutral_300
+@docs to_neutral_400
+@docs to_neutral_500
+@docs to_neutral_600
+@docs to_neutral_700
+@docs to_neutral_800
+@docs to_neutral_900
+@docs to_stone_50
+@docs to_stone_100
+@docs to_stone_200
+@docs to_stone_300
+@docs to_stone_400
+@docs to_stone_500
+@docs to_stone_600
+@docs to_stone_700
+@docs to_stone_800
+@docs to_stone_900
+@docs to_red_50
+@docs to_red_100
+@docs to_red_200
+@docs to_red_300
+@docs to_red_400
+@docs to_red_500
+@docs to_red_600
+@docs to_red_700
+@docs to_red_800
+@docs to_red_900
+@docs to_orange_50
+@docs to_orange_100
+@docs to_orange_200
+@docs to_orange_300
+@docs to_orange_400
+@docs to_orange_500
+@docs to_orange_600
+@docs to_orange_700
+@docs to_orange_800
+@docs to_orange_900
+@docs to_amber_50
+@docs to_amber_100
+@docs to_amber_200
+@docs to_amber_300
+@docs to_amber_400
+@docs to_amber_500
+@docs to_amber_600
+@docs to_amber_700
+@docs to_amber_800
+@docs to_amber_900
+@docs to_yellow_50
+@docs to_yellow_100
+@docs to_yellow_200
+@docs to_yellow_300
+@docs to_yellow_400
+@docs to_yellow_500
+@docs to_yellow_600
+@docs to_yellow_700
+@docs to_yellow_800
+@docs to_yellow_900
+@docs to_lime_50
+@docs to_lime_100
+@docs to_lime_200
+@docs to_lime_300
+@docs to_lime_400
+@docs to_lime_500
+@docs to_lime_600
+@docs to_lime_700
+@docs to_lime_800
+@docs to_lime_900
+@docs to_green_50
+@docs to_green_100
+@docs to_green_200
+@docs to_green_300
+@docs to_green_400
+@docs to_green_500
+@docs to_green_600
+@docs to_green_700
+@docs to_green_800
+@docs to_green_900
+@docs to_emerald_50
+@docs to_emerald_100
+@docs to_emerald_200
+@docs to_emerald_300
+@docs to_emerald_400
+@docs to_emerald_500
+@docs to_emerald_600
+@docs to_emerald_700
+@docs to_emerald_800
+@docs to_emerald_900
+@docs to_teal_50
+@docs to_teal_100
+@docs to_teal_200
+@docs to_teal_300
+@docs to_teal_400
+@docs to_teal_500
+@docs to_teal_600
+@docs to_teal_700
+@docs to_teal_800
+@docs to_teal_900
+@docs to_cyan_50
+@docs to_cyan_100
+@docs to_cyan_200
+@docs to_cyan_300
+@docs to_cyan_400
+@docs to_cyan_500
+@docs to_cyan_600
+@docs to_cyan_700
+@docs to_cyan_800
+@docs to_cyan_900
+@docs to_sky_50
+@docs to_sky_100
+@docs to_sky_200
+@docs to_sky_300
+@docs to_sky_400
+@docs to_sky_500
+@docs to_sky_600
+@docs to_sky_700
+@docs to_sky_800
+@docs to_sky_900
+@docs to_blue_50
+@docs to_blue_100
+@docs to_blue_200
+@docs to_blue_300
+@docs to_blue_400
+@docs to_blue_500
+@docs to_blue_600
+@docs to_blue_700
+@docs to_blue_800
+@docs to_blue_900
+@docs to_indigo_50
+@docs to_indigo_100
+@docs to_indigo_200
+@docs to_indigo_300
+@docs to_indigo_400
+@docs to_indigo_500
+@docs to_indigo_600
+@docs to_indigo_700
+@docs to_indigo_800
+@docs to_indigo_900
+@docs to_violet_50
+@docs to_violet_100
+@docs to_violet_200
+@docs to_violet_300
+@docs to_violet_400
+@docs to_violet_500
+@docs to_violet_600
+@docs to_violet_700
+@docs to_violet_800
+@docs to_violet_900
+@docs to_purple_50
+@docs to_purple_100
+@docs to_purple_200
+@docs to_purple_300
+@docs to_purple_400
+@docs to_purple_500
+@docs to_purple_600
+@docs to_purple_700
+@docs to_purple_800
+@docs to_purple_900
+@docs to_fuchsia_50
+@docs to_fuchsia_100
+@docs to_fuchsia_200
+@docs to_fuchsia_300
+@docs to_fuchsia_400
+@docs to_fuchsia_500
+@docs to_fuchsia_600
+@docs to_fuchsia_700
+@docs to_fuchsia_800
+@docs to_fuchsia_900
+@docs to_pink_50
+@docs to_pink_100
+@docs to_pink_200
+@docs to_pink_300
+@docs to_pink_400
+@docs to_pink_500
+@docs to_pink_600
+@docs to_pink_700
+@docs to_pink_800
+@docs to_pink_900
+@docs to_rose_50
+@docs to_rose_100
+@docs to_rose_200
+@docs to_rose_300
+@docs to_rose_400
+@docs to_rose_500
+@docs to_rose_600
+@docs to_rose_700
+@docs to_rose_800
+@docs to_rose_900
 
 -}
 
@@ -17831,926 +18671,16 @@ from_black =
         ]
 
 
-{-| The tailwind class `from-blue-100`.
+{-| The tailwind class `from-white`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_blue_100 : Css.Style
-from_blue_100 =
+from_white : Css.Style
+from_white =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#dbeafe"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(219, 234, 254, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_200 : Css.Style
-from_blue_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#bfdbfe"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(191, 219, 254, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_300 : Css.Style
-from_blue_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#93c5fd"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(147, 197, 253, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_400 : Css.Style
-from_blue_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#60a5fa"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(96, 165, 250, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_50 : Css.Style
-from_blue_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#eff6ff"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(239, 246, 255, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_500 : Css.Style
-from_blue_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#3b82f6"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(59, 130, 246, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_600 : Css.Style
-from_blue_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#2563eb"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(37, 99, 235, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_700 : Css.Style
-from_blue_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#1d4ed8"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(29, 78, 216, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_800 : Css.Style
-from_blue_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#1e40af"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(30, 64, 175, 0))"
-        ]
-
-
-{-| The tailwind class `from-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_blue_900 : Css.Style
-from_blue_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#1e3a8a"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(30, 58, 138, 0))"
-        ]
-
-
-{-| The tailwind class `from-current`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_current : Css.Style
-from_current =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "currentColor"
+        [ Css.property "--tw-gradient-from" "#fff"
         , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_100 : Css.Style
-from_gray_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f3f4f6"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(243, 244, 246, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_200 : Css.Style
-from_gray_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#e5e7eb"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(229, 231, 235, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_300 : Css.Style
-from_gray_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#d1d5db"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(209, 213, 219, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_400 : Css.Style
-from_gray_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#9ca3af"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(156, 163, 175, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_50 : Css.Style
-from_gray_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f9fafb"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(249, 250, 251, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_500 : Css.Style
-from_gray_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#6b7280"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(107, 114, 128, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_600 : Css.Style
-from_gray_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#4b5563"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(75, 85, 99, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_700 : Css.Style
-from_gray_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#374151"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(55, 65, 81, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_800 : Css.Style
-from_gray_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#1f2937"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(31, 41, 55, 0))"
-        ]
-
-
-{-| The tailwind class `from-gray-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_gray_900 : Css.Style
-from_gray_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#111827"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(17, 24, 39, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_100 : Css.Style
-from_green_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#d1fae5"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(209, 250, 229, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_200 : Css.Style
-from_green_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#a7f3d0"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(167, 243, 208, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_300 : Css.Style
-from_green_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#6ee7b7"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(110, 231, 183, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_400 : Css.Style
-from_green_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#34d399"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(52, 211, 153, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_50 : Css.Style
-from_green_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#ecfdf5"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 253, 245, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_500 : Css.Style
-from_green_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#10b981"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(16, 185, 129, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_600 : Css.Style
-from_green_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#059669"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(5, 150, 105, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_700 : Css.Style
-from_green_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#047857"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(4, 120, 87, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_800 : Css.Style
-from_green_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#065f46"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 95, 70, 0))"
-        ]
-
-
-{-| The tailwind class `from-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_green_900 : Css.Style
-from_green_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#064e3b"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 78, 59, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_100 : Css.Style
-from_indigo_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#e0e7ff"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(224, 231, 255, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_200 : Css.Style
-from_indigo_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#c7d2fe"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(199, 210, 254, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_300 : Css.Style
-from_indigo_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#a5b4fc"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(165, 180, 252, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_400 : Css.Style
-from_indigo_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#818cf8"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(129, 140, 248, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_50 : Css.Style
-from_indigo_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#eef2ff"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(238, 242, 255, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_500 : Css.Style
-from_indigo_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#6366f1"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(99, 102, 241, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_600 : Css.Style
-from_indigo_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#4f46e5"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(79, 70, 229, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_700 : Css.Style
-from_indigo_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#4338ca"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(67, 56, 202, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_800 : Css.Style
-from_indigo_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#3730a3"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(55, 48, 163, 0))"
-        ]
-
-
-{-| The tailwind class `from-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_indigo_900 : Css.Style
-from_indigo_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#312e81"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(49, 46, 129, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_100 : Css.Style
-from_pink_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fce7f3"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 231, 243, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_200 : Css.Style
-from_pink_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fbcfe8"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 207, 232, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_300 : Css.Style
-from_pink_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f9a8d4"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(249, 168, 212, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_400 : Css.Style
-from_pink_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f472b6"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(244, 114, 182, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_50 : Css.Style
-from_pink_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fdf2f8"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 242, 248, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_500 : Css.Style
-from_pink_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#ec4899"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 72, 153, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_600 : Css.Style
-from_pink_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#db2777"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(219, 39, 119, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_700 : Css.Style
-from_pink_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#be185d"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(190, 24, 93, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_800 : Css.Style
-from_pink_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#9d174d"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(157, 23, 77, 0))"
-        ]
-
-
-{-| The tailwind class `from-pink-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_pink_900 : Css.Style
-from_pink_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#831843"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(131, 24, 67, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_100 : Css.Style
-from_purple_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#ede9fe"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(237, 233, 254, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_200 : Css.Style
-from_purple_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#ddd6fe"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(221, 214, 254, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_300 : Css.Style
-from_purple_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#c4b5fd"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(196, 181, 253, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_400 : Css.Style
-from_purple_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#a78bfa"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(167, 139, 250, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_50 : Css.Style
-from_purple_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f5f3ff"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 243, 255, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_500 : Css.Style
-from_purple_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#8b5cf6"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(139, 92, 246, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_600 : Css.Style
-from_purple_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#7c3aed"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(124, 58, 237, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_700 : Css.Style
-from_purple_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#6d28d9"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(109, 40, 217, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_800 : Css.Style
-from_purple_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#5b21b6"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(91, 33, 182, 0))"
-        ]
-
-
-{-| The tailwind class `from-purple-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_purple_900 : Css.Style
-from_purple_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#4c1d95"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(76, 29, 149, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_100 : Css.Style
-from_red_100 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fee2e2"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 226, 226, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_200 : Css.Style
-from_red_200 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fecaca"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 202, 202, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_300 : Css.Style
-from_red_300 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fca5a5"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 165, 165, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_400 : Css.Style
-from_red_400 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#f87171"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(248, 113, 113, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_50 : Css.Style
-from_red_50 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#fef2f2"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 242, 242, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_500 : Css.Style
-from_red_500 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#ef4444"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(239, 68, 68, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_600 : Css.Style
-from_red_600 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#dc2626"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(220, 38, 38, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_700 : Css.Style
-from_red_700 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#b91c1c"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(185, 28, 28, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_800 : Css.Style
-from_red_800 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#991b1b"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(153, 27, 27, 0))"
-        ]
-
-
-{-| The tailwind class `from-red-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-from_red_900 : Css.Style
-from_red_900 =
-    Css.batch
-        [ Css.property "--tw-gradient-from" "#7f1d1d"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(127, 29, 29, 0))"
         ]
 
 
@@ -18767,68 +18697,1056 @@ from_transparent =
         ]
 
 
-{-| The tailwind class `from-white`.
+{-| The tailwind class `from-current`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_white : Css.Style
-from_white =
+from_current : Css.Style
+from_current =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#fff"
+        [ Css.property "--tw-gradient-from" "currentColor"
         , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 255, 255, 0))"
         ]
 
 
-{-| The tailwind class `from-yellow-100`.
+{-| The tailwind class `from-slate-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_yellow_100 : Css.Style
-from_yellow_100 =
+from_slate_50 : Css.Style
+from_slate_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f8fafc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(248, 250, 252))"
+        ]
+
+
+{-| The tailwind class `from-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_100 : Css.Style
+from_slate_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f1f5f9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(241, 245, 249))"
+        ]
+
+
+{-| The tailwind class `from-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_200 : Css.Style
+from_slate_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e2e8f0"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(226, 232, 240))"
+        ]
+
+
+{-| The tailwind class `from-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_300 : Css.Style
+from_slate_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#cbd5e1"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(203, 213, 225))"
+        ]
+
+
+{-| The tailwind class `from-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_400 : Css.Style
+from_slate_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#94a3b8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(148, 163, 184))"
+        ]
+
+
+{-| The tailwind class `from-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_500 : Css.Style
+from_slate_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#64748b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(100, 116, 139))"
+        ]
+
+
+{-| The tailwind class `from-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_600 : Css.Style
+from_slate_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#475569"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(71, 85, 105))"
+        ]
+
+
+{-| The tailwind class `from-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_700 : Css.Style
+from_slate_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#334155"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(51, 65, 85))"
+        ]
+
+
+{-| The tailwind class `from-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_800 : Css.Style
+from_slate_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1e293b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(30, 41, 59))"
+        ]
+
+
+{-| The tailwind class `from-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_slate_900 : Css.Style
+from_slate_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0f172a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(15, 23, 42))"
+        ]
+
+
+{-| The tailwind class `from-gray-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_50 : Css.Style
+from_gray_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f9fafb"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(249, 250, 251))"
+        ]
+
+
+{-| The tailwind class `from-gray-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_100 : Css.Style
+from_gray_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f3f4f6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(243, 244, 246))"
+        ]
+
+
+{-| The tailwind class `from-gray-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_200 : Css.Style
+from_gray_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e5e7eb"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(229, 231, 235))"
+        ]
+
+
+{-| The tailwind class `from-gray-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_300 : Css.Style
+from_gray_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d1d5db"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(209, 213, 219))"
+        ]
+
+
+{-| The tailwind class `from-gray-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_400 : Css.Style
+from_gray_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#9ca3af"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(156, 163, 175))"
+        ]
+
+
+{-| The tailwind class `from-gray-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_500 : Css.Style
+from_gray_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#6b7280"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(107, 114, 128))"
+        ]
+
+
+{-| The tailwind class `from-gray-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_600 : Css.Style
+from_gray_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4b5563"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(75, 85, 99))"
+        ]
+
+
+{-| The tailwind class `from-gray-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_700 : Css.Style
+from_gray_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#374151"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(55, 65, 81))"
+        ]
+
+
+{-| The tailwind class `from-gray-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_800 : Css.Style
+from_gray_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1f2937"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(31, 41, 55))"
+        ]
+
+
+{-| The tailwind class `from-gray-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_gray_900 : Css.Style
+from_gray_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#111827"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(17, 24, 39))"
+        ]
+
+
+{-| The tailwind class `from-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_50 : Css.Style
+from_zinc_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fafafa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 250, 250))"
+        ]
+
+
+{-| The tailwind class `from-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_100 : Css.Style
+from_zinc_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f4f4f5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(244, 244, 245))"
+        ]
+
+
+{-| The tailwind class `from-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_200 : Css.Style
+from_zinc_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e4e4e7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(228, 228, 231))"
+        ]
+
+
+{-| The tailwind class `from-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_300 : Css.Style
+from_zinc_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d4d4d8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(212, 212, 216))"
+        ]
+
+
+{-| The tailwind class `from-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_400 : Css.Style
+from_zinc_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a1a1aa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(161, 161, 170))"
+        ]
+
+
+{-| The tailwind class `from-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_500 : Css.Style
+from_zinc_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#71717a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(113, 113, 122))"
+        ]
+
+
+{-| The tailwind class `from-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_600 : Css.Style
+from_zinc_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#52525b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(82, 82, 91))"
+        ]
+
+
+{-| The tailwind class `from-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_700 : Css.Style
+from_zinc_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#3f3f46"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(63, 63, 70))"
+        ]
+
+
+{-| The tailwind class `from-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_800 : Css.Style
+from_zinc_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#27272a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(39, 39, 42))"
+        ]
+
+
+{-| The tailwind class `from-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_zinc_900 : Css.Style
+from_zinc_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#18181b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(24, 24, 27))"
+        ]
+
+
+{-| The tailwind class `from-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_50 : Css.Style
+from_neutral_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fafafa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 250, 250))"
+        ]
+
+
+{-| The tailwind class `from-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_100 : Css.Style
+from_neutral_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f5f5f5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 245, 245))"
+        ]
+
+
+{-| The tailwind class `from-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_200 : Css.Style
+from_neutral_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e5e5e5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(229, 229, 229))"
+        ]
+
+
+{-| The tailwind class `from-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_300 : Css.Style
+from_neutral_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d4d4d4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(212, 212, 212))"
+        ]
+
+
+{-| The tailwind class `from-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_400 : Css.Style
+from_neutral_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a3a3a3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(163, 163, 163))"
+        ]
+
+
+{-| The tailwind class `from-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_500 : Css.Style
+from_neutral_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#737373"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(115, 115, 115))"
+        ]
+
+
+{-| The tailwind class `from-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_600 : Css.Style
+from_neutral_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#525252"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(82, 82, 82))"
+        ]
+
+
+{-| The tailwind class `from-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_700 : Css.Style
+from_neutral_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#404040"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(64, 64, 64))"
+        ]
+
+
+{-| The tailwind class `from-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_800 : Css.Style
+from_neutral_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#262626"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(38, 38, 38))"
+        ]
+
+
+{-| The tailwind class `from-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_neutral_900 : Css.Style
+from_neutral_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#171717"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(23, 23, 23))"
+        ]
+
+
+{-| The tailwind class `from-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_50 : Css.Style
+from_stone_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fafaf9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 250, 249))"
+        ]
+
+
+{-| The tailwind class `from-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_100 : Css.Style
+from_stone_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f5f5f4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 245, 244))"
+        ]
+
+
+{-| The tailwind class `from-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_200 : Css.Style
+from_stone_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e7e5e4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(231, 229, 228))"
+        ]
+
+
+{-| The tailwind class `from-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_300 : Css.Style
+from_stone_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d6d3d1"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(214, 211, 209))"
+        ]
+
+
+{-| The tailwind class `from-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_400 : Css.Style
+from_stone_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a8a29e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 162, 158))"
+        ]
+
+
+{-| The tailwind class `from-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_500 : Css.Style
+from_stone_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#78716c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(120, 113, 108))"
+        ]
+
+
+{-| The tailwind class `from-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_600 : Css.Style
+from_stone_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#57534e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(87, 83, 78))"
+        ]
+
+
+{-| The tailwind class `from-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_700 : Css.Style
+from_stone_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#44403c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(68, 64, 60))"
+        ]
+
+
+{-| The tailwind class `from-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_800 : Css.Style
+from_stone_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#292524"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(41, 37, 36))"
+        ]
+
+
+{-| The tailwind class `from-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_stone_900 : Css.Style
+from_stone_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1c1917"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(28, 25, 23))"
+        ]
+
+
+{-| The tailwind class `from-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_50 : Css.Style
+from_red_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fef2f2"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 242, 242))"
+        ]
+
+
+{-| The tailwind class `from-red-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_100 : Css.Style
+from_red_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fee2e2"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 226, 226))"
+        ]
+
+
+{-| The tailwind class `from-red-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_200 : Css.Style
+from_red_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fecaca"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 202, 202))"
+        ]
+
+
+{-| The tailwind class `from-red-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_300 : Css.Style
+from_red_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fca5a5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 165, 165))"
+        ]
+
+
+{-| The tailwind class `from-red-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_400 : Css.Style
+from_red_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f87171"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(248, 113, 113))"
+        ]
+
+
+{-| The tailwind class `from-red-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_500 : Css.Style
+from_red_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ef4444"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(239, 68, 68))"
+        ]
+
+
+{-| The tailwind class `from-red-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_600 : Css.Style
+from_red_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#dc2626"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(220, 38, 38))"
+        ]
+
+
+{-| The tailwind class `from-red-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_700 : Css.Style
+from_red_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#b91c1c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(185, 28, 28))"
+        ]
+
+
+{-| The tailwind class `from-red-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_800 : Css.Style
+from_red_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#991b1b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(153, 27, 27))"
+        ]
+
+
+{-| The tailwind class `from-red-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_red_900 : Css.Style
+from_red_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#7f1d1d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(127, 29, 29))"
+        ]
+
+
+{-| The tailwind class `from-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_50 : Css.Style
+from_orange_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fff7ed"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 247, 237))"
+        ]
+
+
+{-| The tailwind class `from-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_100 : Css.Style
+from_orange_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ffedd5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 237, 213))"
+        ]
+
+
+{-| The tailwind class `from-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_200 : Css.Style
+from_orange_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fed7aa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 215, 170))"
+        ]
+
+
+{-| The tailwind class `from-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_300 : Css.Style
+from_orange_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fdba74"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 186, 116))"
+        ]
+
+
+{-| The tailwind class `from-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_400 : Css.Style
+from_orange_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fb923c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 146, 60))"
+        ]
+
+
+{-| The tailwind class `from-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_500 : Css.Style
+from_orange_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f97316"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(249, 115, 22))"
+        ]
+
+
+{-| The tailwind class `from-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_600 : Css.Style
+from_orange_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ea580c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(234, 88, 12))"
+        ]
+
+
+{-| The tailwind class `from-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_700 : Css.Style
+from_orange_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#c2410c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(194, 65, 12))"
+        ]
+
+
+{-| The tailwind class `from-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_800 : Css.Style
+from_orange_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#9a3412"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(154, 52, 18))"
+        ]
+
+
+{-| The tailwind class `from-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_orange_900 : Css.Style
+from_orange_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#7c2d12"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(124, 45, 18))"
+        ]
+
+
+{-| The tailwind class `from-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_50 : Css.Style
+from_amber_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fffbeb"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 251, 235))"
+        ]
+
+
+{-| The tailwind class `from-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_100 : Css.Style
+from_amber_100 =
     Css.batch
         [ Css.property "--tw-gradient-from" "#fef3c7"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 243, 199, 0))"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 243, 199))"
         ]
 
 
-{-| The tailwind class `from-yellow-200`.
+{-| The tailwind class `from-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_yellow_200 : Css.Style
-from_yellow_200 =
+from_amber_200 : Css.Style
+from_amber_200 =
     Css.batch
         [ Css.property "--tw-gradient-from" "#fde68a"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 230, 138, 0))"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 230, 138))"
         ]
 
 
-{-| The tailwind class `from-yellow-300`.
+{-| The tailwind class `from-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_yellow_300 : Css.Style
-from_yellow_300 =
+from_amber_300 : Css.Style
+from_amber_300 =
     Css.batch
         [ Css.property "--tw-gradient-from" "#fcd34d"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 211, 77, 0))"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 211, 77))"
         ]
 
 
-{-| The tailwind class `from-yellow-400`.
+{-| The tailwind class `from-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-from_yellow_400 : Css.Style
-from_yellow_400 =
+from_amber_400 : Css.Style
+from_amber_400 =
     Css.batch
         [ Css.property "--tw-gradient-from" "#fbbf24"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 191, 36, 0))"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 191, 36))"
+        ]
+
+
+{-| The tailwind class `from-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_500 : Css.Style
+from_amber_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f59e0b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 158, 11))"
+        ]
+
+
+{-| The tailwind class `from-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_600 : Css.Style
+from_amber_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d97706"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(217, 119, 6))"
+        ]
+
+
+{-| The tailwind class `from-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_700 : Css.Style
+from_amber_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#b45309"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(180, 83, 9))"
+        ]
+
+
+{-| The tailwind class `from-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_800 : Css.Style
+from_amber_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#92400e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(146, 64, 14))"
+        ]
+
+
+{-| The tailwind class `from-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_amber_900 : Css.Style
+from_amber_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#78350f"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(120, 53, 15))"
         ]
 
 
@@ -18840,8 +19758,60 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_50 : Css.Style
 from_yellow_50 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#fffbeb"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 251, 235, 0))"
+        [ Css.property "--tw-gradient-from" "#fefce8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 252, 232))"
+        ]
+
+
+{-| The tailwind class `from-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_yellow_100 : Css.Style
+from_yellow_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fef9c3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 249, 195))"
+        ]
+
+
+{-| The tailwind class `from-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_yellow_200 : Css.Style
+from_yellow_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fef08a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 240, 138))"
+        ]
+
+
+{-| The tailwind class `from-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_yellow_300 : Css.Style
+from_yellow_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fde047"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 224, 71))"
+        ]
+
+
+{-| The tailwind class `from-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_yellow_400 : Css.Style
+from_yellow_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#facc15"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 204, 21))"
         ]
 
 
@@ -18853,8 +19823,8 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_500 : Css.Style
 from_yellow_500 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#f59e0b"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 158, 11, 0))"
+        [ Css.property "--tw-gradient-from" "#eab308"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(234, 179, 8))"
         ]
 
 
@@ -18866,8 +19836,8 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_600 : Css.Style
 from_yellow_600 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#d97706"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(217, 119, 6, 0))"
+        [ Css.property "--tw-gradient-from" "#ca8a04"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(202, 138, 4))"
         ]
 
 
@@ -18879,8 +19849,8 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_700 : Css.Style
 from_yellow_700 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#b45309"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(180, 83, 9, 0))"
+        [ Css.property "--tw-gradient-from" "#a16207"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(161, 98, 7))"
         ]
 
 
@@ -18892,8 +19862,8 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_800 : Css.Style
 from_yellow_800 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#92400e"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(146, 64, 14, 0))"
+        [ Css.property "--tw-gradient-from" "#854d0e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(133, 77, 14))"
         ]
 
 
@@ -18905,8 +19875,1698 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 from_yellow_900 : Css.Style
 from_yellow_900 =
     Css.batch
-        [ Css.property "--tw-gradient-from" "#78350f"
-        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(120, 53, 15, 0))"
+        [ Css.property "--tw-gradient-from" "#713f12"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(113, 63, 18))"
+        ]
+
+
+{-| The tailwind class `from-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_50 : Css.Style
+from_lime_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f7fee7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(247, 254, 231))"
+        ]
+
+
+{-| The tailwind class `from-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_100 : Css.Style
+from_lime_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ecfccb"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 252, 203))"
+        ]
+
+
+{-| The tailwind class `from-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_200 : Css.Style
+from_lime_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d9f99d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(217, 249, 157))"
+        ]
+
+
+{-| The tailwind class `from-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_300 : Css.Style
+from_lime_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#bef264"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(190, 242, 100))"
+        ]
+
+
+{-| The tailwind class `from-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_400 : Css.Style
+from_lime_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a3e635"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(163, 230, 53))"
+        ]
+
+
+{-| The tailwind class `from-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_500 : Css.Style
+from_lime_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#84cc16"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(132, 204, 22))"
+        ]
+
+
+{-| The tailwind class `from-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_600 : Css.Style
+from_lime_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#65a30d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(101, 163, 13))"
+        ]
+
+
+{-| The tailwind class `from-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_700 : Css.Style
+from_lime_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4d7c0f"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(77, 124, 15))"
+        ]
+
+
+{-| The tailwind class `from-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_800 : Css.Style
+from_lime_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#3f6212"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(63, 98, 18))"
+        ]
+
+
+{-| The tailwind class `from-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_lime_900 : Css.Style
+from_lime_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#365314"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(54, 83, 20))"
+        ]
+
+
+{-| The tailwind class `from-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_50 : Css.Style
+from_green_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f0fdf4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(240, 253, 244))"
+        ]
+
+
+{-| The tailwind class `from-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_100 : Css.Style
+from_green_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#dcfce7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(220, 252, 231))"
+        ]
+
+
+{-| The tailwind class `from-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_200 : Css.Style
+from_green_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#bbf7d0"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(187, 247, 208))"
+        ]
+
+
+{-| The tailwind class `from-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_300 : Css.Style
+from_green_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#86efac"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(134, 239, 172))"
+        ]
+
+
+{-| The tailwind class `from-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_400 : Css.Style
+from_green_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4ade80"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(74, 222, 128))"
+        ]
+
+
+{-| The tailwind class `from-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_500 : Css.Style
+from_green_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#22c55e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(34, 197, 94))"
+        ]
+
+
+{-| The tailwind class `from-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_600 : Css.Style
+from_green_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#16a34a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(22, 163, 74))"
+        ]
+
+
+{-| The tailwind class `from-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_700 : Css.Style
+from_green_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#15803d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(21, 128, 61))"
+        ]
+
+
+{-| The tailwind class `from-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_800 : Css.Style
+from_green_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#166534"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(22, 101, 52))"
+        ]
+
+
+{-| The tailwind class `from-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_green_900 : Css.Style
+from_green_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#14532d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(20, 83, 45))"
+        ]
+
+
+{-| The tailwind class `from-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_50 : Css.Style
+from_emerald_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ecfdf5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 253, 245))"
+        ]
+
+
+{-| The tailwind class `from-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_100 : Css.Style
+from_emerald_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d1fae5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(209, 250, 229))"
+        ]
+
+
+{-| The tailwind class `from-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_200 : Css.Style
+from_emerald_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a7f3d0"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(167, 243, 208))"
+        ]
+
+
+{-| The tailwind class `from-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_300 : Css.Style
+from_emerald_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#6ee7b7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(110, 231, 183))"
+        ]
+
+
+{-| The tailwind class `from-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_400 : Css.Style
+from_emerald_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#34d399"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(52, 211, 153))"
+        ]
+
+
+{-| The tailwind class `from-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_500 : Css.Style
+from_emerald_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#10b981"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(16, 185, 129))"
+        ]
+
+
+{-| The tailwind class `from-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_600 : Css.Style
+from_emerald_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#059669"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(5, 150, 105))"
+        ]
+
+
+{-| The tailwind class `from-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_700 : Css.Style
+from_emerald_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#047857"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(4, 120, 87))"
+        ]
+
+
+{-| The tailwind class `from-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_800 : Css.Style
+from_emerald_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#065f46"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 95, 70))"
+        ]
+
+
+{-| The tailwind class `from-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_emerald_900 : Css.Style
+from_emerald_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#064e3b"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 78, 59))"
+        ]
+
+
+{-| The tailwind class `from-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_50 : Css.Style
+from_teal_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f0fdfa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(240, 253, 250))"
+        ]
+
+
+{-| The tailwind class `from-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_100 : Css.Style
+from_teal_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ccfbf1"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(204, 251, 241))"
+        ]
+
+
+{-| The tailwind class `from-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_200 : Css.Style
+from_teal_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#99f6e4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(153, 246, 228))"
+        ]
+
+
+{-| The tailwind class `from-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_300 : Css.Style
+from_teal_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#5eead4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(94, 234, 212))"
+        ]
+
+
+{-| The tailwind class `from-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_400 : Css.Style
+from_teal_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#2dd4bf"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(45, 212, 191))"
+        ]
+
+
+{-| The tailwind class `from-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_500 : Css.Style
+from_teal_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#14b8a6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(20, 184, 166))"
+        ]
+
+
+{-| The tailwind class `from-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_600 : Css.Style
+from_teal_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0d9488"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(13, 148, 136))"
+        ]
+
+
+{-| The tailwind class `from-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_700 : Css.Style
+from_teal_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0f766e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(15, 118, 110))"
+        ]
+
+
+{-| The tailwind class `from-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_800 : Css.Style
+from_teal_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#115e59"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(17, 94, 89))"
+        ]
+
+
+{-| The tailwind class `from-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_teal_900 : Css.Style
+from_teal_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#134e4a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(19, 78, 74))"
+        ]
+
+
+{-| The tailwind class `from-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_50 : Css.Style
+from_cyan_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ecfeff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 254, 255))"
+        ]
+
+
+{-| The tailwind class `from-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_100 : Css.Style
+from_cyan_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#cffafe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(207, 250, 254))"
+        ]
+
+
+{-| The tailwind class `from-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_200 : Css.Style
+from_cyan_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a5f3fc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(165, 243, 252))"
+        ]
+
+
+{-| The tailwind class `from-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_300 : Css.Style
+from_cyan_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#67e8f9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(103, 232, 249))"
+        ]
+
+
+{-| The tailwind class `from-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_400 : Css.Style
+from_cyan_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#22d3ee"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(34, 211, 238))"
+        ]
+
+
+{-| The tailwind class `from-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_500 : Css.Style
+from_cyan_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#06b6d4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(6, 182, 212))"
+        ]
+
+
+{-| The tailwind class `from-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_600 : Css.Style
+from_cyan_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0891b2"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(8, 145, 178))"
+        ]
+
+
+{-| The tailwind class `from-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_700 : Css.Style
+from_cyan_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0e7490"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(14, 116, 144))"
+        ]
+
+
+{-| The tailwind class `from-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_800 : Css.Style
+from_cyan_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#155e75"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(21, 94, 117))"
+        ]
+
+
+{-| The tailwind class `from-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_cyan_900 : Css.Style
+from_cyan_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#164e63"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(22, 78, 99))"
+        ]
+
+
+{-| The tailwind class `from-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_50 : Css.Style
+from_sky_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f0f9ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(240, 249, 255))"
+        ]
+
+
+{-| The tailwind class `from-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_100 : Css.Style
+from_sky_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e0f2fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(224, 242, 254))"
+        ]
+
+
+{-| The tailwind class `from-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_200 : Css.Style
+from_sky_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#bae6fd"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(186, 230, 253))"
+        ]
+
+
+{-| The tailwind class `from-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_300 : Css.Style
+from_sky_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#7dd3fc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(125, 211, 252))"
+        ]
+
+
+{-| The tailwind class `from-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_400 : Css.Style
+from_sky_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#38bdf8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(56, 189, 248))"
+        ]
+
+
+{-| The tailwind class `from-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_500 : Css.Style
+from_sky_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0ea5e9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(14, 165, 233))"
+        ]
+
+
+{-| The tailwind class `from-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_600 : Css.Style
+from_sky_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0284c7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(2, 132, 199))"
+        ]
+
+
+{-| The tailwind class `from-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_700 : Css.Style
+from_sky_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0369a1"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(3, 105, 161))"
+        ]
+
+
+{-| The tailwind class `from-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_800 : Css.Style
+from_sky_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#075985"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(7, 89, 133))"
+        ]
+
+
+{-| The tailwind class `from-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_sky_900 : Css.Style
+from_sky_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#0c4a6e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(12, 74, 110))"
+        ]
+
+
+{-| The tailwind class `from-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_50 : Css.Style
+from_blue_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#eff6ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(239, 246, 255))"
+        ]
+
+
+{-| The tailwind class `from-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_100 : Css.Style
+from_blue_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#dbeafe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(219, 234, 254))"
+        ]
+
+
+{-| The tailwind class `from-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_200 : Css.Style
+from_blue_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#bfdbfe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(191, 219, 254))"
+        ]
+
+
+{-| The tailwind class `from-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_300 : Css.Style
+from_blue_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#93c5fd"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(147, 197, 253))"
+        ]
+
+
+{-| The tailwind class `from-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_400 : Css.Style
+from_blue_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#60a5fa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(96, 165, 250))"
+        ]
+
+
+{-| The tailwind class `from-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_500 : Css.Style
+from_blue_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#3b82f6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(59, 130, 246))"
+        ]
+
+
+{-| The tailwind class `from-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_600 : Css.Style
+from_blue_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#2563eb"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(37, 99, 235))"
+        ]
+
+
+{-| The tailwind class `from-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_700 : Css.Style
+from_blue_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1d4ed8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(29, 78, 216))"
+        ]
+
+
+{-| The tailwind class `from-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_800 : Css.Style
+from_blue_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1e40af"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(30, 64, 175))"
+        ]
+
+
+{-| The tailwind class `from-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_blue_900 : Css.Style
+from_blue_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#1e3a8a"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(30, 58, 138))"
+        ]
+
+
+{-| The tailwind class `from-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_50 : Css.Style
+from_indigo_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#eef2ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(238, 242, 255))"
+        ]
+
+
+{-| The tailwind class `from-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_100 : Css.Style
+from_indigo_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e0e7ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(224, 231, 255))"
+        ]
+
+
+{-| The tailwind class `from-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_200 : Css.Style
+from_indigo_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#c7d2fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(199, 210, 254))"
+        ]
+
+
+{-| The tailwind class `from-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_300 : Css.Style
+from_indigo_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a5b4fc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(165, 180, 252))"
+        ]
+
+
+{-| The tailwind class `from-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_400 : Css.Style
+from_indigo_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#818cf8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(129, 140, 248))"
+        ]
+
+
+{-| The tailwind class `from-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_500 : Css.Style
+from_indigo_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#6366f1"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(99, 102, 241))"
+        ]
+
+
+{-| The tailwind class `from-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_600 : Css.Style
+from_indigo_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4f46e5"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(79, 70, 229))"
+        ]
+
+
+{-| The tailwind class `from-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_700 : Css.Style
+from_indigo_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4338ca"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(67, 56, 202))"
+        ]
+
+
+{-| The tailwind class `from-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_800 : Css.Style
+from_indigo_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#3730a3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(55, 48, 163))"
+        ]
+
+
+{-| The tailwind class `from-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_indigo_900 : Css.Style
+from_indigo_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#312e81"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(49, 46, 129))"
+        ]
+
+
+{-| The tailwind class `from-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_50 : Css.Style
+from_violet_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f5f3ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 243, 255))"
+        ]
+
+
+{-| The tailwind class `from-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_100 : Css.Style
+from_violet_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ede9fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(237, 233, 254))"
+        ]
+
+
+{-| The tailwind class `from-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_200 : Css.Style
+from_violet_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ddd6fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(221, 214, 254))"
+        ]
+
+
+{-| The tailwind class `from-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_300 : Css.Style
+from_violet_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#c4b5fd"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(196, 181, 253))"
+        ]
+
+
+{-| The tailwind class `from-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_400 : Css.Style
+from_violet_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a78bfa"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(167, 139, 250))"
+        ]
+
+
+{-| The tailwind class `from-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_500 : Css.Style
+from_violet_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#8b5cf6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(139, 92, 246))"
+        ]
+
+
+{-| The tailwind class `from-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_600 : Css.Style
+from_violet_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#7c3aed"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(124, 58, 237))"
+        ]
+
+
+{-| The tailwind class `from-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_700 : Css.Style
+from_violet_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#6d28d9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(109, 40, 217))"
+        ]
+
+
+{-| The tailwind class `from-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_800 : Css.Style
+from_violet_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#5b21b6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(91, 33, 182))"
+        ]
+
+
+{-| The tailwind class `from-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_violet_900 : Css.Style
+from_violet_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#4c1d95"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(76, 29, 149))"
+        ]
+
+
+{-| The tailwind class `from-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_50 : Css.Style
+from_purple_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#faf5ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 245, 255))"
+        ]
+
+
+{-| The tailwind class `from-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_100 : Css.Style
+from_purple_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f3e8ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(243, 232, 255))"
+        ]
+
+
+{-| The tailwind class `from-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_200 : Css.Style
+from_purple_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e9d5ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(233, 213, 255))"
+        ]
+
+
+{-| The tailwind class `from-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_300 : Css.Style
+from_purple_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d8b4fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(216, 180, 254))"
+        ]
+
+
+{-| The tailwind class `from-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_400 : Css.Style
+from_purple_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#c084fc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(192, 132, 252))"
+        ]
+
+
+{-| The tailwind class `from-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_500 : Css.Style
+from_purple_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a855f7"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247))"
+        ]
+
+
+{-| The tailwind class `from-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_600 : Css.Style
+from_purple_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#9333ea"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(147, 51, 234))"
+        ]
+
+
+{-| The tailwind class `from-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_700 : Css.Style
+from_purple_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#7e22ce"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(126, 34, 206))"
+        ]
+
+
+{-| The tailwind class `from-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_800 : Css.Style
+from_purple_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#6b21a8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(107, 33, 168))"
+        ]
+
+
+{-| The tailwind class `from-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_purple_900 : Css.Style
+from_purple_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#581c87"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(88, 28, 135))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_50 : Css.Style
+from_fuchsia_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fdf4ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 244, 255))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_100 : Css.Style
+from_fuchsia_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fae8ff"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(250, 232, 255))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_200 : Css.Style
+from_fuchsia_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f5d0fe"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(245, 208, 254))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_300 : Css.Style
+from_fuchsia_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f0abfc"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(240, 171, 252))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_400 : Css.Style
+from_fuchsia_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e879f9"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(232, 121, 249))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_500 : Css.Style
+from_fuchsia_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#d946ef"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(217, 70, 239))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_600 : Css.Style
+from_fuchsia_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#c026d3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(192, 38, 211))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_700 : Css.Style
+from_fuchsia_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#a21caf"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(162, 28, 175))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_800 : Css.Style
+from_fuchsia_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#86198f"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(134, 25, 143))"
+        ]
+
+
+{-| The tailwind class `from-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_fuchsia_900 : Css.Style
+from_fuchsia_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#701a75"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(112, 26, 117))"
+        ]
+
+
+{-| The tailwind class `from-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_50 : Css.Style
+from_pink_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fdf2f8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 242, 248))"
+        ]
+
+
+{-| The tailwind class `from-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_100 : Css.Style
+from_pink_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fce7f3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(252, 231, 243))"
+        ]
+
+
+{-| The tailwind class `from-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_200 : Css.Style
+from_pink_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fbcfe8"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 207, 232))"
+        ]
+
+
+{-| The tailwind class `from-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_300 : Css.Style
+from_pink_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f9a8d4"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(249, 168, 212))"
+        ]
+
+
+{-| The tailwind class `from-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_400 : Css.Style
+from_pink_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f472b6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(244, 114, 182))"
+        ]
+
+
+{-| The tailwind class `from-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_500 : Css.Style
+from_pink_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ec4899"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(236, 72, 153))"
+        ]
+
+
+{-| The tailwind class `from-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_600 : Css.Style
+from_pink_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#db2777"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(219, 39, 119))"
+        ]
+
+
+{-| The tailwind class `from-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_700 : Css.Style
+from_pink_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#be185d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(190, 24, 93))"
+        ]
+
+
+{-| The tailwind class `from-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_800 : Css.Style
+from_pink_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#9d174d"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(157, 23, 77))"
+        ]
+
+
+{-| The tailwind class `from-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_pink_900 : Css.Style
+from_pink_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#831843"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(131, 24, 67))"
+        ]
+
+
+{-| The tailwind class `from-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_50 : Css.Style
+from_rose_50 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fff1f2"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 241, 242))"
+        ]
+
+
+{-| The tailwind class `from-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_100 : Css.Style
+from_rose_100 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#ffe4e6"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(255, 228, 230))"
+        ]
+
+
+{-| The tailwind class `from-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_200 : Css.Style
+from_rose_200 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fecdd3"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(254, 205, 211))"
+        ]
+
+
+{-| The tailwind class `from-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_300 : Css.Style
+from_rose_300 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fda4af"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(253, 164, 175))"
+        ]
+
+
+{-| The tailwind class `from-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_400 : Css.Style
+from_rose_400 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#fb7185"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 113, 133))"
+        ]
+
+
+{-| The tailwind class `from-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_500 : Css.Style
+from_rose_500 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#f43f5e"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(244, 63, 94))"
+        ]
+
+
+{-| The tailwind class `from-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_600 : Css.Style
+from_rose_600 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#e11d48"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(225, 29, 72))"
+        ]
+
+
+{-| The tailwind class `from-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_700 : Css.Style
+from_rose_700 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#be123c"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(190, 18, 60))"
+        ]
+
+
+{-| The tailwind class `from-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_800 : Css.Style
+from_rose_800 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#9f1239"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(159, 18, 57))"
+        ]
+
+
+{-| The tailwind class `from-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+from_rose_900 : Css.Style
+from_rose_900 =
+    Css.batch
+        [ Css.property "--tw-gradient-from" "#881337"
+        , Css.property "--tw-gradient-stops" "var(--tw-gradient-from), var(--tw-gradient-to, rgba(136, 19, 55))"
         ]
 
 
@@ -51178,104 +53838,14 @@ to_black =
     Css.property "--tw-gradient-to" "#000"
 
 
-{-| The tailwind class `to-blue-100`.
+{-| The tailwind class `to-white`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_blue_100 : Css.Style
-to_blue_100 =
-    Css.property "--tw-gradient-to" "#dbeafe"
-
-
-{-| The tailwind class `to-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_200 : Css.Style
-to_blue_200 =
-    Css.property "--tw-gradient-to" "#bfdbfe"
-
-
-{-| The tailwind class `to-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_300 : Css.Style
-to_blue_300 =
-    Css.property "--tw-gradient-to" "#93c5fd"
-
-
-{-| The tailwind class `to-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_400 : Css.Style
-to_blue_400 =
-    Css.property "--tw-gradient-to" "#60a5fa"
-
-
-{-| The tailwind class `to-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_50 : Css.Style
-to_blue_50 =
-    Css.property "--tw-gradient-to" "#eff6ff"
-
-
-{-| The tailwind class `to-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_500 : Css.Style
-to_blue_500 =
-    Css.property "--tw-gradient-to" "#3b82f6"
-
-
-{-| The tailwind class `to-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_600 : Css.Style
-to_blue_600 =
-    Css.property "--tw-gradient-to" "#2563eb"
-
-
-{-| The tailwind class `to-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_700 : Css.Style
-to_blue_700 =
-    Css.property "--tw-gradient-to" "#1d4ed8"
-
-
-{-| The tailwind class `to-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_800 : Css.Style
-to_blue_800 =
-    Css.property "--tw-gradient-to" "#1e40af"
-
-
-{-| The tailwind class `to-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_blue_900 : Css.Style
-to_blue_900 =
-    Css.property "--tw-gradient-to" "#1e3a8a"
+to_white : Css.Style
+to_white =
+    Css.property "--tw-gradient-to" "#fff"
 
 
 {-| The tailwind class `to-current`.
@@ -51286,6 +53856,126 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 to_current : Css.Style
 to_current =
     Css.property "--tw-gradient-to" "currentColor"
+
+
+{-| The tailwind class `to-black`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_transparent : Css.Style
+to_transparent =
+    Css.property "--tw-gradient-to" "transparent"
+
+
+{-| The tailwind class `to-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_50 : Css.Style
+to_slate_50 =
+    Css.property "--tw-gradient-to" "#f8fafc"
+
+
+{-| The tailwind class `to-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_100 : Css.Style
+to_slate_100 =
+    Css.property "--tw-gradient-to" "#f1f5f9"
+
+
+{-| The tailwind class `to-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_200 : Css.Style
+to_slate_200 =
+    Css.property "--tw-gradient-to" "#e2e8f0"
+
+
+{-| The tailwind class `to-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_300 : Css.Style
+to_slate_300 =
+    Css.property "--tw-gradient-to" "#cbd5e1"
+
+
+{-| The tailwind class `to-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_400 : Css.Style
+to_slate_400 =
+    Css.property "--tw-gradient-to" "#94a3b8"
+
+
+{-| The tailwind class `to-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_500 : Css.Style
+to_slate_500 =
+    Css.property "--tw-gradient-to" "#64748b"
+
+
+{-| The tailwind class `to-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_600 : Css.Style
+to_slate_600 =
+    Css.property "--tw-gradient-to" "#475569"
+
+
+{-| The tailwind class `to-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_700 : Css.Style
+to_slate_700 =
+    Css.property "--tw-gradient-to" "#334155"
+
+
+{-| The tailwind class `to-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_800 : Css.Style
+to_slate_800 =
+    Css.property "--tw-gradient-to" "#1e293b"
+
+
+{-| The tailwind class `to-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_slate_900 : Css.Style
+to_slate_900 =
+    Css.property "--tw-gradient-to" "#0f172a"
+
+
+{-| The tailwind class `to-gray-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_gray_50 : Css.Style
+to_gray_50 =
+    Css.property "--tw-gradient-to" "#f9fafb"
 
 
 {-| The tailwind class `to-gray-100`.
@@ -51326,16 +54016,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 to_gray_400 : Css.Style
 to_gray_400 =
     Css.property "--tw-gradient-to" "#9ca3af"
-
-
-{-| The tailwind class `to-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_gray_50 : Css.Style
-to_gray_50 =
-    Css.property "--tw-gradient-to" "#f9fafb"
 
 
 {-| The tailwind class `to-gray-500`.
@@ -51388,404 +54068,314 @@ to_gray_900 =
     Css.property "--tw-gradient-to" "#111827"
 
 
-{-| The tailwind class `to-green-100`.
+{-| The tailwind class `to-zinc-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_green_100 : Css.Style
-to_green_100 =
-    Css.property "--tw-gradient-to" "#d1fae5"
+to_zinc_50 : Css.Style
+to_zinc_50 =
+    Css.property "--tw-gradient-to" "#fafafa"
 
 
-{-| The tailwind class `to-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_green_200 : Css.Style
-to_green_200 =
-    Css.property "--tw-gradient-to" "#a7f3d0"
-
-
-{-| The tailwind class `to-green-300`.
+{-| The tailwind class `to-zinc-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_green_300 : Css.Style
-to_green_300 =
-    Css.property "--tw-gradient-to" "#6ee7b7"
+to_zinc_100 : Css.Style
+to_zinc_100 =
+    Css.property "--tw-gradient-to" "#f4f4f5"
 
 
-{-| The tailwind class `to-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_green_400 : Css.Style
-to_green_400 =
-    Css.property "--tw-gradient-to" "#34d399"
-
-
-{-| The tailwind class `to-green-50`.
+{-| The tailwind class `to-zinc-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_green_50 : Css.Style
-to_green_50 =
-    Css.property "--tw-gradient-to" "#ecfdf5"
+to_zinc_200 : Css.Style
+to_zinc_200 =
+    Css.property "--tw-gradient-to" "#e4e4e7"
 
 
-{-| The tailwind class `to-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_green_500 : Css.Style
-to_green_500 =
-    Css.property "--tw-gradient-to" "#10b981"
-
-
-{-| The tailwind class `to-green-600`.
+{-| The tailwind class `to-zinc-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_green_600 : Css.Style
-to_green_600 =
-    Css.property "--tw-gradient-to" "#059669"
+to_zinc_300 : Css.Style
+to_zinc_300 =
+    Css.property "--tw-gradient-to" "#d4d4d8"
 
 
-{-| The tailwind class `to-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_green_700 : Css.Style
-to_green_700 =
-    Css.property "--tw-gradient-to" "#047857"
-
-
-{-| The tailwind class `to-green-800`.
+{-| The tailwind class `to-zinc-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_green_800 : Css.Style
-to_green_800 =
-    Css.property "--tw-gradient-to" "#065f46"
+to_zinc_400 : Css.Style
+to_zinc_400 =
+    Css.property "--tw-gradient-to" "#a1a1aa"
 
 
-{-| The tailwind class `to-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_green_900 : Css.Style
-to_green_900 =
-    Css.property "--tw-gradient-to" "#064e3b"
-
-
-{-| The tailwind class `to-indigo-100`.
+{-| The tailwind class `to-zinc-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_indigo_100 : Css.Style
-to_indigo_100 =
-    Css.property "--tw-gradient-to" "#e0e7ff"
+to_zinc_500 : Css.Style
+to_zinc_500 =
+    Css.property "--tw-gradient-to" "#71717a"
 
 
-{-| The tailwind class `to-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_indigo_200 : Css.Style
-to_indigo_200 =
-    Css.property "--tw-gradient-to" "#c7d2fe"
-
-
-{-| The tailwind class `to-indigo-300`.
+{-| The tailwind class `to-zinc-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_indigo_300 : Css.Style
-to_indigo_300 =
-    Css.property "--tw-gradient-to" "#a5b4fc"
+to_zinc_600 : Css.Style
+to_zinc_600 =
+    Css.property "--tw-gradient-to" "#52525b"
 
 
-{-| The tailwind class `to-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_indigo_400 : Css.Style
-to_indigo_400 =
-    Css.property "--tw-gradient-to" "#818cf8"
-
-
-{-| The tailwind class `to-indigo-50`.
+{-| The tailwind class `to-zinc-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_indigo_50 : Css.Style
-to_indigo_50 =
-    Css.property "--tw-gradient-to" "#eef2ff"
+to_zinc_700 : Css.Style
+to_zinc_700 =
+    Css.property "--tw-gradient-to" "#3f3f46"
 
 
-{-| The tailwind class `to-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_indigo_500 : Css.Style
-to_indigo_500 =
-    Css.property "--tw-gradient-to" "#6366f1"
-
-
-{-| The tailwind class `to-indigo-600`.
+{-| The tailwind class `to-zinc-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_indigo_600 : Css.Style
-to_indigo_600 =
-    Css.property "--tw-gradient-to" "#4f46e5"
+to_zinc_800 : Css.Style
+to_zinc_800 =
+    Css.property "--tw-gradient-to" "#27272a"
 
 
-{-| The tailwind class `to-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_indigo_700 : Css.Style
-to_indigo_700 =
-    Css.property "--tw-gradient-to" "#4338ca"
-
-
-{-| The tailwind class `to-indigo-800`.
+{-| The tailwind class `to-zinc-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_indigo_800 : Css.Style
-to_indigo_800 =
-    Css.property "--tw-gradient-to" "#3730a3"
+to_zinc_900 : Css.Style
+to_zinc_900 =
+    Css.property "--tw-gradient-to" "#18181b"
 
 
-{-| The tailwind class `to-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_indigo_900 : Css.Style
-to_indigo_900 =
-    Css.property "--tw-gradient-to" "#312e81"
-
-
-{-| The tailwind class `to-pink-100`.
+{-| The tailwind class `to-neutral-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_pink_100 : Css.Style
-to_pink_100 =
-    Css.property "--tw-gradient-to" "#fce7f3"
+to_neutral_50 : Css.Style
+to_neutral_50 =
+    Css.property "--tw-gradient-to" "#fafafa"
 
 
-{-| The tailwind class `to-pink-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_pink_200 : Css.Style
-to_pink_200 =
-    Css.property "--tw-gradient-to" "#fbcfe8"
-
-
-{-| The tailwind class `to-pink-300`.
+{-| The tailwind class `to-neutral-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_pink_300 : Css.Style
-to_pink_300 =
-    Css.property "--tw-gradient-to" "#f9a8d4"
+to_neutral_100 : Css.Style
+to_neutral_100 =
+    Css.property "--tw-gradient-to" "#f5f5f5"
 
 
-{-| The tailwind class `to-pink-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_pink_400 : Css.Style
-to_pink_400 =
-    Css.property "--tw-gradient-to" "#f472b6"
-
-
-{-| The tailwind class `to-pink-50`.
+{-| The tailwind class `to-neutral-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_pink_50 : Css.Style
-to_pink_50 =
-    Css.property "--tw-gradient-to" "#fdf2f8"
+to_neutral_200 : Css.Style
+to_neutral_200 =
+    Css.property "--tw-gradient-to" "#e5e5e5"
 
 
-{-| The tailwind class `to-pink-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_pink_500 : Css.Style
-to_pink_500 =
-    Css.property "--tw-gradient-to" "#ec4899"
-
-
-{-| The tailwind class `to-pink-600`.
+{-| The tailwind class `to-neutral-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_pink_600 : Css.Style
-to_pink_600 =
-    Css.property "--tw-gradient-to" "#db2777"
+to_neutral_300 : Css.Style
+to_neutral_300 =
+    Css.property "--tw-gradient-to" "#d4d4d4"
 
 
-{-| The tailwind class `to-pink-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_pink_700 : Css.Style
-to_pink_700 =
-    Css.property "--tw-gradient-to" "#be185d"
-
-
-{-| The tailwind class `to-pink-800`.
+{-| The tailwind class `to-neutral-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_pink_800 : Css.Style
-to_pink_800 =
-    Css.property "--tw-gradient-to" "#9d174d"
+to_neutral_400 : Css.Style
+to_neutral_400 =
+    Css.property "--tw-gradient-to" "#a3a3a3"
 
 
-{-| The tailwind class `to-pink-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_pink_900 : Css.Style
-to_pink_900 =
-    Css.property "--tw-gradient-to" "#831843"
-
-
-{-| The tailwind class `to-purple-100`.
+{-| The tailwind class `to-neutral-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_100 : Css.Style
-to_purple_100 =
-    Css.property "--tw-gradient-to" "#ede9fe"
+to_neutral_500 : Css.Style
+to_neutral_500 =
+    Css.property "--tw-gradient-to" "#737373"
 
 
-{-| The tailwind class `to-purple-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_purple_200 : Css.Style
-to_purple_200 =
-    Css.property "--tw-gradient-to" "#ddd6fe"
-
-
-{-| The tailwind class `to-purple-300`.
+{-| The tailwind class `to-neutral-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_300 : Css.Style
-to_purple_300 =
-    Css.property "--tw-gradient-to" "#c4b5fd"
+to_neutral_600 : Css.Style
+to_neutral_600 =
+    Css.property "--tw-gradient-to" "#525252"
 
 
-{-| The tailwind class `to-purple-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_purple_400 : Css.Style
-to_purple_400 =
-    Css.property "--tw-gradient-to" "#a78bfa"
-
-
-{-| The tailwind class `to-purple-50`.
+{-| The tailwind class `to-neutral-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_50 : Css.Style
-to_purple_50 =
-    Css.property "--tw-gradient-to" "#f5f3ff"
+to_neutral_700 : Css.Style
+to_neutral_700 =
+    Css.property "--tw-gradient-to" "#404040"
 
 
-{-| The tailwind class `to-purple-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_purple_500 : Css.Style
-to_purple_500 =
-    Css.property "--tw-gradient-to" "#8b5cf6"
-
-
-{-| The tailwind class `to-purple-600`.
+{-| The tailwind class `to-neutral-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_600 : Css.Style
-to_purple_600 =
-    Css.property "--tw-gradient-to" "#7c3aed"
+to_neutral_800 : Css.Style
+to_neutral_800 =
+    Css.property "--tw-gradient-to" "#262626"
 
 
-{-| The tailwind class `to-purple-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_purple_700 : Css.Style
-to_purple_700 =
-    Css.property "--tw-gradient-to" "#6d28d9"
-
-
-{-| The tailwind class `to-purple-800`.
+{-| The tailwind class `to-neutral-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_800 : Css.Style
-to_purple_800 =
-    Css.property "--tw-gradient-to" "#5b21b6"
+to_neutral_900 : Css.Style
+to_neutral_900 =
+    Css.property "--tw-gradient-to" "#171717"
 
 
-{-| The tailwind class `to-purple-900`.
+{-| The tailwind class `to-stone-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_purple_900 : Css.Style
-to_purple_900 =
-    Css.property "--tw-gradient-to" "#4c1d95"
+to_stone_50 : Css.Style
+to_stone_50 =
+    Css.property "--tw-gradient-to" "#fafaf9"
+
+
+{-| The tailwind class `to-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_100 : Css.Style
+to_stone_100 =
+    Css.property "--tw-gradient-to" "#f5f5f4"
+
+
+{-| The tailwind class `to-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_200 : Css.Style
+to_stone_200 =
+    Css.property "--tw-gradient-to" "#e7e5e4"
+
+
+{-| The tailwind class `to-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_300 : Css.Style
+to_stone_300 =
+    Css.property "--tw-gradient-to" "#d6d3d1"
+
+
+{-| The tailwind class `to-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_400 : Css.Style
+to_stone_400 =
+    Css.property "--tw-gradient-to" "#a8a29e"
+
+
+{-| The tailwind class `to-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_500 : Css.Style
+to_stone_500 =
+    Css.property "--tw-gradient-to" "#78716c"
+
+
+{-| The tailwind class `to-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_600 : Css.Style
+to_stone_600 =
+    Css.property "--tw-gradient-to" "#57534e"
+
+
+{-| The tailwind class `to-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_700 : Css.Style
+to_stone_700 =
+    Css.property "--tw-gradient-to" "#44403c"
+
+
+{-| The tailwind class `to-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_800 : Css.Style
+to_stone_800 =
+    Css.property "--tw-gradient-to" "#292524"
+
+
+{-| The tailwind class `to-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_stone_900 : Css.Style
+to_stone_900 =
+    Css.property "--tw-gradient-to" "#1c1917"
+
+
+{-| The tailwind class `to-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_red_50 : Css.Style
+to_red_50 =
+    Css.property "--tw-gradient-to" "#fef2f2"
 
 
 {-| The tailwind class `to-red-100`.
@@ -51826,16 +54416,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 to_red_400 : Css.Style
 to_red_400 =
     Css.property "--tw-gradient-to" "#f87171"
-
-
-{-| The tailwind class `to-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_red_50 : Css.Style
-to_red_50 =
-    Css.property "--tw-gradient-to" "#fef2f2"
 
 
 {-| The tailwind class `to-red-500`.
@@ -51888,64 +54468,204 @@ to_red_900 =
     Css.property "--tw-gradient-to" "#7f1d1d"
 
 
-{-| The tailwind class `to-transparent`.
+{-| The tailwind class `to-orange-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_transparent : Css.Style
-to_transparent =
-    Css.property "--tw-gradient-to" "transparent"
+to_orange_50 : Css.Style
+to_orange_50 =
+    Css.property "--tw-gradient-to" "#fff7ed"
 
 
-{-| The tailwind class `to-white`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-to_white : Css.Style
-to_white =
-    Css.property "--tw-gradient-to" "#fff"
-
-
-{-| The tailwind class `to-yellow-100`.
+{-| The tailwind class `to-orange-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_yellow_100 : Css.Style
-to_yellow_100 =
+to_orange_100 : Css.Style
+to_orange_100 =
+    Css.property "--tw-gradient-to" "#ffedd5"
+
+
+{-| The tailwind class `to-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_200 : Css.Style
+to_orange_200 =
+    Css.property "--tw-gradient-to" "#fed7aa"
+
+
+{-| The tailwind class `to-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_300 : Css.Style
+to_orange_300 =
+    Css.property "--tw-gradient-to" "#fdba74"
+
+
+{-| The tailwind class `to-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_400 : Css.Style
+to_orange_400 =
+    Css.property "--tw-gradient-to" "#fb923c"
+
+
+{-| The tailwind class `to-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_500 : Css.Style
+to_orange_500 =
+    Css.property "--tw-gradient-to" "#f97316"
+
+
+{-| The tailwind class `to-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_600 : Css.Style
+to_orange_600 =
+    Css.property "--tw-gradient-to" "#ea580c"
+
+
+{-| The tailwind class `to-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_700 : Css.Style
+to_orange_700 =
+    Css.property "--tw-gradient-to" "#c2410c"
+
+
+{-| The tailwind class `to-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_800 : Css.Style
+to_orange_800 =
+    Css.property "--tw-gradient-to" "#9a3412"
+
+
+{-| The tailwind class `to-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_orange_900 : Css.Style
+to_orange_900 =
+    Css.property "--tw-gradient-to" "#7c2d12"
+
+
+{-| The tailwind class `to-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_50 : Css.Style
+to_amber_50 =
+    Css.property "--tw-gradient-to" "#fffbeb"
+
+
+{-| The tailwind class `to-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_100 : Css.Style
+to_amber_100 =
     Css.property "--tw-gradient-to" "#fef3c7"
 
 
-{-| The tailwind class `to-yellow-200`.
+{-| The tailwind class `to-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_yellow_200 : Css.Style
-to_yellow_200 =
+to_amber_200 : Css.Style
+to_amber_200 =
     Css.property "--tw-gradient-to" "#fde68a"
 
 
-{-| The tailwind class `to-yellow-300`.
+{-| The tailwind class `to-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_yellow_300 : Css.Style
-to_yellow_300 =
+to_amber_300 : Css.Style
+to_amber_300 =
     Css.property "--tw-gradient-to" "#fcd34d"
 
 
-{-| The tailwind class `to-yellow-400`.
+{-| The tailwind class `to-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-to_yellow_400 : Css.Style
-to_yellow_400 =
+to_amber_400 : Css.Style
+to_amber_400 =
     Css.property "--tw-gradient-to" "#fbbf24"
+
+
+{-| The tailwind class `to-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_500 : Css.Style
+to_amber_500 =
+    Css.property "--tw-gradient-to" "#f59e0b"
+
+
+{-| The tailwind class `to-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_600 : Css.Style
+to_amber_600 =
+    Css.property "--tw-gradient-to" "#d97706"
+
+
+{-| The tailwind class `to-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_700 : Css.Style
+to_amber_700 =
+    Css.property "--tw-gradient-to" "#b45309"
+
+
+{-| The tailwind class `to-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_800 : Css.Style
+to_amber_800 =
+    Css.property "--tw-gradient-to" "#92400e"
+
+
+{-| The tailwind class `to-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_amber_900 : Css.Style
+to_amber_900 =
+    Css.property "--tw-gradient-to" "#78350f"
 
 
 {-| The tailwind class `to-yellow-50`.
@@ -51955,7 +54675,47 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_50 : Css.Style
 to_yellow_50 =
-    Css.property "--tw-gradient-to" "#fffbeb"
+    Css.property "--tw-gradient-to" "#fefce8"
+
+
+{-| The tailwind class `to-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_yellow_100 : Css.Style
+to_yellow_100 =
+    Css.property "--tw-gradient-to" "#fef9c3"
+
+
+{-| The tailwind class `to-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_yellow_200 : Css.Style
+to_yellow_200 =
+    Css.property "--tw-gradient-to" "#fef08a"
+
+
+{-| The tailwind class `to-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_yellow_300 : Css.Style
+to_yellow_300 =
+    Css.property "--tw-gradient-to" "#fde047"
+
+
+{-| The tailwind class `to-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_yellow_400 : Css.Style
+to_yellow_400 =
+    Css.property "--tw-gradient-to" "#facc15"
 
 
 {-| The tailwind class `to-yellow-500`.
@@ -51965,7 +54725,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_500 : Css.Style
 to_yellow_500 =
-    Css.property "--tw-gradient-to" "#f59e0b"
+    Css.property "--tw-gradient-to" "#eab308"
 
 
 {-| The tailwind class `to-yellow-600`.
@@ -51975,7 +54735,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_600 : Css.Style
 to_yellow_600 =
-    Css.property "--tw-gradient-to" "#d97706"
+    Css.property "--tw-gradient-to" "#ca8a04"
 
 
 {-| The tailwind class `to-yellow-700`.
@@ -51985,7 +54745,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_700 : Css.Style
 to_yellow_700 =
-    Css.property "--tw-gradient-to" "#b45309"
+    Css.property "--tw-gradient-to" "#a16207"
 
 
 {-| The tailwind class `to-yellow-800`.
@@ -51995,7 +54755,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_800 : Css.Style
 to_yellow_800 =
-    Css.property "--tw-gradient-to" "#92400e"
+    Css.property "--tw-gradient-to" "#854d0e"
 
 
 {-| The tailwind class `to-yellow-900`.
@@ -52005,7 +54765,1307 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 to_yellow_900 : Css.Style
 to_yellow_900 =
-    Css.property "--tw-gradient-to" "#78350f"
+    Css.property "--tw-gradient-to" "#713f12"
+
+
+{-| The tailwind class `to-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_50 : Css.Style
+to_lime_50 =
+    Css.property "--tw-gradient-to" "#f7fee7"
+
+
+{-| The tailwind class `to-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_100 : Css.Style
+to_lime_100 =
+    Css.property "--tw-gradient-to" "#ecfccb"
+
+
+{-| The tailwind class `to-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_200 : Css.Style
+to_lime_200 =
+    Css.property "--tw-gradient-to" "#d9f99d"
+
+
+{-| The tailwind class `to-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_300 : Css.Style
+to_lime_300 =
+    Css.property "--tw-gradient-to" "#bef264"
+
+
+{-| The tailwind class `to-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_400 : Css.Style
+to_lime_400 =
+    Css.property "--tw-gradient-to" "#a3e635"
+
+
+{-| The tailwind class `to-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_500 : Css.Style
+to_lime_500 =
+    Css.property "--tw-gradient-to" "#84cc16"
+
+
+{-| The tailwind class `to-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_600 : Css.Style
+to_lime_600 =
+    Css.property "--tw-gradient-to" "#65a30d"
+
+
+{-| The tailwind class `to-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_700 : Css.Style
+to_lime_700 =
+    Css.property "--tw-gradient-to" "#4d7c0f"
+
+
+{-| The tailwind class `to-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_800 : Css.Style
+to_lime_800 =
+    Css.property "--tw-gradient-to" "#3f6212"
+
+
+{-| The tailwind class `to-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_lime_900 : Css.Style
+to_lime_900 =
+    Css.property "--tw-gradient-to" "#365314"
+
+
+{-| The tailwind class `to-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_50 : Css.Style
+to_green_50 =
+    Css.property "--tw-gradient-to" "#f0fdf4"
+
+
+{-| The tailwind class `to-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_100 : Css.Style
+to_green_100 =
+    Css.property "--tw-gradient-to" "#dcfce7"
+
+
+{-| The tailwind class `to-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_200 : Css.Style
+to_green_200 =
+    Css.property "--tw-gradient-to" "#bbf7d0"
+
+
+{-| The tailwind class `to-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_300 : Css.Style
+to_green_300 =
+    Css.property "--tw-gradient-to" "#86efac"
+
+
+{-| The tailwind class `to-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_400 : Css.Style
+to_green_400 =
+    Css.property "--tw-gradient-to" "#4ade80"
+
+
+{-| The tailwind class `to-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_500 : Css.Style
+to_green_500 =
+    Css.property "--tw-gradient-to" "#22c55e"
+
+
+{-| The tailwind class `to-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_600 : Css.Style
+to_green_600 =
+    Css.property "--tw-gradient-to" "#16a34a"
+
+
+{-| The tailwind class `to-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_700 : Css.Style
+to_green_700 =
+    Css.property "--tw-gradient-to" "#15803d"
+
+
+{-| The tailwind class `to-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_800 : Css.Style
+to_green_800 =
+    Css.property "--tw-gradient-to" "#166534"
+
+
+{-| The tailwind class `to-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_green_900 : Css.Style
+to_green_900 =
+    Css.property "--tw-gradient-to" "#14532d"
+
+
+{-| The tailwind class `to-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_50 : Css.Style
+to_emerald_50 =
+    Css.property "--tw-gradient-to" "#ecfdf5"
+
+
+{-| The tailwind class `to-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_100 : Css.Style
+to_emerald_100 =
+    Css.property "--tw-gradient-to" "#d1fae5"
+
+
+{-| The tailwind class `to-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_200 : Css.Style
+to_emerald_200 =
+    Css.property "--tw-gradient-to" "#a7f3d0"
+
+
+{-| The tailwind class `to-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_300 : Css.Style
+to_emerald_300 =
+    Css.property "--tw-gradient-to" "#6ee7b7"
+
+
+{-| The tailwind class `to-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_400 : Css.Style
+to_emerald_400 =
+    Css.property "--tw-gradient-to" "#34d399"
+
+
+{-| The tailwind class `to-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_500 : Css.Style
+to_emerald_500 =
+    Css.property "--tw-gradient-to" "#10b981"
+
+
+{-| The tailwind class `to-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_600 : Css.Style
+to_emerald_600 =
+    Css.property "--tw-gradient-to" "#059669"
+
+
+{-| The tailwind class `to-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_700 : Css.Style
+to_emerald_700 =
+    Css.property "--tw-gradient-to" "#047857"
+
+
+{-| The tailwind class `to-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_800 : Css.Style
+to_emerald_800 =
+    Css.property "--tw-gradient-to" "#065f46"
+
+
+{-| The tailwind class `to-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_emerald_900 : Css.Style
+to_emerald_900 =
+    Css.property "--tw-gradient-to" "#064e3b"
+
+
+{-| The tailwind class `to-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_50 : Css.Style
+to_teal_50 =
+    Css.property "--tw-gradient-to" "#f0fdfa"
+
+
+{-| The tailwind class `to-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_100 : Css.Style
+to_teal_100 =
+    Css.property "--tw-gradient-to" "#ccfbf1"
+
+
+{-| The tailwind class `to-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_200 : Css.Style
+to_teal_200 =
+    Css.property "--tw-gradient-to" "#99f6e4"
+
+
+{-| The tailwind class `to-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_300 : Css.Style
+to_teal_300 =
+    Css.property "--tw-gradient-to" "#5eead4"
+
+
+{-| The tailwind class `to-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_400 : Css.Style
+to_teal_400 =
+    Css.property "--tw-gradient-to" "#2dd4bf"
+
+
+{-| The tailwind class `to-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_500 : Css.Style
+to_teal_500 =
+    Css.property "--tw-gradient-to" "#14b8a6"
+
+
+{-| The tailwind class `to-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_600 : Css.Style
+to_teal_600 =
+    Css.property "--tw-gradient-to" "#0d9488"
+
+
+{-| The tailwind class `to-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_700 : Css.Style
+to_teal_700 =
+    Css.property "--tw-gradient-to" "#0f766e"
+
+
+{-| The tailwind class `to-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_800 : Css.Style
+to_teal_800 =
+    Css.property "--tw-gradient-to" "#115e59"
+
+
+{-| The tailwind class `to-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_teal_900 : Css.Style
+to_teal_900 =
+    Css.property "--tw-gradient-to" "#134e4a"
+
+
+{-| The tailwind class `to-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_50 : Css.Style
+to_cyan_50 =
+    Css.property "--tw-gradient-to" "#ecfeff"
+
+
+{-| The tailwind class `to-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_100 : Css.Style
+to_cyan_100 =
+    Css.property "--tw-gradient-to" "#cffafe"
+
+
+{-| The tailwind class `to-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_200 : Css.Style
+to_cyan_200 =
+    Css.property "--tw-gradient-to" "#a5f3fc"
+
+
+{-| The tailwind class `to-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_300 : Css.Style
+to_cyan_300 =
+    Css.property "--tw-gradient-to" "#67e8f9"
+
+
+{-| The tailwind class `to-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_400 : Css.Style
+to_cyan_400 =
+    Css.property "--tw-gradient-to" "#22d3ee"
+
+
+{-| The tailwind class `to-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_500 : Css.Style
+to_cyan_500 =
+    Css.property "--tw-gradient-to" "#06b6d4"
+
+
+{-| The tailwind class `to-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_600 : Css.Style
+to_cyan_600 =
+    Css.property "--tw-gradient-to" "#0891b2"
+
+
+{-| The tailwind class `to-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_700 : Css.Style
+to_cyan_700 =
+    Css.property "--tw-gradient-to" "#0e7490"
+
+
+{-| The tailwind class `to-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_800 : Css.Style
+to_cyan_800 =
+    Css.property "--tw-gradient-to" "#155e75"
+
+
+{-| The tailwind class `to-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_cyan_900 : Css.Style
+to_cyan_900 =
+    Css.property "--tw-gradient-to" "#164e63"
+
+
+{-| The tailwind class `to-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_50 : Css.Style
+to_sky_50 =
+    Css.property "--tw-gradient-to" "#f0f9ff"
+
+
+{-| The tailwind class `to-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_100 : Css.Style
+to_sky_100 =
+    Css.property "--tw-gradient-to" "#e0f2fe"
+
+
+{-| The tailwind class `to-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_200 : Css.Style
+to_sky_200 =
+    Css.property "--tw-gradient-to" "#bae6fd"
+
+
+{-| The tailwind class `to-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_300 : Css.Style
+to_sky_300 =
+    Css.property "--tw-gradient-to" "#7dd3fc"
+
+
+{-| The tailwind class `to-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_400 : Css.Style
+to_sky_400 =
+    Css.property "--tw-gradient-to" "#38bdf8"
+
+
+{-| The tailwind class `to-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_500 : Css.Style
+to_sky_500 =
+    Css.property "--tw-gradient-to" "#0ea5e9"
+
+
+{-| The tailwind class `to-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_600 : Css.Style
+to_sky_600 =
+    Css.property "--tw-gradient-to" "#0284c7"
+
+
+{-| The tailwind class `to-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_700 : Css.Style
+to_sky_700 =
+    Css.property "--tw-gradient-to" "#0369a1"
+
+
+{-| The tailwind class `to-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_800 : Css.Style
+to_sky_800 =
+    Css.property "--tw-gradient-to" "#075985"
+
+
+{-| The tailwind class `to-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_sky_900 : Css.Style
+to_sky_900 =
+    Css.property "--tw-gradient-to" "#0c4a6e"
+
+
+{-| The tailwind class `to-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_50 : Css.Style
+to_blue_50 =
+    Css.property "--tw-gradient-to" "#eff6ff"
+
+
+{-| The tailwind class `to-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_100 : Css.Style
+to_blue_100 =
+    Css.property "--tw-gradient-to" "#dbeafe"
+
+
+{-| The tailwind class `to-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_200 : Css.Style
+to_blue_200 =
+    Css.property "--tw-gradient-to" "#bfdbfe"
+
+
+{-| The tailwind class `to-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_300 : Css.Style
+to_blue_300 =
+    Css.property "--tw-gradient-to" "#93c5fd"
+
+
+{-| The tailwind class `to-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_400 : Css.Style
+to_blue_400 =
+    Css.property "--tw-gradient-to" "#60a5fa"
+
+
+{-| The tailwind class `to-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_500 : Css.Style
+to_blue_500 =
+    Css.property "--tw-gradient-to" "#3b82f6"
+
+
+{-| The tailwind class `to-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_600 : Css.Style
+to_blue_600 =
+    Css.property "--tw-gradient-to" "#2563eb"
+
+
+{-| The tailwind class `to-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_700 : Css.Style
+to_blue_700 =
+    Css.property "--tw-gradient-to" "#1d4ed8"
+
+
+{-| The tailwind class `to-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_800 : Css.Style
+to_blue_800 =
+    Css.property "--tw-gradient-to" "#1e40af"
+
+
+{-| The tailwind class `to-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_blue_900 : Css.Style
+to_blue_900 =
+    Css.property "--tw-gradient-to" "#1e3a8a"
+
+
+{-| The tailwind class `to-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_50 : Css.Style
+to_indigo_50 =
+    Css.property "--tw-gradient-to" "#eef2ff"
+
+
+{-| The tailwind class `to-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_100 : Css.Style
+to_indigo_100 =
+    Css.property "--tw-gradient-to" "#e0e7ff"
+
+
+{-| The tailwind class `to-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_200 : Css.Style
+to_indigo_200 =
+    Css.property "--tw-gradient-to" "#c7d2fe"
+
+
+{-| The tailwind class `to-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_300 : Css.Style
+to_indigo_300 =
+    Css.property "--tw-gradient-to" "#a5b4fc"
+
+
+{-| The tailwind class `to-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_400 : Css.Style
+to_indigo_400 =
+    Css.property "--tw-gradient-to" "#818cf8"
+
+
+{-| The tailwind class `to-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_500 : Css.Style
+to_indigo_500 =
+    Css.property "--tw-gradient-to" "#6366f1"
+
+
+{-| The tailwind class `to-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_600 : Css.Style
+to_indigo_600 =
+    Css.property "--tw-gradient-to" "#4f46e5"
+
+
+{-| The tailwind class `to-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_700 : Css.Style
+to_indigo_700 =
+    Css.property "--tw-gradient-to" "#4338ca"
+
+
+{-| The tailwind class `to-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_800 : Css.Style
+to_indigo_800 =
+    Css.property "--tw-gradient-to" "#3730a3"
+
+
+{-| The tailwind class `to-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_indigo_900 : Css.Style
+to_indigo_900 =
+    Css.property "--tw-gradient-to" "#312e81"
+
+
+{-| The tailwind class `to-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_50 : Css.Style
+to_violet_50 =
+    Css.property "--tw-gradient-to" "#f5f3ff"
+
+
+{-| The tailwind class `to-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_100 : Css.Style
+to_violet_100 =
+    Css.property "--tw-gradient-to" "#ede9fe"
+
+
+{-| The tailwind class `to-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_200 : Css.Style
+to_violet_200 =
+    Css.property "--tw-gradient-to" "#ddd6fe"
+
+
+{-| The tailwind class `to-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_300 : Css.Style
+to_violet_300 =
+    Css.property "--tw-gradient-to" "#c4b5fd"
+
+
+{-| The tailwind class `to-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_400 : Css.Style
+to_violet_400 =
+    Css.property "--tw-gradient-to" "#a78bfa"
+
+
+{-| The tailwind class `to-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_500 : Css.Style
+to_violet_500 =
+    Css.property "--tw-gradient-to" "#8b5cf6"
+
+
+{-| The tailwind class `to-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_600 : Css.Style
+to_violet_600 =
+    Css.property "--tw-gradient-to" "#7c3aed"
+
+
+{-| The tailwind class `to-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_700 : Css.Style
+to_violet_700 =
+    Css.property "--tw-gradient-to" "#6d28d9"
+
+
+{-| The tailwind class `to-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_800 : Css.Style
+to_violet_800 =
+    Css.property "--tw-gradient-to" "#5b21b6"
+
+
+{-| The tailwind class `to-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_violet_900 : Css.Style
+to_violet_900 =
+    Css.property "--tw-gradient-to" "#4c1d95"
+
+
+{-| The tailwind class `to-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_50 : Css.Style
+to_purple_50 =
+    Css.property "--tw-gradient-to" "#faf5ff"
+
+
+{-| The tailwind class `to-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_100 : Css.Style
+to_purple_100 =
+    Css.property "--tw-gradient-to" "#f3e8ff"
+
+
+{-| The tailwind class `to-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_200 : Css.Style
+to_purple_200 =
+    Css.property "--tw-gradient-to" "#e9d5ff"
+
+
+{-| The tailwind class `to-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_300 : Css.Style
+to_purple_300 =
+    Css.property "--tw-gradient-to" "#d8b4fe"
+
+
+{-| The tailwind class `to-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_400 : Css.Style
+to_purple_400 =
+    Css.property "--tw-gradient-to" "#c084fc"
+
+
+{-| The tailwind class `to-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_500 : Css.Style
+to_purple_500 =
+    Css.property "--tw-gradient-to" "#a855f7"
+
+
+{-| The tailwind class `to-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_600 : Css.Style
+to_purple_600 =
+    Css.property "--tw-gradient-to" "#9333ea"
+
+
+{-| The tailwind class `to-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_700 : Css.Style
+to_purple_700 =
+    Css.property "--tw-gradient-to" "#7e22ce"
+
+
+{-| The tailwind class `to-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_800 : Css.Style
+to_purple_800 =
+    Css.property "--tw-gradient-to" "#6b21a8"
+
+
+{-| The tailwind class `to-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_purple_900 : Css.Style
+to_purple_900 =
+    Css.property "--tw-gradient-to" "#581c87"
+
+
+{-| The tailwind class `to-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_50 : Css.Style
+to_fuchsia_50 =
+    Css.property "--tw-gradient-to" "#fdf4ff"
+
+
+{-| The tailwind class `to-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_100 : Css.Style
+to_fuchsia_100 =
+    Css.property "--tw-gradient-to" "#fae8ff"
+
+
+{-| The tailwind class `to-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_200 : Css.Style
+to_fuchsia_200 =
+    Css.property "--tw-gradient-to" "#f5d0fe"
+
+
+{-| The tailwind class `to-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_300 : Css.Style
+to_fuchsia_300 =
+    Css.property "--tw-gradient-to" "#f0abfc"
+
+
+{-| The tailwind class `to-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_400 : Css.Style
+to_fuchsia_400 =
+    Css.property "--tw-gradient-to" "#e879f9"
+
+
+{-| The tailwind class `to-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_500 : Css.Style
+to_fuchsia_500 =
+    Css.property "--tw-gradient-to" "#d946ef"
+
+
+{-| The tailwind class `to-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_600 : Css.Style
+to_fuchsia_600 =
+    Css.property "--tw-gradient-to" "#c026d3"
+
+
+{-| The tailwind class `to-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_700 : Css.Style
+to_fuchsia_700 =
+    Css.property "--tw-gradient-to" "#a21caf"
+
+
+{-| The tailwind class `to-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_800 : Css.Style
+to_fuchsia_800 =
+    Css.property "--tw-gradient-to" "#86198f"
+
+
+{-| The tailwind class `to-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_fuchsia_900 : Css.Style
+to_fuchsia_900 =
+    Css.property "--tw-gradient-to" "#701a75"
+
+
+{-| The tailwind class `to-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_50 : Css.Style
+to_pink_50 =
+    Css.property "--tw-gradient-to" "#fdf2f8"
+
+
+{-| The tailwind class `to-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_100 : Css.Style
+to_pink_100 =
+    Css.property "--tw-gradient-to" "#fce7f3"
+
+
+{-| The tailwind class `to-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_200 : Css.Style
+to_pink_200 =
+    Css.property "--tw-gradient-to" "#fbcfe8"
+
+
+{-| The tailwind class `to-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_300 : Css.Style
+to_pink_300 =
+    Css.property "--tw-gradient-to" "#f9a8d4"
+
+
+{-| The tailwind class `to-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_400 : Css.Style
+to_pink_400 =
+    Css.property "--tw-gradient-to" "#f472b6"
+
+
+{-| The tailwind class `to-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_500 : Css.Style
+to_pink_500 =
+    Css.property "--tw-gradient-to" "#ec4899"
+
+
+{-| The tailwind class `to-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_600 : Css.Style
+to_pink_600 =
+    Css.property "--tw-gradient-to" "#db2777"
+
+
+{-| The tailwind class `to-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_700 : Css.Style
+to_pink_700 =
+    Css.property "--tw-gradient-to" "#be185d"
+
+
+{-| The tailwind class `to-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_800 : Css.Style
+to_pink_800 =
+    Css.property "--tw-gradient-to" "#9d174d"
+
+
+{-| The tailwind class `to-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_pink_900 : Css.Style
+to_pink_900 =
+    Css.property "--tw-gradient-to" "#831843"
+
+
+{-| The tailwind class `to-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_50 : Css.Style
+to_rose_50 =
+    Css.property "--tw-gradient-to" "#fff1f2"
+
+
+{-| The tailwind class `to-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_100 : Css.Style
+to_rose_100 =
+    Css.property "--tw-gradient-to" "#ffe4e6"
+
+
+{-| The tailwind class `to-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_200 : Css.Style
+to_rose_200 =
+    Css.property "--tw-gradient-to" "#fecdd3"
+
+
+{-| The tailwind class `to-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_300 : Css.Style
+to_rose_300 =
+    Css.property "--tw-gradient-to" "#fda4af"
+
+
+{-| The tailwind class `to-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_400 : Css.Style
+to_rose_400 =
+    Css.property "--tw-gradient-to" "#fb7185"
+
+
+{-| The tailwind class `to-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_500 : Css.Style
+to_rose_500 =
+    Css.property "--tw-gradient-to" "#f43f5e"
+
+
+{-| The tailwind class `to-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_600 : Css.Style
+to_rose_600 =
+    Css.property "--tw-gradient-to" "#e11d48"
+
+
+{-| The tailwind class `to-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_700 : Css.Style
+to_rose_700 =
+    Css.property "--tw-gradient-to" "#be123c"
+
+
+{-| The tailwind class `to-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_800 : Css.Style
+to_rose_800 =
+    Css.property "--tw-gradient-to" "#9f1239"
+
+
+{-| The tailwind class `to-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+to_rose_900 : Css.Style
+to_rose_900 =
+    Css.property "--tw-gradient-to" "#881337"
 
 
 {-| The tailwind class `top-0`.
@@ -53526,104 +57586,24 @@ via_black =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #000, var(--tw-gradient-to, rgba(0, 0, 0, 0))"
 
 
-{-| The tailwind class `via-blue-100`.
+{-| The tailwind class `via-white`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_blue_100 : Css.Style
-via_blue_100 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #dbeafe, var(--tw-gradient-to, rgba(219, 234, 254, 0))"
+via_white : Css.Style
+via_white =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fff, var(--tw-gradient-to, rgba(255, 255, 255, 0))"
 
 
-{-| The tailwind class `via-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_200 : Css.Style
-via_blue_200 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bfdbfe, var(--tw-gradient-to, rgba(191, 219, 254, 0))"
-
-
-{-| The tailwind class `via-blue-300`.
+{-| The tailwind class `via-transparent`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_blue_300 : Css.Style
-via_blue_300 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #93c5fd, var(--tw-gradient-to, rgba(147, 197, 253, 0))"
-
-
-{-| The tailwind class `via-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_400 : Css.Style
-via_blue_400 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #60a5fa, var(--tw-gradient-to, rgba(96, 165, 250, 0))"
-
-
-{-| The tailwind class `via-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_50 : Css.Style
-via_blue_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eff6ff, var(--tw-gradient-to, rgba(239, 246, 255, 0))"
-
-
-{-| The tailwind class `via-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_500 : Css.Style
-via_blue_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3b82f6, var(--tw-gradient-to, rgba(59, 130, 246, 0))"
-
-
-{-| The tailwind class `via-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_600 : Css.Style
-via_blue_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #2563eb, var(--tw-gradient-to, rgba(37, 99, 235, 0))"
-
-
-{-| The tailwind class `via-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_700 : Css.Style
-via_blue_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1d4ed8, var(--tw-gradient-to, rgba(29, 78, 216, 0))"
-
-
-{-| The tailwind class `via-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_800 : Css.Style
-via_blue_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e40af, var(--tw-gradient-to, rgba(30, 64, 175, 0))"
-
-
-{-| The tailwind class `via-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_blue_900 : Css.Style
-via_blue_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e3a8a, var(--tw-gradient-to, rgba(30, 58, 138, 0))"
+via_transparent : Css.Style
+via_transparent =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0))"
 
 
 {-| The tailwind class `via-current`.
@@ -53634,6 +57614,116 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 via_current : Css.Style
 via_current =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), currentColor, var(--tw-gradient-to, rgba(255, 255, 255, 0))"
+
+
+{-| The tailwind class `via-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_50 : Css.Style
+via_slate_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f8fafc, var(--tw-gradient-to, rgba(248, 250, 252, 0))"
+
+
+{-| The tailwind class `via-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_100 : Css.Style
+via_slate_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f1f5f9, var(--tw-gradient-to, rgba(241, 245, 249, 0))"
+
+
+{-| The tailwind class `via-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_200 : Css.Style
+via_slate_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e2e8f0, var(--tw-gradient-to, rgba(226, 232, 240, 0))"
+
+
+{-| The tailwind class `via-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_300 : Css.Style
+via_slate_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #cbd5e1, var(--tw-gradient-to, rgba(203, 213, 225, 0))"
+
+
+{-| The tailwind class `via-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_400 : Css.Style
+via_slate_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #94a3b8, var(--tw-gradient-to, rgba(148, 163, 184, 0))"
+
+
+{-| The tailwind class `via-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_500 : Css.Style
+via_slate_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #64748b, var(--tw-gradient-to, rgba(100, 116, 139, 0))"
+
+
+{-| The tailwind class `via-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_600 : Css.Style
+via_slate_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #475569, var(--tw-gradient-to, rgba(71, 85, 105, 0))"
+
+
+{-| The tailwind class `via-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_700 : Css.Style
+via_slate_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #334155, var(--tw-gradient-to, rgba(51, 65, 85, 0))"
+
+
+{-| The tailwind class `via-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_800 : Css.Style
+via_slate_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e293b, var(--tw-gradient-to, rgba(30, 41, 59, 0))"
+
+
+{-| The tailwind class `via-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_slate_900 : Css.Style
+via_slate_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0f172a, var(--tw-gradient-to, rgba(15, 23, 42, 0))"
+
+
+{-| The tailwind class `via-gray-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_gray_50 : Css.Style
+via_gray_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9fafb, var(--tw-gradient-to, rgba(249, 250, 251, 0))"
 
 
 {-| The tailwind class `via-gray-100`.
@@ -53674,16 +57764,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 via_gray_400 : Css.Style
 via_gray_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9ca3af, var(--tw-gradient-to, rgba(156, 163, 175, 0))"
-
-
-{-| The tailwind class `via-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_gray_50 : Css.Style
-via_gray_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9fafb, var(--tw-gradient-to, rgba(249, 250, 251, 0))"
 
 
 {-| The tailwind class `via-gray-500`.
@@ -53736,404 +57816,314 @@ via_gray_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #111827, var(--tw-gradient-to, rgba(17, 24, 39, 0))"
 
 
-{-| The tailwind class `via-green-100`.
+{-| The tailwind class `via-zinc-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_green_100 : Css.Style
-via_green_100 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d1fae5, var(--tw-gradient-to, rgba(209, 250, 229, 0))"
+via_zinc_50 : Css.Style
+via_zinc_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fafafa, var(--tw-gradient-to, rgba(250, 250, 250, 0))"
 
 
-{-| The tailwind class `via-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_green_200 : Css.Style
-via_green_200 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a7f3d0, var(--tw-gradient-to, rgba(167, 243, 208, 0))"
-
-
-{-| The tailwind class `via-green-300`.
+{-| The tailwind class `via-zinc-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_green_300 : Css.Style
-via_green_300 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6ee7b7, var(--tw-gradient-to, rgba(110, 231, 183, 0))"
+via_zinc_100 : Css.Style
+via_zinc_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f4f4f5, var(--tw-gradient-to, rgba(244, 244, 245, 0))"
 
 
-{-| The tailwind class `via-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_green_400 : Css.Style
-via_green_400 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #34d399, var(--tw-gradient-to, rgba(52, 211, 153, 0))"
-
-
-{-| The tailwind class `via-green-50`.
+{-| The tailwind class `via-zinc-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_green_50 : Css.Style
-via_green_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ecfdf5, var(--tw-gradient-to, rgba(236, 253, 245, 0))"
+via_zinc_200 : Css.Style
+via_zinc_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e4e4e7, var(--tw-gradient-to, rgba(228, 228, 231, 0))"
 
 
-{-| The tailwind class `via-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_green_500 : Css.Style
-via_green_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #10b981, var(--tw-gradient-to, rgba(16, 185, 129, 0))"
-
-
-{-| The tailwind class `via-green-600`.
+{-| The tailwind class `via-zinc-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_green_600 : Css.Style
-via_green_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #059669, var(--tw-gradient-to, rgba(5, 150, 105, 0))"
+via_zinc_300 : Css.Style
+via_zinc_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d4d4d8, var(--tw-gradient-to, rgba(212, 212, 216, 0))"
 
 
-{-| The tailwind class `via-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_green_700 : Css.Style
-via_green_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #047857, var(--tw-gradient-to, rgba(4, 120, 87, 0))"
-
-
-{-| The tailwind class `via-green-800`.
+{-| The tailwind class `via-zinc-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_green_800 : Css.Style
-via_green_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #065f46, var(--tw-gradient-to, rgba(6, 95, 70, 0))"
+via_zinc_400 : Css.Style
+via_zinc_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a1a1aa, var(--tw-gradient-to, rgba(161, 161, 170, 0))"
 
 
-{-| The tailwind class `via-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_green_900 : Css.Style
-via_green_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #064e3b, var(--tw-gradient-to, rgba(6, 78, 59, 0))"
-
-
-{-| The tailwind class `via-indigo-100`.
+{-| The tailwind class `via-zinc-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_indigo_100 : Css.Style
-via_indigo_100 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e0e7ff, var(--tw-gradient-to, rgba(224, 231, 255, 0))"
+via_zinc_500 : Css.Style
+via_zinc_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #71717a, var(--tw-gradient-to, rgba(113, 113, 122, 0))"
 
 
-{-| The tailwind class `via-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_indigo_200 : Css.Style
-via_indigo_200 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c7d2fe, var(--tw-gradient-to, rgba(199, 210, 254, 0))"
-
-
-{-| The tailwind class `via-indigo-300`.
+{-| The tailwind class `via-zinc-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_indigo_300 : Css.Style
-via_indigo_300 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a5b4fc, var(--tw-gradient-to, rgba(165, 180, 252, 0))"
+via_zinc_600 : Css.Style
+via_zinc_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #52525b, var(--tw-gradient-to, rgba(82, 82, 91, 0))"
 
 
-{-| The tailwind class `via-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_indigo_400 : Css.Style
-via_indigo_400 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #818cf8, var(--tw-gradient-to, rgba(129, 140, 248, 0))"
-
-
-{-| The tailwind class `via-indigo-50`.
+{-| The tailwind class `via-zinc-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_indigo_50 : Css.Style
-via_indigo_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eef2ff, var(--tw-gradient-to, rgba(238, 242, 255, 0))"
+via_zinc_700 : Css.Style
+via_zinc_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3f3f46, var(--tw-gradient-to, rgba(63, 63, 70, 0))"
 
 
-{-| The tailwind class `via-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_indigo_500 : Css.Style
-via_indigo_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6366f1, var(--tw-gradient-to, rgba(99, 102, 241, 0))"
-
-
-{-| The tailwind class `via-indigo-600`.
+{-| The tailwind class `via-zinc-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_indigo_600 : Css.Style
-via_indigo_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4f46e5, var(--tw-gradient-to, rgba(79, 70, 229, 0))"
+via_zinc_800 : Css.Style
+via_zinc_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #27272a, var(--tw-gradient-to, rgba(39, 39, 42, 0))"
 
 
-{-| The tailwind class `via-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_indigo_700 : Css.Style
-via_indigo_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4338ca, var(--tw-gradient-to, rgba(67, 56, 202, 0))"
-
-
-{-| The tailwind class `via-indigo-800`.
+{-| The tailwind class `via-zinc-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_indigo_800 : Css.Style
-via_indigo_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3730a3, var(--tw-gradient-to, rgba(55, 48, 163, 0))"
+via_zinc_900 : Css.Style
+via_zinc_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #18181b, var(--tw-gradient-to, rgba(24, 24, 27, 0))"
 
 
-{-| The tailwind class `via-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_indigo_900 : Css.Style
-via_indigo_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #312e81, var(--tw-gradient-to, rgba(49, 46, 129, 0))"
-
-
-{-| The tailwind class `via-pink-100`.
+{-| The tailwind class `via-neutral-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_pink_100 : Css.Style
-via_pink_100 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fce7f3, var(--tw-gradient-to, rgba(252, 231, 243, 0))"
+via_neutral_50 : Css.Style
+via_neutral_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fafafa, var(--tw-gradient-to, rgba(250, 250, 250, 0))"
 
 
-{-| The tailwind class `via-pink-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_pink_200 : Css.Style
-via_pink_200 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fbcfe8, var(--tw-gradient-to, rgba(251, 207, 232, 0))"
-
-
-{-| The tailwind class `via-pink-300`.
+{-| The tailwind class `via-neutral-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_pink_300 : Css.Style
-via_pink_300 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9a8d4, var(--tw-gradient-to, rgba(249, 168, 212, 0))"
+via_neutral_100 : Css.Style
+via_neutral_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5f5f5, var(--tw-gradient-to, rgba(245, 245, 245, 0))"
 
 
-{-| The tailwind class `via-pink-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_pink_400 : Css.Style
-via_pink_400 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f472b6, var(--tw-gradient-to, rgba(244, 114, 182, 0))"
-
-
-{-| The tailwind class `via-pink-50`.
+{-| The tailwind class `via-neutral-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_pink_50 : Css.Style
-via_pink_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fdf2f8, var(--tw-gradient-to, rgba(253, 242, 248, 0))"
+via_neutral_200 : Css.Style
+via_neutral_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e5e5e5, var(--tw-gradient-to, rgba(229, 229, 229, 0))"
 
 
-{-| The tailwind class `via-pink-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_pink_500 : Css.Style
-via_pink_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ec4899, var(--tw-gradient-to, rgba(236, 72, 153, 0))"
-
-
-{-| The tailwind class `via-pink-600`.
+{-| The tailwind class `via-neutral-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_pink_600 : Css.Style
-via_pink_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #db2777, var(--tw-gradient-to, rgba(219, 39, 119, 0))"
+via_neutral_300 : Css.Style
+via_neutral_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d4d4d4, var(--tw-gradient-to, rgba(212, 212, 212, 0))"
 
 
-{-| The tailwind class `via-pink-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_pink_700 : Css.Style
-via_pink_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #be185d, var(--tw-gradient-to, rgba(190, 24, 93, 0))"
-
-
-{-| The tailwind class `via-pink-800`.
+{-| The tailwind class `via-neutral-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_pink_800 : Css.Style
-via_pink_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9d174d, var(--tw-gradient-to, rgba(157, 23, 77, 0))"
+via_neutral_400 : Css.Style
+via_neutral_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a3a3a3, var(--tw-gradient-to, rgba(163, 163, 163, 0))"
 
 
-{-| The tailwind class `via-pink-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_pink_900 : Css.Style
-via_pink_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #831843, var(--tw-gradient-to, rgba(131, 24, 67, 0))"
-
-
-{-| The tailwind class `via-purple-100`.
+{-| The tailwind class `via-neutral-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_100 : Css.Style
-via_purple_100 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ede9fe, var(--tw-gradient-to, rgba(237, 233, 254, 0))"
+via_neutral_500 : Css.Style
+via_neutral_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #737373, var(--tw-gradient-to, rgba(115, 115, 115, 0))"
 
 
-{-| The tailwind class `via-purple-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_purple_200 : Css.Style
-via_purple_200 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ddd6fe, var(--tw-gradient-to, rgba(221, 214, 254, 0))"
-
-
-{-| The tailwind class `via-purple-300`.
+{-| The tailwind class `via-neutral-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_300 : Css.Style
-via_purple_300 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c4b5fd, var(--tw-gradient-to, rgba(196, 181, 253, 0))"
+via_neutral_600 : Css.Style
+via_neutral_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #525252, var(--tw-gradient-to, rgba(82, 82, 82, 0))"
 
 
-{-| The tailwind class `via-purple-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_purple_400 : Css.Style
-via_purple_400 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a78bfa, var(--tw-gradient-to, rgba(167, 139, 250, 0))"
-
-
-{-| The tailwind class `via-purple-50`.
+{-| The tailwind class `via-neutral-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_50 : Css.Style
-via_purple_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5f3ff, var(--tw-gradient-to, rgba(245, 243, 255, 0))"
+via_neutral_700 : Css.Style
+via_neutral_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #404040, var(--tw-gradient-to, rgba(64, 64, 64, 0))"
 
 
-{-| The tailwind class `via-purple-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_purple_500 : Css.Style
-via_purple_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #8b5cf6, var(--tw-gradient-to, rgba(139, 92, 246, 0))"
-
-
-{-| The tailwind class `via-purple-600`.
+{-| The tailwind class `via-neutral-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_600 : Css.Style
-via_purple_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7c3aed, var(--tw-gradient-to, rgba(124, 58, 237, 0))"
+via_neutral_800 : Css.Style
+via_neutral_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #262626, var(--tw-gradient-to, rgba(38, 38, 38, 0))"
 
 
-{-| The tailwind class `via-purple-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_purple_700 : Css.Style
-via_purple_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6d28d9, var(--tw-gradient-to, rgba(109, 40, 217, 0))"
-
-
-{-| The tailwind class `via-purple-800`.
+{-| The tailwind class `via-neutral-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_800 : Css.Style
-via_purple_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #5b21b6, var(--tw-gradient-to, rgba(91, 33, 182, 0))"
+via_neutral_900 : Css.Style
+via_neutral_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #171717, var(--tw-gradient-to, rgba(23, 23, 23, 0))"
 
 
-{-| The tailwind class `via-purple-900`.
+{-| The tailwind class `via-stone-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_purple_900 : Css.Style
-via_purple_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4c1d95, var(--tw-gradient-to, rgba(76, 29, 149, 0))"
+via_stone_50 : Css.Style
+via_stone_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fafaf9, var(--tw-gradient-to, rgba(250, 250, 249, 0))"
+
+
+{-| The tailwind class `via-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_100 : Css.Style
+via_stone_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5f5f4, var(--tw-gradient-to, rgba(245, 245, 244, 0))"
+
+
+{-| The tailwind class `via-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_200 : Css.Style
+via_stone_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e7e5e4, var(--tw-gradient-to, rgba(231, 229, 228, 0))"
+
+
+{-| The tailwind class `via-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_300 : Css.Style
+via_stone_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d6d3d1, var(--tw-gradient-to, rgba(214, 211, 209, 0))"
+
+
+{-| The tailwind class `via-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_400 : Css.Style
+via_stone_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a8a29e, var(--tw-gradient-to, rgba(168, 162, 158, 0))"
+
+
+{-| The tailwind class `via-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_500 : Css.Style
+via_stone_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #78716c, var(--tw-gradient-to, rgba(120, 113, 108, 0))"
+
+
+{-| The tailwind class `via-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_600 : Css.Style
+via_stone_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #57534e, var(--tw-gradient-to, rgba(87, 83, 78, 0))"
+
+
+{-| The tailwind class `via-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_700 : Css.Style
+via_stone_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #44403c, var(--tw-gradient-to, rgba(68, 64, 60, 0))"
+
+
+{-| The tailwind class `via-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_800 : Css.Style
+via_stone_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #292524, var(--tw-gradient-to, rgba(41, 37, 36, 0))"
+
+
+{-| The tailwind class `via-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_stone_900 : Css.Style
+via_stone_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1c1917, var(--tw-gradient-to, rgba(28, 25, 23, 0))"
+
+
+{-| The tailwind class `via-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_red_50 : Css.Style
+via_red_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef2f2, var(--tw-gradient-to, rgba(254, 242, 242, 0))"
 
 
 {-| The tailwind class `via-red-100`.
@@ -54174,16 +58164,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 via_red_400 : Css.Style
 via_red_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f87171, var(--tw-gradient-to, rgba(248, 113, 113, 0))"
-
-
-{-| The tailwind class `via-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_red_50 : Css.Style
-via_red_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef2f2, var(--tw-gradient-to, rgba(254, 242, 242, 0))"
 
 
 {-| The tailwind class `via-red-500`.
@@ -54236,64 +58216,204 @@ via_red_900 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7f1d1d, var(--tw-gradient-to, rgba(127, 29, 29, 0))"
 
 
-{-| The tailwind class `via-transparent`.
+{-| The tailwind class `via-orange-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_transparent : Css.Style
-via_transparent =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), transparent, var(--tw-gradient-to, rgba(0, 0, 0, 0))"
+via_orange_50 : Css.Style
+via_orange_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fff7ed, var(--tw-gradient-to, rgba(255, 247, 237, 0))"
 
 
-{-| The tailwind class `via-white`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-via_white : Css.Style
-via_white =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fff, var(--tw-gradient-to, rgba(255, 255, 255, 0))"
-
-
-{-| The tailwind class `via-yellow-100`.
+{-| The tailwind class `via-orange-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_yellow_100 : Css.Style
-via_yellow_100 =
+via_orange_100 : Css.Style
+via_orange_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ffedd5, var(--tw-gradient-to, rgba(255, 237, 213, 0))"
+
+
+{-| The tailwind class `via-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_200 : Css.Style
+via_orange_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fed7aa, var(--tw-gradient-to, rgba(254, 215, 170, 0))"
+
+
+{-| The tailwind class `via-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_300 : Css.Style
+via_orange_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fdba74, var(--tw-gradient-to, rgba(253, 186, 116, 0))"
+
+
+{-| The tailwind class `via-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_400 : Css.Style
+via_orange_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fb923c, var(--tw-gradient-to, rgba(251, 146, 60, 0))"
+
+
+{-| The tailwind class `via-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_500 : Css.Style
+via_orange_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f97316, var(--tw-gradient-to, rgba(249, 115, 22, 0))"
+
+
+{-| The tailwind class `via-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_600 : Css.Style
+via_orange_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ea580c, var(--tw-gradient-to, rgba(234, 88, 12, 0))"
+
+
+{-| The tailwind class `via-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_700 : Css.Style
+via_orange_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c2410c, var(--tw-gradient-to, rgba(194, 65, 12, 0))"
+
+
+{-| The tailwind class `via-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_800 : Css.Style
+via_orange_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9a3412, var(--tw-gradient-to, rgba(154, 52, 18, 0))"
+
+
+{-| The tailwind class `via-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_orange_900 : Css.Style
+via_orange_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7c2d12, var(--tw-gradient-to, rgba(124, 45, 18, 0))"
+
+
+{-| The tailwind class `via-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_50 : Css.Style
+via_amber_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fffbeb, var(--tw-gradient-to, rgba(255, 251, 235, 0))"
+
+
+{-| The tailwind class `via-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_100 : Css.Style
+via_amber_100 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef3c7, var(--tw-gradient-to, rgba(254, 243, 199, 0))"
 
 
-{-| The tailwind class `via-yellow-200`.
+{-| The tailwind class `via-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_yellow_200 : Css.Style
-via_yellow_200 =
+via_amber_200 : Css.Style
+via_amber_200 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fde68a, var(--tw-gradient-to, rgba(253, 230, 138, 0))"
 
 
-{-| The tailwind class `via-yellow-300`.
+{-| The tailwind class `via-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_yellow_300 : Css.Style
-via_yellow_300 =
+via_amber_300 : Css.Style
+via_amber_300 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fcd34d, var(--tw-gradient-to, rgba(252, 211, 77, 0))"
 
 
-{-| The tailwind class `via-yellow-400`.
+{-| The tailwind class `via-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-via_yellow_400 : Css.Style
-via_yellow_400 =
+via_amber_400 : Css.Style
+via_amber_400 =
     Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fbbf24, var(--tw-gradient-to, rgba(251, 191, 36, 0))"
+
+
+{-| The tailwind class `via-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_500 : Css.Style
+via_amber_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f59e0b, var(--tw-gradient-to, rgba(245, 158, 11, 0))"
+
+
+{-| The tailwind class `via-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_600 : Css.Style
+via_amber_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d97706, var(--tw-gradient-to, rgba(217, 119, 6, 0))"
+
+
+{-| The tailwind class `via-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_700 : Css.Style
+via_amber_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #b45309, var(--tw-gradient-to, rgba(180, 83, 9, 0))"
+
+
+{-| The tailwind class `via-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_800 : Css.Style
+via_amber_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #92400e, var(--tw-gradient-to, rgba(146, 64, 14, 0))"
+
+
+{-| The tailwind class `via-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_amber_900 : Css.Style
+via_amber_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #78350f, var(--tw-gradient-to, rgba(120, 53, 15, 0))"
 
 
 {-| The tailwind class `via-yellow-50`.
@@ -54303,7 +58423,47 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_50 : Css.Style
 via_yellow_50 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fffbeb, var(--tw-gradient-to, rgba(255, 251, 235, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fefce8, var(--tw-gradient-to, rgba(254, 252, 232, 0))"
+
+
+{-| The tailwind class `via-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_yellow_100 : Css.Style
+via_yellow_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef9c3, var(--tw-gradient-to, rgba(254, 249, 195, 0))"
+
+
+{-| The tailwind class `via-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_yellow_200 : Css.Style
+via_yellow_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fef08a, var(--tw-gradient-to, rgba(254, 240, 138, 0))"
+
+
+{-| The tailwind class `via-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_yellow_300 : Css.Style
+via_yellow_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fde047, var(--tw-gradient-to, rgba(253, 224, 71, 0))"
+
+
+{-| The tailwind class `via-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_yellow_400 : Css.Style
+via_yellow_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #facc15, var(--tw-gradient-to, rgba(250, 204, 21, 0))"
 
 
 {-| The tailwind class `via-yellow-500`.
@@ -54313,7 +58473,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_500 : Css.Style
 via_yellow_500 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f59e0b, var(--tw-gradient-to, rgba(245, 158, 11, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eab308, var(--tw-gradient-to, rgba(234, 179, 8, 0))"
 
 
 {-| The tailwind class `via-yellow-600`.
@@ -54323,7 +58483,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_600 : Css.Style
 via_yellow_600 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d97706, var(--tw-gradient-to, rgba(217, 119, 6, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ca8a04, var(--tw-gradient-to, rgba(202, 138, 4, 0))"
 
 
 {-| The tailwind class `via-yellow-700`.
@@ -54333,7 +58493,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_700 : Css.Style
 via_yellow_700 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #b45309, var(--tw-gradient-to, rgba(180, 83, 9, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a16207, var(--tw-gradient-to, rgba(161, 98, 7, 0))"
 
 
 {-| The tailwind class `via-yellow-800`.
@@ -54343,7 +58503,7 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_800 : Css.Style
 via_yellow_800 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #92400e, var(--tw-gradient-to, rgba(146, 64, 14, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #854d0e, var(--tw-gradient-to, rgba(133, 77, 14, 0))"
 
 
 {-| The tailwind class `via-yellow-900`.
@@ -54353,7 +58513,1307 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 -}
 via_yellow_900 : Css.Style
 via_yellow_900 =
-    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #78350f, var(--tw-gradient-to, rgba(120, 53, 15, 0))"
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #713f12, var(--tw-gradient-to, rgba(113, 63, 18, 0))"
+
+
+{-| The tailwind class `via-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_50 : Css.Style
+via_lime_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f7fee7, var(--tw-gradient-to, rgba(247, 254, 231, 0))"
+
+
+{-| The tailwind class `via-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_100 : Css.Style
+via_lime_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ecfccb, var(--tw-gradient-to, rgba(236, 252, 203, 0))"
+
+
+{-| The tailwind class `via-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_200 : Css.Style
+via_lime_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d9f99d, var(--tw-gradient-to, rgba(217, 249, 157, 0))"
+
+
+{-| The tailwind class `via-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_300 : Css.Style
+via_lime_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bef264, var(--tw-gradient-to, rgba(190, 242, 100, 0))"
+
+
+{-| The tailwind class `via-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_400 : Css.Style
+via_lime_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a3e635, var(--tw-gradient-to, rgba(163, 230, 53, 0))"
+
+
+{-| The tailwind class `via-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_500 : Css.Style
+via_lime_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #84cc16, var(--tw-gradient-to, rgba(132, 204, 22, 0))"
+
+
+{-| The tailwind class `via-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_600 : Css.Style
+via_lime_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #65a30d, var(--tw-gradient-to, rgba(101, 163, 13, 0))"
+
+
+{-| The tailwind class `via-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_700 : Css.Style
+via_lime_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4d7c0f, var(--tw-gradient-to, rgba(77, 124, 15, 0))"
+
+
+{-| The tailwind class `via-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_800 : Css.Style
+via_lime_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3f6212, var(--tw-gradient-to, rgba(63, 98, 18, 0))"
+
+
+{-| The tailwind class `via-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_lime_900 : Css.Style
+via_lime_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #365314, var(--tw-gradient-to, rgba(54, 83, 20, 0))"
+
+
+{-| The tailwind class `via-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_50 : Css.Style
+via_green_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f0fdf4, var(--tw-gradient-to, rgba(240, 253, 244, 0))"
+
+
+{-| The tailwind class `via-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_100 : Css.Style
+via_green_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #dcfce7, var(--tw-gradient-to, rgba(220, 252, 231, 0))"
+
+
+{-| The tailwind class `via-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_200 : Css.Style
+via_green_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bbf7d0, var(--tw-gradient-to, rgba(187, 247, 208, 0))"
+
+
+{-| The tailwind class `via-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_300 : Css.Style
+via_green_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #86efac, var(--tw-gradient-to, rgba(134, 239, 172, 0))"
+
+
+{-| The tailwind class `via-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_400 : Css.Style
+via_green_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4ade80, var(--tw-gradient-to, rgba(74, 222, 128, 0))"
+
+
+{-| The tailwind class `via-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_500 : Css.Style
+via_green_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #22c55e, var(--tw-gradient-to, rgba(34, 197, 94, 0))"
+
+
+{-| The tailwind class `via-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_600 : Css.Style
+via_green_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #16a34a, var(--tw-gradient-to, rgba(22, 163, 74, 0))"
+
+
+{-| The tailwind class `via-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_700 : Css.Style
+via_green_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #15803d, var(--tw-gradient-to, rgba(21, 128, 61, 0))"
+
+
+{-| The tailwind class `via-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_800 : Css.Style
+via_green_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #166534, var(--tw-gradient-to, rgba(22, 101, 52, 0))"
+
+
+{-| The tailwind class `via-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_green_900 : Css.Style
+via_green_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #14532d, var(--tw-gradient-to, rgba(20, 83, 45, 0))"
+
+
+{-| The tailwind class `via-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_50 : Css.Style
+via_emerald_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ecfdf5, var(--tw-gradient-to, rgba(236, 253, 245, 0))"
+
+
+{-| The tailwind class `via-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_100 : Css.Style
+via_emerald_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d1fae5, var(--tw-gradient-to, rgba(209, 250, 229, 0))"
+
+
+{-| The tailwind class `via-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_200 : Css.Style
+via_emerald_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a7f3d0, var(--tw-gradient-to, rgba(167, 243, 208, 0))"
+
+
+{-| The tailwind class `via-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_300 : Css.Style
+via_emerald_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6ee7b7, var(--tw-gradient-to, rgba(110, 231, 183, 0))"
+
+
+{-| The tailwind class `via-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_400 : Css.Style
+via_emerald_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #34d399, var(--tw-gradient-to, rgba(52, 211, 153, 0))"
+
+
+{-| The tailwind class `via-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_500 : Css.Style
+via_emerald_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #10b981, var(--tw-gradient-to, rgba(16, 185, 129, 0))"
+
+
+{-| The tailwind class `via-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_600 : Css.Style
+via_emerald_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #059669, var(--tw-gradient-to, rgba(5, 150, 105, 0))"
+
+
+{-| The tailwind class `via-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_700 : Css.Style
+via_emerald_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #047857, var(--tw-gradient-to, rgba(4, 120, 87, 0))"
+
+
+{-| The tailwind class `via-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_800 : Css.Style
+via_emerald_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #065f46, var(--tw-gradient-to, rgba(6, 95, 70, 0))"
+
+
+{-| The tailwind class `via-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_emerald_900 : Css.Style
+via_emerald_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #064e3b, var(--tw-gradient-to, rgba(6, 78, 59, 0))"
+
+
+{-| The tailwind class `via-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_50 : Css.Style
+via_teal_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f0fdfa, var(--tw-gradient-to, rgba(240, 253, 250, 0))"
+
+
+{-| The tailwind class `via-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_100 : Css.Style
+via_teal_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ccfbf1, var(--tw-gradient-to, rgba(204, 251, 241, 0))"
+
+
+{-| The tailwind class `via-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_200 : Css.Style
+via_teal_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #99f6e4, var(--tw-gradient-to, rgba(153, 246, 228, 0))"
+
+
+{-| The tailwind class `via-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_300 : Css.Style
+via_teal_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #5eead4, var(--tw-gradient-to, rgba(94, 234, 212, 0))"
+
+
+{-| The tailwind class `via-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_400 : Css.Style
+via_teal_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #2dd4bf, var(--tw-gradient-to, rgba(45, 212, 191, 0))"
+
+
+{-| The tailwind class `via-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_500 : Css.Style
+via_teal_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #14b8a6, var(--tw-gradient-to, rgba(20, 184, 166, 0))"
+
+
+{-| The tailwind class `via-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_600 : Css.Style
+via_teal_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0d9488, var(--tw-gradient-to, rgba(13, 148, 136, 0))"
+
+
+{-| The tailwind class `via-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_700 : Css.Style
+via_teal_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0f766e, var(--tw-gradient-to, rgba(15, 118, 110, 0))"
+
+
+{-| The tailwind class `via-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_800 : Css.Style
+via_teal_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #115e59, var(--tw-gradient-to, rgba(17, 94, 89, 0))"
+
+
+{-| The tailwind class `via-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_teal_900 : Css.Style
+via_teal_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #134e4a, var(--tw-gradient-to, rgba(19, 78, 74, 0))"
+
+
+{-| The tailwind class `via-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_50 : Css.Style
+via_cyan_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ecfeff, var(--tw-gradient-to, rgba(236, 254, 255, 0))"
+
+
+{-| The tailwind class `via-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_100 : Css.Style
+via_cyan_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #cffafe, var(--tw-gradient-to, rgba(207, 250, 254, 0))"
+
+
+{-| The tailwind class `via-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_200 : Css.Style
+via_cyan_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a5f3fc, var(--tw-gradient-to, rgba(165, 243, 252, 0))"
+
+
+{-| The tailwind class `via-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_300 : Css.Style
+via_cyan_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #67e8f9, var(--tw-gradient-to, rgba(103, 232, 249, 0))"
+
+
+{-| The tailwind class `via-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_400 : Css.Style
+via_cyan_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #22d3ee, var(--tw-gradient-to, rgba(34, 211, 238, 0))"
+
+
+{-| The tailwind class `via-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_500 : Css.Style
+via_cyan_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #06b6d4, var(--tw-gradient-to, rgba(6, 182, 212, 0))"
+
+
+{-| The tailwind class `via-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_600 : Css.Style
+via_cyan_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0891b2, var(--tw-gradient-to, rgba(8, 145, 178, 0))"
+
+
+{-| The tailwind class `via-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_700 : Css.Style
+via_cyan_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0e7490, var(--tw-gradient-to, rgba(14, 116, 144, 0))"
+
+
+{-| The tailwind class `via-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_800 : Css.Style
+via_cyan_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #155e75, var(--tw-gradient-to, rgba(21, 94, 117, 0))"
+
+
+{-| The tailwind class `via-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_cyan_900 : Css.Style
+via_cyan_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #164e63, var(--tw-gradient-to, rgba(22, 78, 99, 0))"
+
+
+{-| The tailwind class `via-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_50 : Css.Style
+via_sky_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f0f9ff, var(--tw-gradient-to, rgba(240, 249, 255, 0))"
+
+
+{-| The tailwind class `via-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_100 : Css.Style
+via_sky_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e0f2fe, var(--tw-gradient-to, rgba(224, 242, 254, 0))"
+
+
+{-| The tailwind class `via-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_200 : Css.Style
+via_sky_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bae6fd, var(--tw-gradient-to, rgba(186, 230, 253, 0))"
+
+
+{-| The tailwind class `via-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_300 : Css.Style
+via_sky_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7dd3fc, var(--tw-gradient-to, rgba(125, 211, 252, 0))"
+
+
+{-| The tailwind class `via-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_400 : Css.Style
+via_sky_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #38bdf8, var(--tw-gradient-to, rgba(56, 189, 248, 0))"
+
+
+{-| The tailwind class `via-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_500 : Css.Style
+via_sky_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0ea5e9, var(--tw-gradient-to, rgba(14, 165, 233, 0))"
+
+
+{-| The tailwind class `via-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_600 : Css.Style
+via_sky_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0284c7, var(--tw-gradient-to, rgba(2, 132, 199, 0))"
+
+
+{-| The tailwind class `via-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_700 : Css.Style
+via_sky_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0369a1, var(--tw-gradient-to, rgba(3, 105, 161, 0))"
+
+
+{-| The tailwind class `via-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_800 : Css.Style
+via_sky_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #075985, var(--tw-gradient-to, rgba(7, 89, 133, 0))"
+
+
+{-| The tailwind class `via-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_sky_900 : Css.Style
+via_sky_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #0c4a6e, var(--tw-gradient-to, rgba(12, 74, 110, 0))"
+
+
+{-| The tailwind class `via-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_50 : Css.Style
+via_blue_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eff6ff, var(--tw-gradient-to, rgba(239, 246, 255, 0))"
+
+
+{-| The tailwind class `via-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_100 : Css.Style
+via_blue_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #dbeafe, var(--tw-gradient-to, rgba(219, 234, 254, 0))"
+
+
+{-| The tailwind class `via-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_200 : Css.Style
+via_blue_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #bfdbfe, var(--tw-gradient-to, rgba(191, 219, 254, 0))"
+
+
+{-| The tailwind class `via-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_300 : Css.Style
+via_blue_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #93c5fd, var(--tw-gradient-to, rgba(147, 197, 253, 0))"
+
+
+{-| The tailwind class `via-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_400 : Css.Style
+via_blue_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #60a5fa, var(--tw-gradient-to, rgba(96, 165, 250, 0))"
+
+
+{-| The tailwind class `via-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_500 : Css.Style
+via_blue_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3b82f6, var(--tw-gradient-to, rgba(59, 130, 246, 0))"
+
+
+{-| The tailwind class `via-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_600 : Css.Style
+via_blue_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #2563eb, var(--tw-gradient-to, rgba(37, 99, 235, 0))"
+
+
+{-| The tailwind class `via-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_700 : Css.Style
+via_blue_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1d4ed8, var(--tw-gradient-to, rgba(29, 78, 216, 0))"
+
+
+{-| The tailwind class `via-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_800 : Css.Style
+via_blue_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e40af, var(--tw-gradient-to, rgba(30, 64, 175, 0))"
+
+
+{-| The tailwind class `via-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_blue_900 : Css.Style
+via_blue_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #1e3a8a, var(--tw-gradient-to, rgba(30, 58, 138, 0))"
+
+
+{-| The tailwind class `via-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_50 : Css.Style
+via_indigo_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #eef2ff, var(--tw-gradient-to, rgba(238, 242, 255, 0))"
+
+
+{-| The tailwind class `via-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_100 : Css.Style
+via_indigo_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e0e7ff, var(--tw-gradient-to, rgba(224, 231, 255, 0))"
+
+
+{-| The tailwind class `via-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_200 : Css.Style
+via_indigo_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c7d2fe, var(--tw-gradient-to, rgba(199, 210, 254, 0))"
+
+
+{-| The tailwind class `via-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_300 : Css.Style
+via_indigo_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a5b4fc, var(--tw-gradient-to, rgba(165, 180, 252, 0))"
+
+
+{-| The tailwind class `via-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_400 : Css.Style
+via_indigo_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #818cf8, var(--tw-gradient-to, rgba(129, 140, 248, 0))"
+
+
+{-| The tailwind class `via-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_500 : Css.Style
+via_indigo_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6366f1, var(--tw-gradient-to, rgba(99, 102, 241, 0))"
+
+
+{-| The tailwind class `via-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_600 : Css.Style
+via_indigo_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4f46e5, var(--tw-gradient-to, rgba(79, 70, 229, 0))"
+
+
+{-| The tailwind class `via-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_700 : Css.Style
+via_indigo_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4338ca, var(--tw-gradient-to, rgba(67, 56, 202, 0))"
+
+
+{-| The tailwind class `via-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_800 : Css.Style
+via_indigo_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #3730a3, var(--tw-gradient-to, rgba(55, 48, 163, 0))"
+
+
+{-| The tailwind class `via-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_indigo_900 : Css.Style
+via_indigo_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #312e81, var(--tw-gradient-to, rgba(49, 46, 129, 0))"
+
+
+{-| The tailwind class `via-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_50 : Css.Style
+via_violet_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5f3ff, var(--tw-gradient-to, rgba(245, 243, 255, 0))"
+
+
+{-| The tailwind class `via-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_100 : Css.Style
+via_violet_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ede9fe, var(--tw-gradient-to, rgba(237, 233, 254, 0))"
+
+
+{-| The tailwind class `via-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_200 : Css.Style
+via_violet_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ddd6fe, var(--tw-gradient-to, rgba(221, 214, 254, 0))"
+
+
+{-| The tailwind class `via-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_300 : Css.Style
+via_violet_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c4b5fd, var(--tw-gradient-to, rgba(196, 181, 253, 0))"
+
+
+{-| The tailwind class `via-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_400 : Css.Style
+via_violet_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a78bfa, var(--tw-gradient-to, rgba(167, 139, 250, 0))"
+
+
+{-| The tailwind class `via-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_500 : Css.Style
+via_violet_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #8b5cf6, var(--tw-gradient-to, rgba(139, 92, 246, 0))"
+
+
+{-| The tailwind class `via-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_600 : Css.Style
+via_violet_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7c3aed, var(--tw-gradient-to, rgba(124, 58, 237, 0))"
+
+
+{-| The tailwind class `via-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_700 : Css.Style
+via_violet_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6d28d9, var(--tw-gradient-to, rgba(109, 40, 217, 0))"
+
+
+{-| The tailwind class `via-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_800 : Css.Style
+via_violet_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #5b21b6, var(--tw-gradient-to, rgba(91, 33, 182, 0))"
+
+
+{-| The tailwind class `via-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_violet_900 : Css.Style
+via_violet_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #4c1d95, var(--tw-gradient-to, rgba(76, 29, 149, 0))"
+
+
+{-| The tailwind class `via-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_50 : Css.Style
+via_purple_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #faf5ff, var(--tw-gradient-to, rgba(250, 245, 255, 0))"
+
+
+{-| The tailwind class `via-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_100 : Css.Style
+via_purple_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f3e8ff, var(--tw-gradient-to, rgba(243, 232, 255, 0))"
+
+
+{-| The tailwind class `via-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_200 : Css.Style
+via_purple_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e9d5ff, var(--tw-gradient-to, rgba(233, 213, 255, 0))"
+
+
+{-| The tailwind class `via-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_300 : Css.Style
+via_purple_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d8b4fe, var(--tw-gradient-to, rgba(216, 180, 254, 0))"
+
+
+{-| The tailwind class `via-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_400 : Css.Style
+via_purple_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c084fc, var(--tw-gradient-to, rgba(192, 132, 252, 0))"
+
+
+{-| The tailwind class `via-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_500 : Css.Style
+via_purple_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a855f7, var(--tw-gradient-to, rgba(168, 85, 247, 0))"
+
+
+{-| The tailwind class `via-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_600 : Css.Style
+via_purple_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9333ea, var(--tw-gradient-to, rgba(147, 51, 234, 0))"
+
+
+{-| The tailwind class `via-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_700 : Css.Style
+via_purple_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #7e22ce, var(--tw-gradient-to, rgba(126, 34, 206, 0))"
+
+
+{-| The tailwind class `via-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_800 : Css.Style
+via_purple_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #6b21a8, var(--tw-gradient-to, rgba(107, 33, 168, 0))"
+
+
+{-| The tailwind class `via-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_purple_900 : Css.Style
+via_purple_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #581c87, var(--tw-gradient-to, rgba(88, 28, 135, 0))"
+
+
+{-| The tailwind class `via-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_50 : Css.Style
+via_fuchsia_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fdf4ff, var(--tw-gradient-to, rgba(253, 244, 255, 0))"
+
+
+{-| The tailwind class `via-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_100 : Css.Style
+via_fuchsia_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fae8ff, var(--tw-gradient-to, rgba(250, 232, 255, 0))"
+
+
+{-| The tailwind class `via-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_200 : Css.Style
+via_fuchsia_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f5d0fe, var(--tw-gradient-to, rgba(245, 208, 254, 0))"
+
+
+{-| The tailwind class `via-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_300 : Css.Style
+via_fuchsia_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f0abfc, var(--tw-gradient-to, rgba(240, 171, 252, 0))"
+
+
+{-| The tailwind class `via-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_400 : Css.Style
+via_fuchsia_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e879f9, var(--tw-gradient-to, rgba(232, 121, 249, 0))"
+
+
+{-| The tailwind class `via-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_500 : Css.Style
+via_fuchsia_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #d946ef, var(--tw-gradient-to, rgba(217, 70, 239, 0))"
+
+
+{-| The tailwind class `via-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_600 : Css.Style
+via_fuchsia_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #c026d3, var(--tw-gradient-to, rgba(192, 38, 211, 0))"
+
+
+{-| The tailwind class `via-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_700 : Css.Style
+via_fuchsia_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #a21caf, var(--tw-gradient-to, rgba(162, 28, 175, 0))"
+
+
+{-| The tailwind class `via-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_800 : Css.Style
+via_fuchsia_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #86198f, var(--tw-gradient-to, rgba(134, 25, 143, 0))"
+
+
+{-| The tailwind class `via-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_fuchsia_900 : Css.Style
+via_fuchsia_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #701a75, var(--tw-gradient-to, rgba(112, 26, 117, 0))"
+
+
+{-| The tailwind class `via-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_50 : Css.Style
+via_pink_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fdf2f8, var(--tw-gradient-to, rgba(253, 242, 248, 0))"
+
+
+{-| The tailwind class `via-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_100 : Css.Style
+via_pink_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fce7f3, var(--tw-gradient-to, rgba(252, 231, 243, 0))"
+
+
+{-| The tailwind class `via-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_200 : Css.Style
+via_pink_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fbcfe8, var(--tw-gradient-to, rgba(251, 207, 232, 0))"
+
+
+{-| The tailwind class `via-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_300 : Css.Style
+via_pink_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f9a8d4, var(--tw-gradient-to, rgba(249, 168, 212, 0))"
+
+
+{-| The tailwind class `via-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_400 : Css.Style
+via_pink_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f472b6, var(--tw-gradient-to, rgba(244, 114, 182, 0))"
+
+
+{-| The tailwind class `via-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_500 : Css.Style
+via_pink_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ec4899, var(--tw-gradient-to, rgba(236, 72, 153, 0))"
+
+
+{-| The tailwind class `via-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_600 : Css.Style
+via_pink_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #db2777, var(--tw-gradient-to, rgba(219, 39, 119, 0))"
+
+
+{-| The tailwind class `via-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_700 : Css.Style
+via_pink_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #be185d, var(--tw-gradient-to, rgba(190, 24, 93, 0))"
+
+
+{-| The tailwind class `via-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_800 : Css.Style
+via_pink_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9d174d, var(--tw-gradient-to, rgba(157, 23, 77, 0))"
+
+
+{-| The tailwind class `via-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_pink_900 : Css.Style
+via_pink_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #831843, var(--tw-gradient-to, rgba(131, 24, 67, 0))"
+
+
+{-| The tailwind class `via-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_50 : Css.Style
+via_rose_50 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fff1f2, var(--tw-gradient-to, rgba(255, 241, 242, 0))"
+
+
+{-| The tailwind class `via-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_100 : Css.Style
+via_rose_100 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #ffe4e6, var(--tw-gradient-to, rgba(255, 228, 230, 0))"
+
+
+{-| The tailwind class `via-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_200 : Css.Style
+via_rose_200 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fecdd3, var(--tw-gradient-to, rgba(254, 205, 211, 0))"
+
+
+{-| The tailwind class `via-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_300 : Css.Style
+via_rose_300 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fda4af, var(--tw-gradient-to, rgba(253, 164, 175, 0))"
+
+
+{-| The tailwind class `via-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_400 : Css.Style
+via_rose_400 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #fb7185, var(--tw-gradient-to, rgba(251, 113, 133, 0))"
+
+
+{-| The tailwind class `via-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_500 : Css.Style
+via_rose_500 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #f43f5e, var(--tw-gradient-to, rgba(244, 63, 94, 0))"
+
+
+{-| The tailwind class `via-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_600 : Css.Style
+via_rose_600 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #e11d48, var(--tw-gradient-to, rgba(225, 29, 72, 0))"
+
+
+{-| The tailwind class `via-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_700 : Css.Style
+via_rose_700 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #be123c, var(--tw-gradient-to, rgba(190, 18, 60, 0))"
+
+
+{-| The tailwind class `via-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_800 : Css.Style
+via_rose_800 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #9f1239, var(--tw-gradient-to, rgba(159, 18, 57, 0))"
+
+
+{-| The tailwind class `via-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+via_rose_900 : Css.Style
+via_rose_900 =
+    Css.property "--tw-gradient-stops" "var(--tw-gradient-from), #881337, var(--tw-gradient-to, rgba(136, 19, 55, 0))"
 
 
 {-| The tailwind class `visible`.

--- a/src/Tailwind/Utilities.elm
+++ b/src/Tailwind/Utilities.elm
@@ -2406,47 +2406,7 @@ module Tailwind.Utilities exposing
     , place_self_start
     , place_self_stretch
     , placeholder_black
-    , placeholder_blue_100
-    , placeholder_blue_200
-    , placeholder_blue_300
-    , placeholder_blue_400
-    , placeholder_blue_50
-    , placeholder_blue_500
-    , placeholder_blue_600
-    , placeholder_blue_700
-    , placeholder_blue_800
-    , placeholder_blue_900
     , placeholder_current
-    , placeholder_gray_100
-    , placeholder_gray_200
-    , placeholder_gray_300
-    , placeholder_gray_400
-    , placeholder_gray_50
-    , placeholder_gray_500
-    , placeholder_gray_600
-    , placeholder_gray_700
-    , placeholder_gray_800
-    , placeholder_gray_900
-    , placeholder_green_100
-    , placeholder_green_200
-    , placeholder_green_300
-    , placeholder_green_400
-    , placeholder_green_50
-    , placeholder_green_500
-    , placeholder_green_600
-    , placeholder_green_700
-    , placeholder_green_800
-    , placeholder_green_900
-    , placeholder_indigo_100
-    , placeholder_indigo_200
-    , placeholder_indigo_300
-    , placeholder_indigo_400
-    , placeholder_indigo_50
-    , placeholder_indigo_500
-    , placeholder_indigo_600
-    , placeholder_indigo_700
-    , placeholder_indigo_800
-    , placeholder_indigo_900
     , placeholder_opacity_0
     , placeholder_opacity_10
     , placeholder_opacity_100
@@ -2462,48 +2422,228 @@ module Tailwind.Utilities exposing
     , placeholder_opacity_80
     , placeholder_opacity_90
     , placeholder_opacity_95
-    , placeholder_pink_100
-    , placeholder_pink_200
-    , placeholder_pink_300
-    , placeholder_pink_400
-    , placeholder_pink_50
-    , placeholder_pink_500
-    , placeholder_pink_600
-    , placeholder_pink_700
-    , placeholder_pink_800
-    , placeholder_pink_900
-    , placeholder_purple_100
-    , placeholder_purple_200
-    , placeholder_purple_300
-    , placeholder_purple_400
-    , placeholder_purple_50
-    , placeholder_purple_500
-    , placeholder_purple_600
-    , placeholder_purple_700
-    , placeholder_purple_800
-    , placeholder_purple_900
+    , placeholder_transparent
+    , placeholder_white
+    , placeholder_slate_50
+    , placeholder_slate_100
+    , placeholder_slate_200
+    , placeholder_slate_300
+    , placeholder_slate_400
+    , placeholder_slate_500
+    , placeholder_slate_600
+    , placeholder_slate_700
+    , placeholder_slate_800
+    , placeholder_slate_900
+    , placeholder_gray_50
+    , placeholder_gray_100
+    , placeholder_gray_200
+    , placeholder_gray_300
+    , placeholder_gray_400
+    , placeholder_gray_500
+    , placeholder_gray_600
+    , placeholder_gray_700
+    , placeholder_gray_800
+    , placeholder_gray_900
+    , placeholder_zinc_50
+    , placeholder_zinc_100
+    , placeholder_zinc_200
+    , placeholder_zinc_300
+    , placeholder_zinc_400
+    , placeholder_zinc_500
+    , placeholder_zinc_600
+    , placeholder_zinc_700
+    , placeholder_zinc_800
+    , placeholder_zinc_900
+    , placeholder_neutral_50
+    , placeholder_neutral_100
+    , placeholder_neutral_200
+    , placeholder_neutral_300
+    , placeholder_neutral_400
+    , placeholder_neutral_500
+    , placeholder_neutral_600
+    , placeholder_neutral_700
+    , placeholder_neutral_800
+    , placeholder_neutral_900
+    , placeholder_stone_50
+    , placeholder_stone_100
+    , placeholder_stone_200
+    , placeholder_stone_300
+    , placeholder_stone_400
+    , placeholder_stone_500
+    , placeholder_stone_600
+    , placeholder_stone_700
+    , placeholder_stone_800
+    , placeholder_stone_900
+    , placeholder_red_50
     , placeholder_red_100
     , placeholder_red_200
     , placeholder_red_300
     , placeholder_red_400
-    , placeholder_red_50
     , placeholder_red_500
     , placeholder_red_600
     , placeholder_red_700
     , placeholder_red_800
     , placeholder_red_900
-    , placeholder_transparent
-    , placeholder_white
+    , placeholder_orange_50
+    , placeholder_orange_100
+    , placeholder_orange_200
+    , placeholder_orange_300
+    , placeholder_orange_400
+    , placeholder_orange_500
+    , placeholder_orange_600
+    , placeholder_orange_700
+    , placeholder_orange_800
+    , placeholder_orange_900
+    , placeholder_amber_50
+    , placeholder_amber_100
+    , placeholder_amber_200
+    , placeholder_amber_300
+    , placeholder_amber_400
+    , placeholder_amber_500
+    , placeholder_amber_600
+    , placeholder_amber_700
+    , placeholder_amber_800
+    , placeholder_amber_900
+    , placeholder_yellow_50
     , placeholder_yellow_100
     , placeholder_yellow_200
     , placeholder_yellow_300
     , placeholder_yellow_400
-    , placeholder_yellow_50
     , placeholder_yellow_500
     , placeholder_yellow_600
     , placeholder_yellow_700
     , placeholder_yellow_800
     , placeholder_yellow_900
+    , placeholder_lime_50
+    , placeholder_lime_100
+    , placeholder_lime_200
+    , placeholder_lime_300
+    , placeholder_lime_400
+    , placeholder_lime_500
+    , placeholder_lime_600
+    , placeholder_lime_700
+    , placeholder_lime_800
+    , placeholder_lime_900
+    , placeholder_green_50
+    , placeholder_green_100
+    , placeholder_green_200
+    , placeholder_green_300
+    , placeholder_green_400
+    , placeholder_green_500
+    , placeholder_green_600
+    , placeholder_green_700
+    , placeholder_green_800
+    , placeholder_green_900
+    , placeholder_emerald_50
+    , placeholder_emerald_100
+    , placeholder_emerald_200
+    , placeholder_emerald_300
+    , placeholder_emerald_400
+    , placeholder_emerald_500
+    , placeholder_emerald_600
+    , placeholder_emerald_700
+    , placeholder_emerald_800
+    , placeholder_emerald_900
+    , placeholder_teal_50
+    , placeholder_teal_100
+    , placeholder_teal_200
+    , placeholder_teal_300
+    , placeholder_teal_400
+    , placeholder_teal_500
+    , placeholder_teal_600
+    , placeholder_teal_700
+    , placeholder_teal_800
+    , placeholder_teal_900
+    , placeholder_cyan_50
+    , placeholder_cyan_100
+    , placeholder_cyan_200
+    , placeholder_cyan_300
+    , placeholder_cyan_400
+    , placeholder_cyan_500
+    , placeholder_cyan_600
+    , placeholder_cyan_700
+    , placeholder_cyan_800
+    , placeholder_cyan_900
+    , placeholder_sky_50
+    , placeholder_sky_100
+    , placeholder_sky_200
+    , placeholder_sky_300
+    , placeholder_sky_400
+    , placeholder_sky_500
+    , placeholder_sky_600
+    , placeholder_sky_700
+    , placeholder_sky_800
+    , placeholder_sky_900
+    , placeholder_blue_50
+    , placeholder_blue_100
+    , placeholder_blue_200
+    , placeholder_blue_300
+    , placeholder_blue_400
+    , placeholder_blue_500
+    , placeholder_blue_600
+    , placeholder_blue_700
+    , placeholder_blue_800
+    , placeholder_blue_900
+    , placeholder_indigo_50
+    , placeholder_indigo_100
+    , placeholder_indigo_200
+    , placeholder_indigo_300
+    , placeholder_indigo_400
+    , placeholder_indigo_500
+    , placeholder_indigo_600
+    , placeholder_indigo_700
+    , placeholder_indigo_800
+    , placeholder_indigo_900
+    , placeholder_violet_50
+    , placeholder_violet_100
+    , placeholder_violet_200
+    , placeholder_violet_300
+    , placeholder_violet_400
+    , placeholder_violet_500
+    , placeholder_violet_600
+    , placeholder_violet_700
+    , placeholder_violet_800
+    , placeholder_violet_900
+    , placeholder_purple_50
+    , placeholder_purple_100
+    , placeholder_purple_200
+    , placeholder_purple_300
+    , placeholder_purple_400
+    , placeholder_purple_500
+    , placeholder_purple_600
+    , placeholder_purple_700
+    , placeholder_purple_800
+    , placeholder_purple_900
+    , placeholder_fuchsia_50
+    , placeholder_fuchsia_100
+    , placeholder_fuchsia_200
+    , placeholder_fuchsia_300
+    , placeholder_fuchsia_400
+    , placeholder_fuchsia_500
+    , placeholder_fuchsia_600
+    , placeholder_fuchsia_700
+    , placeholder_fuchsia_800
+    , placeholder_fuchsia_900
+    , placeholder_pink_50
+    , placeholder_pink_100
+    , placeholder_pink_200
+    , placeholder_pink_300
+    , placeholder_pink_400
+    , placeholder_pink_500
+    , placeholder_pink_600
+    , placeholder_pink_700
+    , placeholder_pink_800
+    , placeholder_pink_900
+    , placeholder_rose_50
+    , placeholder_rose_100
+    , placeholder_rose_200
+    , placeholder_rose_300
+    , placeholder_rose_400
+    , placeholder_rose_500
+    , placeholder_rose_600
+    , placeholder_rose_700
+    , placeholder_rose_800
+    , placeholder_rose_900
     , pointer_events_auto
     , pointer_events_none
     , pr_0
@@ -2714,47 +2854,7 @@ module Tailwind.Utilities exposing
     , ring_4
     , ring_8
     , ring_black
-    , ring_blue_100
-    , ring_blue_200
-    , ring_blue_300
-    , ring_blue_400
-    , ring_blue_50
-    , ring_blue_500
-    , ring_blue_600
-    , ring_blue_700
-    , ring_blue_800
-    , ring_blue_900
     , ring_current
-    , ring_gray_100
-    , ring_gray_200
-    , ring_gray_300
-    , ring_gray_400
-    , ring_gray_50
-    , ring_gray_500
-    , ring_gray_600
-    , ring_gray_700
-    , ring_gray_800
-    , ring_gray_900
-    , ring_green_100
-    , ring_green_200
-    , ring_green_300
-    , ring_green_400
-    , ring_green_50
-    , ring_green_500
-    , ring_green_600
-    , ring_green_700
-    , ring_green_800
-    , ring_green_900
-    , ring_indigo_100
-    , ring_indigo_200
-    , ring_indigo_300
-    , ring_indigo_400
-    , ring_indigo_50
-    , ring_indigo_500
-    , ring_indigo_600
-    , ring_indigo_700
-    , ring_indigo_800
-    , ring_indigo_900
     , ring_inset
     , ring_offset_0
     , ring_offset_1
@@ -2762,89 +2862,9 @@ module Tailwind.Utilities exposing
     , ring_offset_4
     , ring_offset_8
     , ring_offset_black
-    , ring_offset_blue_100
-    , ring_offset_blue_200
-    , ring_offset_blue_300
-    , ring_offset_blue_400
-    , ring_offset_blue_50
-    , ring_offset_blue_500
-    , ring_offset_blue_600
-    , ring_offset_blue_700
-    , ring_offset_blue_800
-    , ring_offset_blue_900
     , ring_offset_current
-    , ring_offset_gray_100
-    , ring_offset_gray_200
-    , ring_offset_gray_300
-    , ring_offset_gray_400
-    , ring_offset_gray_50
-    , ring_offset_gray_500
-    , ring_offset_gray_600
-    , ring_offset_gray_700
-    , ring_offset_gray_800
-    , ring_offset_gray_900
-    , ring_offset_green_100
-    , ring_offset_green_200
-    , ring_offset_green_300
-    , ring_offset_green_400
-    , ring_offset_green_50
-    , ring_offset_green_500
-    , ring_offset_green_600
-    , ring_offset_green_700
-    , ring_offset_green_800
-    , ring_offset_green_900
-    , ring_offset_indigo_100
-    , ring_offset_indigo_200
-    , ring_offset_indigo_300
-    , ring_offset_indigo_400
-    , ring_offset_indigo_50
-    , ring_offset_indigo_500
-    , ring_offset_indigo_600
-    , ring_offset_indigo_700
-    , ring_offset_indigo_800
-    , ring_offset_indigo_900
-    , ring_offset_pink_100
-    , ring_offset_pink_200
-    , ring_offset_pink_300
-    , ring_offset_pink_400
-    , ring_offset_pink_50
-    , ring_offset_pink_500
-    , ring_offset_pink_600
-    , ring_offset_pink_700
-    , ring_offset_pink_800
-    , ring_offset_pink_900
-    , ring_offset_purple_100
-    , ring_offset_purple_200
-    , ring_offset_purple_300
-    , ring_offset_purple_400
-    , ring_offset_purple_50
-    , ring_offset_purple_500
-    , ring_offset_purple_600
-    , ring_offset_purple_700
-    , ring_offset_purple_800
-    , ring_offset_purple_900
-    , ring_offset_red_100
-    , ring_offset_red_200
-    , ring_offset_red_300
-    , ring_offset_red_400
-    , ring_offset_red_50
-    , ring_offset_red_500
-    , ring_offset_red_600
-    , ring_offset_red_700
-    , ring_offset_red_800
-    , ring_offset_red_900
     , ring_offset_transparent
     , ring_offset_white
-    , ring_offset_yellow_100
-    , ring_offset_yellow_200
-    , ring_offset_yellow_300
-    , ring_offset_yellow_400
-    , ring_offset_yellow_50
-    , ring_offset_yellow_500
-    , ring_offset_yellow_600
-    , ring_offset_yellow_700
-    , ring_offset_yellow_800
-    , ring_offset_yellow_900
     , ring_opacity_0
     , ring_opacity_10
     , ring_opacity_100
@@ -2860,48 +2880,448 @@ module Tailwind.Utilities exposing
     , ring_opacity_80
     , ring_opacity_90
     , ring_opacity_95
-    , ring_pink_100
-    , ring_pink_200
-    , ring_pink_300
-    , ring_pink_400
-    , ring_pink_50
-    , ring_pink_500
-    , ring_pink_600
-    , ring_pink_700
-    , ring_pink_800
-    , ring_pink_900
-    , ring_purple_100
-    , ring_purple_200
-    , ring_purple_300
-    , ring_purple_400
-    , ring_purple_50
-    , ring_purple_500
-    , ring_purple_600
-    , ring_purple_700
-    , ring_purple_800
-    , ring_purple_900
+    , ring_transparent
+    , ring_white
+    , ring_slate_50
+    , ring_slate_100
+    , ring_slate_200
+    , ring_slate_300
+    , ring_slate_400
+    , ring_slate_500
+    , ring_slate_600
+    , ring_slate_700
+    , ring_slate_800
+    , ring_slate_900
+    , ring_gray_50
+    , ring_gray_100
+    , ring_gray_200
+    , ring_gray_300
+    , ring_gray_400
+    , ring_gray_500
+    , ring_gray_600
+    , ring_gray_700
+    , ring_gray_800
+    , ring_gray_900
+    , ring_zinc_50
+    , ring_zinc_100
+    , ring_zinc_200
+    , ring_zinc_300
+    , ring_zinc_400
+    , ring_zinc_500
+    , ring_zinc_600
+    , ring_zinc_700
+    , ring_zinc_800
+    , ring_zinc_900
+    , ring_neutral_50
+    , ring_neutral_100
+    , ring_neutral_200
+    , ring_neutral_300
+    , ring_neutral_400
+    , ring_neutral_500
+    , ring_neutral_600
+    , ring_neutral_700
+    , ring_neutral_800
+    , ring_neutral_900
+    , ring_stone_50
+    , ring_stone_100
+    , ring_stone_200
+    , ring_stone_300
+    , ring_stone_400
+    , ring_stone_500
+    , ring_stone_600
+    , ring_stone_700
+    , ring_stone_800
+    , ring_stone_900
+    , ring_red_50
     , ring_red_100
     , ring_red_200
     , ring_red_300
     , ring_red_400
-    , ring_red_50
     , ring_red_500
     , ring_red_600
     , ring_red_700
     , ring_red_800
     , ring_red_900
-    , ring_transparent
-    , ring_white
+    , ring_orange_50
+    , ring_orange_100
+    , ring_orange_200
+    , ring_orange_300
+    , ring_orange_400
+    , ring_orange_500
+    , ring_orange_600
+    , ring_orange_700
+    , ring_orange_800
+    , ring_orange_900
+    , ring_amber_50
+    , ring_amber_100
+    , ring_amber_200
+    , ring_amber_300
+    , ring_amber_400
+    , ring_amber_500
+    , ring_amber_600
+    , ring_amber_700
+    , ring_amber_800
+    , ring_amber_900
+    , ring_yellow_50
     , ring_yellow_100
     , ring_yellow_200
     , ring_yellow_300
     , ring_yellow_400
-    , ring_yellow_50
     , ring_yellow_500
     , ring_yellow_600
     , ring_yellow_700
     , ring_yellow_800
     , ring_yellow_900
+    , ring_lime_50
+    , ring_lime_100
+    , ring_lime_200
+    , ring_lime_300
+    , ring_lime_400
+    , ring_lime_500
+    , ring_lime_600
+    , ring_lime_700
+    , ring_lime_800
+    , ring_lime_900
+    , ring_green_50
+    , ring_green_100
+    , ring_green_200
+    , ring_green_300
+    , ring_green_400
+    , ring_green_500
+    , ring_green_600
+    , ring_green_700
+    , ring_green_800
+    , ring_green_900
+    , ring_emerald_50
+    , ring_emerald_100
+    , ring_emerald_200
+    , ring_emerald_300
+    , ring_emerald_400
+    , ring_emerald_500
+    , ring_emerald_600
+    , ring_emerald_700
+    , ring_emerald_800
+    , ring_emerald_900
+    , ring_teal_50
+    , ring_teal_100
+    , ring_teal_200
+    , ring_teal_300
+    , ring_teal_400
+    , ring_teal_500
+    , ring_teal_600
+    , ring_teal_700
+    , ring_teal_800
+    , ring_teal_900
+    , ring_cyan_50
+    , ring_cyan_100
+    , ring_cyan_200
+    , ring_cyan_300
+    , ring_cyan_400
+    , ring_cyan_500
+    , ring_cyan_600
+    , ring_cyan_700
+    , ring_cyan_800
+    , ring_cyan_900
+    , ring_sky_50
+    , ring_sky_100
+    , ring_sky_200
+    , ring_sky_300
+    , ring_sky_400
+    , ring_sky_500
+    , ring_sky_600
+    , ring_sky_700
+    , ring_sky_800
+    , ring_sky_900
+    , ring_blue_50
+    , ring_blue_100
+    , ring_blue_200
+    , ring_blue_300
+    , ring_blue_400
+    , ring_blue_500
+    , ring_blue_600
+    , ring_blue_700
+    , ring_blue_800
+    , ring_blue_900
+    , ring_indigo_50
+    , ring_indigo_100
+    , ring_indigo_200
+    , ring_indigo_300
+    , ring_indigo_400
+    , ring_indigo_500
+    , ring_indigo_600
+    , ring_indigo_700
+    , ring_indigo_800
+    , ring_indigo_900
+    , ring_violet_50
+    , ring_violet_100
+    , ring_violet_200
+    , ring_violet_300
+    , ring_violet_400
+    , ring_violet_500
+    , ring_violet_600
+    , ring_violet_700
+    , ring_violet_800
+    , ring_violet_900
+    , ring_purple_50
+    , ring_purple_100
+    , ring_purple_200
+    , ring_purple_300
+    , ring_purple_400
+    , ring_purple_500
+    , ring_purple_600
+    , ring_purple_700
+    , ring_purple_800
+    , ring_purple_900
+    , ring_fuchsia_50
+    , ring_fuchsia_100
+    , ring_fuchsia_200
+    , ring_fuchsia_300
+    , ring_fuchsia_400
+    , ring_fuchsia_500
+    , ring_fuchsia_600
+    , ring_fuchsia_700
+    , ring_fuchsia_800
+    , ring_fuchsia_900
+    , ring_pink_50
+    , ring_pink_100
+    , ring_pink_200
+    , ring_pink_300
+    , ring_pink_400
+    , ring_pink_500
+    , ring_pink_600
+    , ring_pink_700
+    , ring_pink_800
+    , ring_pink_900
+    , ring_rose_50
+    , ring_rose_100
+    , ring_rose_200
+    , ring_rose_300
+    , ring_rose_400
+    , ring_rose_500
+    , ring_rose_600
+    , ring_rose_700
+    , ring_rose_800
+    , ring_rose_900
+    , ring_offset_slate_50
+    , ring_offset_slate_100
+    , ring_offset_slate_200
+    , ring_offset_slate_300
+    , ring_offset_slate_400
+    , ring_offset_slate_500
+    , ring_offset_slate_600
+    , ring_offset_slate_700
+    , ring_offset_slate_800
+    , ring_offset_slate_900
+    , ring_offset_gray_50
+    , ring_offset_gray_100
+    , ring_offset_gray_200
+    , ring_offset_gray_300
+    , ring_offset_gray_400
+    , ring_offset_gray_500
+    , ring_offset_gray_600
+    , ring_offset_gray_700
+    , ring_offset_gray_800
+    , ring_offset_gray_900
+    , ring_offset_zinc_50
+    , ring_offset_zinc_100
+    , ring_offset_zinc_200
+    , ring_offset_zinc_300
+    , ring_offset_zinc_400
+    , ring_offset_zinc_500
+    , ring_offset_zinc_600
+    , ring_offset_zinc_700
+    , ring_offset_zinc_800
+    , ring_offset_zinc_900
+    , ring_offset_neutral_50
+    , ring_offset_neutral_100
+    , ring_offset_neutral_200
+    , ring_offset_neutral_300
+    , ring_offset_neutral_400
+    , ring_offset_neutral_500
+    , ring_offset_neutral_600
+    , ring_offset_neutral_700
+    , ring_offset_neutral_800
+    , ring_offset_neutral_900
+    , ring_offset_stone_50
+    , ring_offset_stone_100
+    , ring_offset_stone_200
+    , ring_offset_stone_300
+    , ring_offset_stone_400
+    , ring_offset_stone_500
+    , ring_offset_stone_600
+    , ring_offset_stone_700
+    , ring_offset_stone_800
+    , ring_offset_stone_900
+    , ring_offset_red_50
+    , ring_offset_red_100
+    , ring_offset_red_200
+    , ring_offset_red_300
+    , ring_offset_red_400
+    , ring_offset_red_500
+    , ring_offset_red_600
+    , ring_offset_red_700
+    , ring_offset_red_800
+    , ring_offset_red_900
+    , ring_offset_orange_50
+    , ring_offset_orange_100
+    , ring_offset_orange_200
+    , ring_offset_orange_300
+    , ring_offset_orange_400
+    , ring_offset_orange_500
+    , ring_offset_orange_600
+    , ring_offset_orange_700
+    , ring_offset_orange_800
+    , ring_offset_orange_900
+    , ring_offset_amber_50
+    , ring_offset_amber_100
+    , ring_offset_amber_200
+    , ring_offset_amber_300
+    , ring_offset_amber_400
+    , ring_offset_amber_500
+    , ring_offset_amber_600
+    , ring_offset_amber_700
+    , ring_offset_amber_800
+    , ring_offset_amber_900
+    , ring_offset_yellow_50
+    , ring_offset_yellow_100
+    , ring_offset_yellow_200
+    , ring_offset_yellow_300
+    , ring_offset_yellow_400
+    , ring_offset_yellow_500
+    , ring_offset_yellow_600
+    , ring_offset_yellow_700
+    , ring_offset_yellow_800
+    , ring_offset_yellow_900
+    , ring_offset_lime_50
+    , ring_offset_lime_100
+    , ring_offset_lime_200
+    , ring_offset_lime_300
+    , ring_offset_lime_400
+    , ring_offset_lime_500
+    , ring_offset_lime_600
+    , ring_offset_lime_700
+    , ring_offset_lime_800
+    , ring_offset_lime_900
+    , ring_offset_green_50
+    , ring_offset_green_100
+    , ring_offset_green_200
+    , ring_offset_green_300
+    , ring_offset_green_400
+    , ring_offset_green_500
+    , ring_offset_green_600
+    , ring_offset_green_700
+    , ring_offset_green_800
+    , ring_offset_green_900
+    , ring_offset_emerald_50
+    , ring_offset_emerald_100
+    , ring_offset_emerald_200
+    , ring_offset_emerald_300
+    , ring_offset_emerald_400
+    , ring_offset_emerald_500
+    , ring_offset_emerald_600
+    , ring_offset_emerald_700
+    , ring_offset_emerald_800
+    , ring_offset_emerald_900
+    , ring_offset_teal_50
+    , ring_offset_teal_100
+    , ring_offset_teal_200
+    , ring_offset_teal_300
+    , ring_offset_teal_400
+    , ring_offset_teal_500
+    , ring_offset_teal_600
+    , ring_offset_teal_700
+    , ring_offset_teal_800
+    , ring_offset_teal_900
+    , ring_offset_cyan_50
+    , ring_offset_cyan_100
+    , ring_offset_cyan_200
+    , ring_offset_cyan_300
+    , ring_offset_cyan_400
+    , ring_offset_cyan_500
+    , ring_offset_cyan_600
+    , ring_offset_cyan_700
+    , ring_offset_cyan_800
+    , ring_offset_cyan_900
+    , ring_offset_sky_50
+    , ring_offset_sky_100
+    , ring_offset_sky_200
+    , ring_offset_sky_300
+    , ring_offset_sky_400
+    , ring_offset_sky_500
+    , ring_offset_sky_600
+    , ring_offset_sky_700
+    , ring_offset_sky_800
+    , ring_offset_sky_900
+    , ring_offset_blue_50
+    , ring_offset_blue_100
+    , ring_offset_blue_200
+    , ring_offset_blue_300
+    , ring_offset_blue_400
+    , ring_offset_blue_500
+    , ring_offset_blue_600
+    , ring_offset_blue_700
+    , ring_offset_blue_800
+    , ring_offset_blue_900
+    , ring_offset_indigo_50
+    , ring_offset_indigo_100
+    , ring_offset_indigo_200
+    , ring_offset_indigo_300
+    , ring_offset_indigo_400
+    , ring_offset_indigo_500
+    , ring_offset_indigo_600
+    , ring_offset_indigo_700
+    , ring_offset_indigo_800
+    , ring_offset_indigo_900
+    , ring_offset_violet_50
+    , ring_offset_violet_100
+    , ring_offset_violet_200
+    , ring_offset_violet_300
+    , ring_offset_violet_400
+    , ring_offset_violet_500
+    , ring_offset_violet_600
+    , ring_offset_violet_700
+    , ring_offset_violet_800
+    , ring_offset_violet_900
+    , ring_offset_purple_50
+    , ring_offset_purple_100
+    , ring_offset_purple_200
+    , ring_offset_purple_300
+    , ring_offset_purple_400
+    , ring_offset_purple_500
+    , ring_offset_purple_600
+    , ring_offset_purple_700
+    , ring_offset_purple_800
+    , ring_offset_purple_900
+    , ring_offset_fuchsia_50
+    , ring_offset_fuchsia_100
+    , ring_offset_fuchsia_200
+    , ring_offset_fuchsia_300
+    , ring_offset_fuchsia_400
+    , ring_offset_fuchsia_500
+    , ring_offset_fuchsia_600
+    , ring_offset_fuchsia_700
+    , ring_offset_fuchsia_800
+    , ring_offset_fuchsia_900
+    , ring_offset_pink_50
+    , ring_offset_pink_100
+    , ring_offset_pink_200
+    , ring_offset_pink_300
+    , ring_offset_pink_400
+    , ring_offset_pink_500
+    , ring_offset_pink_600
+    , ring_offset_pink_700
+    , ring_offset_pink_800
+    , ring_offset_pink_900
+    , ring_offset_rose_50
+    , ring_offset_rose_100
+    , ring_offset_rose_200
+    , ring_offset_rose_300
+    , ring_offset_rose_400
+    , ring_offset_rose_500
+    , ring_offset_rose_600
+    , ring_offset_rose_700
+    , ring_offset_rose_800
+    , ring_offset_rose_900
     , rotate_0
     , rotate_1
     , rotate_12
@@ -7167,47 +7587,7 @@ This module contains
 @docs place_self_start
 @docs place_self_stretch
 @docs placeholder_black
-@docs placeholder_blue_100
-@docs placeholder_blue_200
-@docs placeholder_blue_300
-@docs placeholder_blue_400
-@docs placeholder_blue_50
-@docs placeholder_blue_500
-@docs placeholder_blue_600
-@docs placeholder_blue_700
-@docs placeholder_blue_800
-@docs placeholder_blue_900
 @docs placeholder_current
-@docs placeholder_gray_100
-@docs placeholder_gray_200
-@docs placeholder_gray_300
-@docs placeholder_gray_400
-@docs placeholder_gray_50
-@docs placeholder_gray_500
-@docs placeholder_gray_600
-@docs placeholder_gray_700
-@docs placeholder_gray_800
-@docs placeholder_gray_900
-@docs placeholder_green_100
-@docs placeholder_green_200
-@docs placeholder_green_300
-@docs placeholder_green_400
-@docs placeholder_green_50
-@docs placeholder_green_500
-@docs placeholder_green_600
-@docs placeholder_green_700
-@docs placeholder_green_800
-@docs placeholder_green_900
-@docs placeholder_indigo_100
-@docs placeholder_indigo_200
-@docs placeholder_indigo_300
-@docs placeholder_indigo_400
-@docs placeholder_indigo_50
-@docs placeholder_indigo_500
-@docs placeholder_indigo_600
-@docs placeholder_indigo_700
-@docs placeholder_indigo_800
-@docs placeholder_indigo_900
 @docs placeholder_opacity_0
 @docs placeholder_opacity_10
 @docs placeholder_opacity_100
@@ -7223,48 +7603,228 @@ This module contains
 @docs placeholder_opacity_80
 @docs placeholder_opacity_90
 @docs placeholder_opacity_95
-@docs placeholder_pink_100
-@docs placeholder_pink_200
-@docs placeholder_pink_300
-@docs placeholder_pink_400
-@docs placeholder_pink_50
-@docs placeholder_pink_500
-@docs placeholder_pink_600
-@docs placeholder_pink_700
-@docs placeholder_pink_800
-@docs placeholder_pink_900
-@docs placeholder_purple_100
-@docs placeholder_purple_200
-@docs placeholder_purple_300
-@docs placeholder_purple_400
-@docs placeholder_purple_50
-@docs placeholder_purple_500
-@docs placeholder_purple_600
-@docs placeholder_purple_700
-@docs placeholder_purple_800
-@docs placeholder_purple_900
+@docs placeholder_transparent
+@docs placeholder_white
+@docs placeholder_slate_50
+@docs placeholder_slate_100
+@docs placeholder_slate_200
+@docs placeholder_slate_300
+@docs placeholder_slate_400
+@docs placeholder_slate_500
+@docs placeholder_slate_600
+@docs placeholder_slate_700
+@docs placeholder_slate_800
+@docs placeholder_slate_900
+@docs placeholder_gray_50
+@docs placeholder_gray_100
+@docs placeholder_gray_200
+@docs placeholder_gray_300
+@docs placeholder_gray_400
+@docs placeholder_gray_500
+@docs placeholder_gray_600
+@docs placeholder_gray_700
+@docs placeholder_gray_800
+@docs placeholder_gray_900
+@docs placeholder_zinc_50
+@docs placeholder_zinc_100
+@docs placeholder_zinc_200
+@docs placeholder_zinc_300
+@docs placeholder_zinc_400
+@docs placeholder_zinc_500
+@docs placeholder_zinc_600
+@docs placeholder_zinc_700
+@docs placeholder_zinc_800
+@docs placeholder_zinc_900
+@docs placeholder_neutral_50
+@docs placeholder_neutral_100
+@docs placeholder_neutral_200
+@docs placeholder_neutral_300
+@docs placeholder_neutral_400
+@docs placeholder_neutral_500
+@docs placeholder_neutral_600
+@docs placeholder_neutral_700
+@docs placeholder_neutral_800
+@docs placeholder_neutral_900
+@docs placeholder_stone_50
+@docs placeholder_stone_100
+@docs placeholder_stone_200
+@docs placeholder_stone_300
+@docs placeholder_stone_400
+@docs placeholder_stone_500
+@docs placeholder_stone_600
+@docs placeholder_stone_700
+@docs placeholder_stone_800
+@docs placeholder_stone_900
+@docs placeholder_red_50
 @docs placeholder_red_100
 @docs placeholder_red_200
 @docs placeholder_red_300
 @docs placeholder_red_400
-@docs placeholder_red_50
 @docs placeholder_red_500
 @docs placeholder_red_600
 @docs placeholder_red_700
 @docs placeholder_red_800
 @docs placeholder_red_900
-@docs placeholder_transparent
-@docs placeholder_white
+@docs placeholder_orange_50
+@docs placeholder_orange_100
+@docs placeholder_orange_200
+@docs placeholder_orange_300
+@docs placeholder_orange_400
+@docs placeholder_orange_500
+@docs placeholder_orange_600
+@docs placeholder_orange_700
+@docs placeholder_orange_800
+@docs placeholder_orange_900
+@docs placeholder_amber_50
+@docs placeholder_amber_100
+@docs placeholder_amber_200
+@docs placeholder_amber_300
+@docs placeholder_amber_400
+@docs placeholder_amber_500
+@docs placeholder_amber_600
+@docs placeholder_amber_700
+@docs placeholder_amber_800
+@docs placeholder_amber_900
+@docs placeholder_yellow_50
 @docs placeholder_yellow_100
 @docs placeholder_yellow_200
 @docs placeholder_yellow_300
 @docs placeholder_yellow_400
-@docs placeholder_yellow_50
 @docs placeholder_yellow_500
 @docs placeholder_yellow_600
 @docs placeholder_yellow_700
 @docs placeholder_yellow_800
 @docs placeholder_yellow_900
+@docs placeholder_lime_50
+@docs placeholder_lime_100
+@docs placeholder_lime_200
+@docs placeholder_lime_300
+@docs placeholder_lime_400
+@docs placeholder_lime_500
+@docs placeholder_lime_600
+@docs placeholder_lime_700
+@docs placeholder_lime_800
+@docs placeholder_lime_900
+@docs placeholder_green_50
+@docs placeholder_green_100
+@docs placeholder_green_200
+@docs placeholder_green_300
+@docs placeholder_green_400
+@docs placeholder_green_500
+@docs placeholder_green_600
+@docs placeholder_green_700
+@docs placeholder_green_800
+@docs placeholder_green_900
+@docs placeholder_emerald_50
+@docs placeholder_emerald_100
+@docs placeholder_emerald_200
+@docs placeholder_emerald_300
+@docs placeholder_emerald_400
+@docs placeholder_emerald_500
+@docs placeholder_emerald_600
+@docs placeholder_emerald_700
+@docs placeholder_emerald_800
+@docs placeholder_emerald_900
+@docs placeholder_teal_50
+@docs placeholder_teal_100
+@docs placeholder_teal_200
+@docs placeholder_teal_300
+@docs placeholder_teal_400
+@docs placeholder_teal_500
+@docs placeholder_teal_600
+@docs placeholder_teal_700
+@docs placeholder_teal_800
+@docs placeholder_teal_900
+@docs placeholder_cyan_50
+@docs placeholder_cyan_100
+@docs placeholder_cyan_200
+@docs placeholder_cyan_300
+@docs placeholder_cyan_400
+@docs placeholder_cyan_500
+@docs placeholder_cyan_600
+@docs placeholder_cyan_700
+@docs placeholder_cyan_800
+@docs placeholder_cyan_900
+@docs placeholder_sky_50
+@docs placeholder_sky_100
+@docs placeholder_sky_200
+@docs placeholder_sky_300
+@docs placeholder_sky_400
+@docs placeholder_sky_500
+@docs placeholder_sky_600
+@docs placeholder_sky_700
+@docs placeholder_sky_800
+@docs placeholder_sky_900
+@docs placeholder_blue_50
+@docs placeholder_blue_100
+@docs placeholder_blue_200
+@docs placeholder_blue_300
+@docs placeholder_blue_400
+@docs placeholder_blue_500
+@docs placeholder_blue_600
+@docs placeholder_blue_700
+@docs placeholder_blue_800
+@docs placeholder_blue_900
+@docs placeholder_indigo_50
+@docs placeholder_indigo_100
+@docs placeholder_indigo_200
+@docs placeholder_indigo_300
+@docs placeholder_indigo_400
+@docs placeholder_indigo_500
+@docs placeholder_indigo_600
+@docs placeholder_indigo_700
+@docs placeholder_indigo_800
+@docs placeholder_indigo_900
+@docs placeholder_violet_50
+@docs placeholder_violet_100
+@docs placeholder_violet_200
+@docs placeholder_violet_300
+@docs placeholder_violet_400
+@docs placeholder_violet_500
+@docs placeholder_violet_600
+@docs placeholder_violet_700
+@docs placeholder_violet_800
+@docs placeholder_violet_900
+@docs placeholder_purple_50
+@docs placeholder_purple_100
+@docs placeholder_purple_200
+@docs placeholder_purple_300
+@docs placeholder_purple_400
+@docs placeholder_purple_500
+@docs placeholder_purple_600
+@docs placeholder_purple_700
+@docs placeholder_purple_800
+@docs placeholder_purple_900
+@docs placeholder_fuchsia_50
+@docs placeholder_fuchsia_100
+@docs placeholder_fuchsia_200
+@docs placeholder_fuchsia_300
+@docs placeholder_fuchsia_400
+@docs placeholder_fuchsia_500
+@docs placeholder_fuchsia_600
+@docs placeholder_fuchsia_700
+@docs placeholder_fuchsia_800
+@docs placeholder_fuchsia_900
+@docs placeholder_pink_50
+@docs placeholder_pink_100
+@docs placeholder_pink_200
+@docs placeholder_pink_300
+@docs placeholder_pink_400
+@docs placeholder_pink_500
+@docs placeholder_pink_600
+@docs placeholder_pink_700
+@docs placeholder_pink_800
+@docs placeholder_pink_900
+@docs placeholder_rose_50
+@docs placeholder_rose_100
+@docs placeholder_rose_200
+@docs placeholder_rose_300
+@docs placeholder_rose_400
+@docs placeholder_rose_500
+@docs placeholder_rose_600
+@docs placeholder_rose_700
+@docs placeholder_rose_800
+@docs placeholder_rose_900
 @docs pointer_events_auto
 @docs pointer_events_none
 @docs pr_0
@@ -7475,47 +8035,7 @@ This module contains
 @docs ring_4
 @docs ring_8
 @docs ring_black
-@docs ring_blue_100
-@docs ring_blue_200
-@docs ring_blue_300
-@docs ring_blue_400
-@docs ring_blue_50
-@docs ring_blue_500
-@docs ring_blue_600
-@docs ring_blue_700
-@docs ring_blue_800
-@docs ring_blue_900
 @docs ring_current
-@docs ring_gray_100
-@docs ring_gray_200
-@docs ring_gray_300
-@docs ring_gray_400
-@docs ring_gray_50
-@docs ring_gray_500
-@docs ring_gray_600
-@docs ring_gray_700
-@docs ring_gray_800
-@docs ring_gray_900
-@docs ring_green_100
-@docs ring_green_200
-@docs ring_green_300
-@docs ring_green_400
-@docs ring_green_50
-@docs ring_green_500
-@docs ring_green_600
-@docs ring_green_700
-@docs ring_green_800
-@docs ring_green_900
-@docs ring_indigo_100
-@docs ring_indigo_200
-@docs ring_indigo_300
-@docs ring_indigo_400
-@docs ring_indigo_50
-@docs ring_indigo_500
-@docs ring_indigo_600
-@docs ring_indigo_700
-@docs ring_indigo_800
-@docs ring_indigo_900
 @docs ring_inset
 @docs ring_offset_0
 @docs ring_offset_1
@@ -7523,89 +8043,9 @@ This module contains
 @docs ring_offset_4
 @docs ring_offset_8
 @docs ring_offset_black
-@docs ring_offset_blue_100
-@docs ring_offset_blue_200
-@docs ring_offset_blue_300
-@docs ring_offset_blue_400
-@docs ring_offset_blue_50
-@docs ring_offset_blue_500
-@docs ring_offset_blue_600
-@docs ring_offset_blue_700
-@docs ring_offset_blue_800
-@docs ring_offset_blue_900
 @docs ring_offset_current
-@docs ring_offset_gray_100
-@docs ring_offset_gray_200
-@docs ring_offset_gray_300
-@docs ring_offset_gray_400
-@docs ring_offset_gray_50
-@docs ring_offset_gray_500
-@docs ring_offset_gray_600
-@docs ring_offset_gray_700
-@docs ring_offset_gray_800
-@docs ring_offset_gray_900
-@docs ring_offset_green_100
-@docs ring_offset_green_200
-@docs ring_offset_green_300
-@docs ring_offset_green_400
-@docs ring_offset_green_50
-@docs ring_offset_green_500
-@docs ring_offset_green_600
-@docs ring_offset_green_700
-@docs ring_offset_green_800
-@docs ring_offset_green_900
-@docs ring_offset_indigo_100
-@docs ring_offset_indigo_200
-@docs ring_offset_indigo_300
-@docs ring_offset_indigo_400
-@docs ring_offset_indigo_50
-@docs ring_offset_indigo_500
-@docs ring_offset_indigo_600
-@docs ring_offset_indigo_700
-@docs ring_offset_indigo_800
-@docs ring_offset_indigo_900
-@docs ring_offset_pink_100
-@docs ring_offset_pink_200
-@docs ring_offset_pink_300
-@docs ring_offset_pink_400
-@docs ring_offset_pink_50
-@docs ring_offset_pink_500
-@docs ring_offset_pink_600
-@docs ring_offset_pink_700
-@docs ring_offset_pink_800
-@docs ring_offset_pink_900
-@docs ring_offset_purple_100
-@docs ring_offset_purple_200
-@docs ring_offset_purple_300
-@docs ring_offset_purple_400
-@docs ring_offset_purple_50
-@docs ring_offset_purple_500
-@docs ring_offset_purple_600
-@docs ring_offset_purple_700
-@docs ring_offset_purple_800
-@docs ring_offset_purple_900
-@docs ring_offset_red_100
-@docs ring_offset_red_200
-@docs ring_offset_red_300
-@docs ring_offset_red_400
-@docs ring_offset_red_50
-@docs ring_offset_red_500
-@docs ring_offset_red_600
-@docs ring_offset_red_700
-@docs ring_offset_red_800
-@docs ring_offset_red_900
 @docs ring_offset_transparent
 @docs ring_offset_white
-@docs ring_offset_yellow_100
-@docs ring_offset_yellow_200
-@docs ring_offset_yellow_300
-@docs ring_offset_yellow_400
-@docs ring_offset_yellow_50
-@docs ring_offset_yellow_500
-@docs ring_offset_yellow_600
-@docs ring_offset_yellow_700
-@docs ring_offset_yellow_800
-@docs ring_offset_yellow_900
 @docs ring_opacity_0
 @docs ring_opacity_10
 @docs ring_opacity_100
@@ -7621,48 +8061,448 @@ This module contains
 @docs ring_opacity_80
 @docs ring_opacity_90
 @docs ring_opacity_95
-@docs ring_pink_100
-@docs ring_pink_200
-@docs ring_pink_300
-@docs ring_pink_400
-@docs ring_pink_50
-@docs ring_pink_500
-@docs ring_pink_600
-@docs ring_pink_700
-@docs ring_pink_800
-@docs ring_pink_900
-@docs ring_purple_100
-@docs ring_purple_200
-@docs ring_purple_300
-@docs ring_purple_400
-@docs ring_purple_50
-@docs ring_purple_500
-@docs ring_purple_600
-@docs ring_purple_700
-@docs ring_purple_800
-@docs ring_purple_900
+@docs ring_transparent
+@docs ring_white
+@docs ring_slate_50
+@docs ring_slate_100
+@docs ring_slate_200
+@docs ring_slate_300
+@docs ring_slate_400
+@docs ring_slate_500
+@docs ring_slate_600
+@docs ring_slate_700
+@docs ring_slate_800
+@docs ring_slate_900
+@docs ring_gray_50
+@docs ring_gray_100
+@docs ring_gray_200
+@docs ring_gray_300
+@docs ring_gray_400
+@docs ring_gray_500
+@docs ring_gray_600
+@docs ring_gray_700
+@docs ring_gray_800
+@docs ring_gray_900
+@docs ring_zinc_50
+@docs ring_zinc_100
+@docs ring_zinc_200
+@docs ring_zinc_300
+@docs ring_zinc_400
+@docs ring_zinc_500
+@docs ring_zinc_600
+@docs ring_zinc_700
+@docs ring_zinc_800
+@docs ring_zinc_900
+@docs ring_neutral_50
+@docs ring_neutral_100
+@docs ring_neutral_200
+@docs ring_neutral_300
+@docs ring_neutral_400
+@docs ring_neutral_500
+@docs ring_neutral_600
+@docs ring_neutral_700
+@docs ring_neutral_800
+@docs ring_neutral_900
+@docs ring_stone_50
+@docs ring_stone_100
+@docs ring_stone_200
+@docs ring_stone_300
+@docs ring_stone_400
+@docs ring_stone_500
+@docs ring_stone_600
+@docs ring_stone_700
+@docs ring_stone_800
+@docs ring_stone_900
+@docs ring_red_50
 @docs ring_red_100
 @docs ring_red_200
 @docs ring_red_300
 @docs ring_red_400
-@docs ring_red_50
 @docs ring_red_500
 @docs ring_red_600
 @docs ring_red_700
 @docs ring_red_800
 @docs ring_red_900
-@docs ring_transparent
-@docs ring_white
+@docs ring_orange_50
+@docs ring_orange_100
+@docs ring_orange_200
+@docs ring_orange_300
+@docs ring_orange_400
+@docs ring_orange_500
+@docs ring_orange_600
+@docs ring_orange_700
+@docs ring_orange_800
+@docs ring_orange_900
+@docs ring_amber_50
+@docs ring_amber_100
+@docs ring_amber_200
+@docs ring_amber_300
+@docs ring_amber_400
+@docs ring_amber_500
+@docs ring_amber_600
+@docs ring_amber_700
+@docs ring_amber_800
+@docs ring_amber_900
+@docs ring_yellow_50
 @docs ring_yellow_100
 @docs ring_yellow_200
 @docs ring_yellow_300
 @docs ring_yellow_400
-@docs ring_yellow_50
 @docs ring_yellow_500
 @docs ring_yellow_600
 @docs ring_yellow_700
 @docs ring_yellow_800
 @docs ring_yellow_900
+@docs ring_lime_50
+@docs ring_lime_100
+@docs ring_lime_200
+@docs ring_lime_300
+@docs ring_lime_400
+@docs ring_lime_500
+@docs ring_lime_600
+@docs ring_lime_700
+@docs ring_lime_800
+@docs ring_lime_900
+@docs ring_green_50
+@docs ring_green_100
+@docs ring_green_200
+@docs ring_green_300
+@docs ring_green_400
+@docs ring_green_500
+@docs ring_green_600
+@docs ring_green_700
+@docs ring_green_800
+@docs ring_green_900
+@docs ring_emerald_50
+@docs ring_emerald_100
+@docs ring_emerald_200
+@docs ring_emerald_300
+@docs ring_emerald_400
+@docs ring_emerald_500
+@docs ring_emerald_600
+@docs ring_emerald_700
+@docs ring_emerald_800
+@docs ring_emerald_900
+@docs ring_teal_50
+@docs ring_teal_100
+@docs ring_teal_200
+@docs ring_teal_300
+@docs ring_teal_400
+@docs ring_teal_500
+@docs ring_teal_600
+@docs ring_teal_700
+@docs ring_teal_800
+@docs ring_teal_900
+@docs ring_cyan_50
+@docs ring_cyan_100
+@docs ring_cyan_200
+@docs ring_cyan_300
+@docs ring_cyan_400
+@docs ring_cyan_500
+@docs ring_cyan_600
+@docs ring_cyan_700
+@docs ring_cyan_800
+@docs ring_cyan_900
+@docs ring_sky_50
+@docs ring_sky_100
+@docs ring_sky_200
+@docs ring_sky_300
+@docs ring_sky_400
+@docs ring_sky_500
+@docs ring_sky_600
+@docs ring_sky_700
+@docs ring_sky_800
+@docs ring_sky_900
+@docs ring_blue_50
+@docs ring_blue_100
+@docs ring_blue_200
+@docs ring_blue_300
+@docs ring_blue_400
+@docs ring_blue_500
+@docs ring_blue_600
+@docs ring_blue_700
+@docs ring_blue_800
+@docs ring_blue_900
+@docs ring_indigo_50
+@docs ring_indigo_100
+@docs ring_indigo_200
+@docs ring_indigo_300
+@docs ring_indigo_400
+@docs ring_indigo_500
+@docs ring_indigo_600
+@docs ring_indigo_700
+@docs ring_indigo_800
+@docs ring_indigo_900
+@docs ring_violet_50
+@docs ring_violet_100
+@docs ring_violet_200
+@docs ring_violet_300
+@docs ring_violet_400
+@docs ring_violet_500
+@docs ring_violet_600
+@docs ring_violet_700
+@docs ring_violet_800
+@docs ring_violet_900
+@docs ring_purple_50
+@docs ring_purple_100
+@docs ring_purple_200
+@docs ring_purple_300
+@docs ring_purple_400
+@docs ring_purple_500
+@docs ring_purple_600
+@docs ring_purple_700
+@docs ring_purple_800
+@docs ring_purple_900
+@docs ring_fuchsia_50
+@docs ring_fuchsia_100
+@docs ring_fuchsia_200
+@docs ring_fuchsia_300
+@docs ring_fuchsia_400
+@docs ring_fuchsia_500
+@docs ring_fuchsia_600
+@docs ring_fuchsia_700
+@docs ring_fuchsia_800
+@docs ring_fuchsia_900
+@docs ring_pink_50
+@docs ring_pink_100
+@docs ring_pink_200
+@docs ring_pink_300
+@docs ring_pink_400
+@docs ring_pink_500
+@docs ring_pink_600
+@docs ring_pink_700
+@docs ring_pink_800
+@docs ring_pink_900
+@docs ring_rose_50
+@docs ring_rose_100
+@docs ring_rose_200
+@docs ring_rose_300
+@docs ring_rose_400
+@docs ring_rose_500
+@docs ring_rose_600
+@docs ring_rose_700
+@docs ring_rose_800
+@docs ring_rose_900
+@docs ring_offset_slate_50
+@docs ring_offset_slate_100
+@docs ring_offset_slate_200
+@docs ring_offset_slate_300
+@docs ring_offset_slate_400
+@docs ring_offset_slate_500
+@docs ring_offset_slate_600
+@docs ring_offset_slate_700
+@docs ring_offset_slate_800
+@docs ring_offset_slate_900
+@docs ring_offset_gray_50
+@docs ring_offset_gray_100
+@docs ring_offset_gray_200
+@docs ring_offset_gray_300
+@docs ring_offset_gray_400
+@docs ring_offset_gray_500
+@docs ring_offset_gray_600
+@docs ring_offset_gray_700
+@docs ring_offset_gray_800
+@docs ring_offset_gray_900
+@docs ring_offset_zinc_50
+@docs ring_offset_zinc_100
+@docs ring_offset_zinc_200
+@docs ring_offset_zinc_300
+@docs ring_offset_zinc_400
+@docs ring_offset_zinc_500
+@docs ring_offset_zinc_600
+@docs ring_offset_zinc_700
+@docs ring_offset_zinc_800
+@docs ring_offset_zinc_900
+@docs ring_offset_neutral_50
+@docs ring_offset_neutral_100
+@docs ring_offset_neutral_200
+@docs ring_offset_neutral_300
+@docs ring_offset_neutral_400
+@docs ring_offset_neutral_500
+@docs ring_offset_neutral_600
+@docs ring_offset_neutral_700
+@docs ring_offset_neutral_800
+@docs ring_offset_neutral_900
+@docs ring_offset_stone_50
+@docs ring_offset_stone_100
+@docs ring_offset_stone_200
+@docs ring_offset_stone_300
+@docs ring_offset_stone_400
+@docs ring_offset_stone_500
+@docs ring_offset_stone_600
+@docs ring_offset_stone_700
+@docs ring_offset_stone_800
+@docs ring_offset_stone_900
+@docs ring_offset_red_50
+@docs ring_offset_red_100
+@docs ring_offset_red_200
+@docs ring_offset_red_300
+@docs ring_offset_red_400
+@docs ring_offset_red_500
+@docs ring_offset_red_600
+@docs ring_offset_red_700
+@docs ring_offset_red_800
+@docs ring_offset_red_900
+@docs ring_offset_orange_50
+@docs ring_offset_orange_100
+@docs ring_offset_orange_200
+@docs ring_offset_orange_300
+@docs ring_offset_orange_400
+@docs ring_offset_orange_500
+@docs ring_offset_orange_600
+@docs ring_offset_orange_700
+@docs ring_offset_orange_800
+@docs ring_offset_orange_900
+@docs ring_offset_amber_50
+@docs ring_offset_amber_100
+@docs ring_offset_amber_200
+@docs ring_offset_amber_300
+@docs ring_offset_amber_400
+@docs ring_offset_amber_500
+@docs ring_offset_amber_600
+@docs ring_offset_amber_700
+@docs ring_offset_amber_800
+@docs ring_offset_amber_900
+@docs ring_offset_yellow_50
+@docs ring_offset_yellow_100
+@docs ring_offset_yellow_200
+@docs ring_offset_yellow_300
+@docs ring_offset_yellow_400
+@docs ring_offset_yellow_500
+@docs ring_offset_yellow_600
+@docs ring_offset_yellow_700
+@docs ring_offset_yellow_800
+@docs ring_offset_yellow_900
+@docs ring_offset_lime_50
+@docs ring_offset_lime_100
+@docs ring_offset_lime_200
+@docs ring_offset_lime_300
+@docs ring_offset_lime_400
+@docs ring_offset_lime_500
+@docs ring_offset_lime_600
+@docs ring_offset_lime_700
+@docs ring_offset_lime_800
+@docs ring_offset_lime_900
+@docs ring_offset_green_50
+@docs ring_offset_green_100
+@docs ring_offset_green_200
+@docs ring_offset_green_300
+@docs ring_offset_green_400
+@docs ring_offset_green_500
+@docs ring_offset_green_600
+@docs ring_offset_green_700
+@docs ring_offset_green_800
+@docs ring_offset_green_900
+@docs ring_offset_emerald_50
+@docs ring_offset_emerald_100
+@docs ring_offset_emerald_200
+@docs ring_offset_emerald_300
+@docs ring_offset_emerald_400
+@docs ring_offset_emerald_500
+@docs ring_offset_emerald_600
+@docs ring_offset_emerald_700
+@docs ring_offset_emerald_800
+@docs ring_offset_emerald_900
+@docs ring_offset_teal_50
+@docs ring_offset_teal_100
+@docs ring_offset_teal_200
+@docs ring_offset_teal_300
+@docs ring_offset_teal_400
+@docs ring_offset_teal_500
+@docs ring_offset_teal_600
+@docs ring_offset_teal_700
+@docs ring_offset_teal_800
+@docs ring_offset_teal_900
+@docs ring_offset_cyan_50
+@docs ring_offset_cyan_100
+@docs ring_offset_cyan_200
+@docs ring_offset_cyan_300
+@docs ring_offset_cyan_400
+@docs ring_offset_cyan_500
+@docs ring_offset_cyan_600
+@docs ring_offset_cyan_700
+@docs ring_offset_cyan_800
+@docs ring_offset_cyan_900
+@docs ring_offset_sky_50
+@docs ring_offset_sky_100
+@docs ring_offset_sky_200
+@docs ring_offset_sky_300
+@docs ring_offset_sky_400
+@docs ring_offset_sky_500
+@docs ring_offset_sky_600
+@docs ring_offset_sky_700
+@docs ring_offset_sky_800
+@docs ring_offset_sky_900
+@docs ring_offset_blue_50
+@docs ring_offset_blue_100
+@docs ring_offset_blue_200
+@docs ring_offset_blue_300
+@docs ring_offset_blue_400
+@docs ring_offset_blue_500
+@docs ring_offset_blue_600
+@docs ring_offset_blue_700
+@docs ring_offset_blue_800
+@docs ring_offset_blue_900
+@docs ring_offset_indigo_50
+@docs ring_offset_indigo_100
+@docs ring_offset_indigo_200
+@docs ring_offset_indigo_300
+@docs ring_offset_indigo_400
+@docs ring_offset_indigo_500
+@docs ring_offset_indigo_600
+@docs ring_offset_indigo_700
+@docs ring_offset_indigo_800
+@docs ring_offset_indigo_900
+@docs ring_offset_violet_50
+@docs ring_offset_violet_100
+@docs ring_offset_violet_200
+@docs ring_offset_violet_300
+@docs ring_offset_violet_400
+@docs ring_offset_violet_500
+@docs ring_offset_violet_600
+@docs ring_offset_violet_700
+@docs ring_offset_violet_800
+@docs ring_offset_violet_900
+@docs ring_offset_purple_50
+@docs ring_offset_purple_100
+@docs ring_offset_purple_200
+@docs ring_offset_purple_300
+@docs ring_offset_purple_400
+@docs ring_offset_purple_500
+@docs ring_offset_purple_600
+@docs ring_offset_purple_700
+@docs ring_offset_purple_800
+@docs ring_offset_purple_900
+@docs ring_offset_fuchsia_50
+@docs ring_offset_fuchsia_100
+@docs ring_offset_fuchsia_200
+@docs ring_offset_fuchsia_300
+@docs ring_offset_fuchsia_400
+@docs ring_offset_fuchsia_500
+@docs ring_offset_fuchsia_600
+@docs ring_offset_fuchsia_700
+@docs ring_offset_fuchsia_800
+@docs ring_offset_fuchsia_900
+@docs ring_offset_pink_50
+@docs ring_offset_pink_100
+@docs ring_offset_pink_200
+@docs ring_offset_pink_300
+@docs ring_offset_pink_400
+@docs ring_offset_pink_500
+@docs ring_offset_pink_600
+@docs ring_offset_pink_700
+@docs ring_offset_pink_800
+@docs ring_offset_pink_900
+@docs ring_offset_rose_50
+@docs ring_offset_rose_100
+@docs ring_offset_rose_200
+@docs ring_offset_rose_300
+@docs ring_offset_rose_400
+@docs ring_offset_rose_500
+@docs ring_offset_rose_600
+@docs ring_offset_rose_700
+@docs ring_offset_rose_800
+@docs ring_offset_rose_900
 @docs rotate_0
 @docs rotate_1
 @docs rotate_12
@@ -40888,236 +41728,6 @@ placeholder_black =
         ]
 
 
-{-| The tailwind class `placeholder-blue-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_100 : Css.Style
-placeholder_blue_100 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_200 : Css.Style
-placeholder_blue_200 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_300 : Css.Style
-placeholder_blue_300 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_400 : Css.Style
-placeholder_blue_400 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_50 : Css.Style
-placeholder_blue_50 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_500 : Css.Style
-placeholder_blue_500 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_600 : Css.Style
-placeholder_blue_600 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_700 : Css.Style
-placeholder_blue_700 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_800 : Css.Style
-placeholder_blue_800 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_blue_900 : Css.Style
-placeholder_blue_900 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
 {-| The tailwind class `placeholder-current`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
@@ -41134,696 +41744,6 @@ placeholder_current =
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "color" "currentColor"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_100 : Css.Style
-placeholder_gray_100 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_200 : Css.Style
-placeholder_gray_200 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_300 : Css.Style
-placeholder_gray_300 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_400 : Css.Style
-placeholder_gray_400 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_50 : Css.Style
-placeholder_gray_50 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_500 : Css.Style
-placeholder_gray_500 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_600 : Css.Style
-placeholder_gray_600 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_700 : Css.Style
-placeholder_gray_700 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_800 : Css.Style
-placeholder_gray_800 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-gray-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_gray_900 : Css.Style
-placeholder_gray_900 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_100 : Css.Style
-placeholder_green_100 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_200 : Css.Style
-placeholder_green_200 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_300 : Css.Style
-placeholder_green_300 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_400 : Css.Style
-placeholder_green_400 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_50 : Css.Style
-placeholder_green_50 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_500 : Css.Style
-placeholder_green_500 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_600 : Css.Style
-placeholder_green_600 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_700 : Css.Style
-placeholder_green_700 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_800 : Css.Style
-placeholder_green_800 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_green_900 : Css.Style
-placeholder_green_900 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_100 : Css.Style
-placeholder_indigo_100 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_200 : Css.Style
-placeholder_indigo_200 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_300 : Css.Style
-placeholder_indigo_300 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_400 : Css.Style
-placeholder_indigo_400 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_50 : Css.Style
-placeholder_indigo_50 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_500 : Css.Style
-placeholder_indigo_500 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_600 : Css.Style
-placeholder_indigo_600 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_700 : Css.Style
-placeholder_indigo_700 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_800 : Css.Style
-placeholder_indigo_800 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_indigo_900 : Css.Style
-placeholder_indigo_900 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -42128,462 +42048,1218 @@ placeholder_opacity_95 =
         ]
 
 
-{-| The tailwind class `placeholder-pink-100`.
+{-| The tailwind class `placeholder-transparent`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_100 : Css.Style
-placeholder_pink_100 =
+placeholder_transparent : Css.Style
+placeholder_transparent =
     Css.batch
         [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            [ Css.property "color" "transparent"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            [ Css.property "color" "transparent"
             ]
         , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            [ Css.property "color" "transparent"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-200`.
+{-| The tailwind class `placeholder-white`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_200 : Css.Style
-placeholder_pink_200 =
+placeholder_white : Css.Style
+placeholder_white =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-300`.
+{-| The tailwind class `placeholder-slate-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_300 : Css.Style
-placeholder_pink_300 =
+placeholder_slate_50 : Css.Style
+placeholder_slate_50 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(248, 250, 252, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(248, 250, 252, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(248, 250, 252, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-400`.
+{-| The tailwind class `placeholder-slate-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_400 : Css.Style
-placeholder_pink_400 =
+placeholder_slate_100 : Css.Style
+placeholder_slate_100 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(241, 245, 249, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(241, 245, 249, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(241, 245, 249, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-50`.
+{-| The tailwind class `placeholder-slate-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_50 : Css.Style
-placeholder_pink_50 =
+placeholder_slate_200 : Css.Style
+placeholder_slate_200 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(226, 232, 240, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(226, 232, 240, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(226, 232, 240, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-500`.
+{-| The tailwind class `placeholder-slate-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_500 : Css.Style
-placeholder_pink_500 =
+placeholder_slate_300 : Css.Style
+placeholder_slate_300 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(203, 213, 225, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(203, 213, 225, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(203, 213, 225, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-600`.
+{-| The tailwind class `placeholder-slate-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_600 : Css.Style
-placeholder_pink_600 =
+placeholder_slate_400 : Css.Style
+placeholder_slate_400 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(148, 163, 184, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(148, 163, 184, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(148, 163, 184, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-700`.
+{-| The tailwind class `placeholder-slate-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_700 : Css.Style
-placeholder_pink_700 =
+placeholder_slate_500 : Css.Style
+placeholder_slate_500 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(100, 116, 139, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(100, 116, 139, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(100, 116, 139, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-800`.
+{-| The tailwind class `placeholder-slate-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_800 : Css.Style
-placeholder_pink_800 =
+placeholder_slate_600 : Css.Style
+placeholder_slate_600 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(71, 85, 105, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(71, 85, 105, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(71, 85, 105, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-pink-900`.
+{-| The tailwind class `placeholder-slate-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_pink_900 : Css.Style
-placeholder_pink_900 =
+placeholder_slate_700 : Css.Style
+placeholder_slate_700 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(51, 65, 85, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(51, 65, 85, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(51, 65, 85, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-100`.
+{-| The tailwind class `placeholder-slate-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_100 : Css.Style
-placeholder_purple_100 =
+placeholder_slate_800 : Css.Style
+placeholder_slate_800 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(30, 41, 59, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(30, 41, 59, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(30, 41, 59, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-200`.
+{-| The tailwind class `placeholder-slate-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_200 : Css.Style
-placeholder_purple_200 =
+placeholder_slate_900 : Css.Style
+placeholder_slate_900 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(15, 23, 42, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(15, 23, 42, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(15, 23, 42, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-300`.
+{-| The tailwind class `placeholder-gray-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_300 : Css.Style
-placeholder_purple_300 =
+placeholder_gray_50 : Css.Style
+placeholder_gray_50 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(249, 250, 251, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-400`.
+{-| The tailwind class `placeholder-gray-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_400 : Css.Style
-placeholder_purple_400 =
+placeholder_gray_100 : Css.Style
+placeholder_gray_100 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(243, 244, 246, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-50`.
+{-| The tailwind class `placeholder-gray-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_50 : Css.Style
-placeholder_purple_50 =
+placeholder_gray_200 : Css.Style
+placeholder_gray_200 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(229, 231, 235, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-500`.
+{-| The tailwind class `placeholder-gray-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_500 : Css.Style
-placeholder_purple_500 =
+placeholder_gray_300 : Css.Style
+placeholder_gray_300 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(209, 213, 219, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-600`.
+{-| The tailwind class `placeholder-gray-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_600 : Css.Style
-placeholder_purple_600 =
+placeholder_gray_400 : Css.Style
+placeholder_gray_400 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(156, 163, 175, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-700`.
+{-| The tailwind class `placeholder-gray-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_700 : Css.Style
-placeholder_purple_700 =
+placeholder_gray_500 : Css.Style
+placeholder_gray_500 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(107, 114, 128, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-800`.
+{-| The tailwind class `placeholder-gray-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_800 : Css.Style
-placeholder_purple_800 =
+placeholder_gray_600 : Css.Style
+placeholder_gray_600 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(75, 85, 99, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-purple-900`.
+{-| The tailwind class `placeholder-gray-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_purple_900 : Css.Style
-placeholder_purple_900 =
+placeholder_gray_700 : Css.Style
+placeholder_gray_700 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(55, 65, 81, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-gray-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_gray_800 : Css.Style
+placeholder_gray_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(31, 41, 55, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-gray-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_gray_900 : Css.Style
+placeholder_gray_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 24, 39, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_50 : Css.Style
+placeholder_zinc_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_100 : Css.Style
+placeholder_zinc_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 244, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 244, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 244, 245, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_200 : Css.Style
+placeholder_zinc_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(228, 228, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(228, 228, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(228, 228, 231, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_300 : Css.Style
+placeholder_zinc_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 216, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 216, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 216, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_400 : Css.Style
+placeholder_zinc_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(161, 161, 170, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(161, 161, 170, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(161, 161, 170, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_500 : Css.Style
+placeholder_zinc_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(113, 113, 122, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(113, 113, 122, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(113, 113, 122, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_600 : Css.Style
+placeholder_zinc_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 91, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 91, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 91, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_700 : Css.Style
+placeholder_zinc_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 63, 70, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 63, 70, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 63, 70, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_800 : Css.Style
+placeholder_zinc_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(39, 39, 42, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(39, 39, 42, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(39, 39, 42, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_zinc_900 : Css.Style
+placeholder_zinc_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(24, 24, 27, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(24, 24, 27, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(24, 24, 27, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_50 : Css.Style
+placeholder_neutral_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 250, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_100 : Css.Style
+placeholder_neutral_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 245, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_200 : Css.Style
+placeholder_neutral_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(229, 229, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(229, 229, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(229, 229, 229, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_300 : Css.Style
+placeholder_neutral_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(212, 212, 212, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_400 : Css.Style
+placeholder_neutral_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 163, 163, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 163, 163, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 163, 163, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_500 : Css.Style
+placeholder_neutral_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(115, 115, 115, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(115, 115, 115, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(115, 115, 115, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_600 : Css.Style
+placeholder_neutral_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 82, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 82, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(82, 82, 82, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_700 : Css.Style
+placeholder_neutral_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(64, 64, 64, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(64, 64, 64, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(64, 64, 64, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_800 : Css.Style
+placeholder_neutral_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(38, 38, 38, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(38, 38, 38, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(38, 38, 38, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_neutral_900 : Css.Style
+placeholder_neutral_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(23, 23, 23, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(23, 23, 23, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(23, 23, 23, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_50 : Css.Style
+placeholder_stone_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 250, 249, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_100 : Css.Style
+placeholder_stone_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 244, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 244, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 245, 244, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_200 : Css.Style
+placeholder_stone_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(231, 229, 228, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(231, 229, 228, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(231, 229, 228, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_300 : Css.Style
+placeholder_stone_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(214, 211, 209, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(214, 211, 209, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(214, 211, 209, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_400 : Css.Style
+placeholder_stone_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 162, 158, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 162, 158, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 162, 158, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_500 : Css.Style
+placeholder_stone_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 113, 108, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 113, 108, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 113, 108, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_600 : Css.Style
+placeholder_stone_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(87, 83, 78, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(87, 83, 78, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(87, 83, 78, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_700 : Css.Style
+placeholder_stone_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(68, 64, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(68, 64, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(68, 64, 60, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_800 : Css.Style
+placeholder_stone_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(41, 37, 36, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(41, 37, 36, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(41, 37, 36, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_stone_900 : Css.Style
+placeholder_stone_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(28, 25, 23, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(28, 25, 23, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(28, 25, 23, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_red_50 : Css.Style
+placeholder_red_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -42676,29 +43352,6 @@ placeholder_red_400 =
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
             , Css.property "color" "rgba(248, 113, 113, var(--tw-placeholder-opacity))"
-            ]
-        ]
-
-
-{-| The tailwind class `placeholder-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-placeholder_red_50 : Css.Style
-placeholder_red_50 =
-    Css.batch
-        [ Css.pseudoElement "placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
-            ]
-        , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(254, 242, 242, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -42818,56 +43471,266 @@ placeholder_red_900 =
         ]
 
 
-{-| The tailwind class `placeholder-transparent`.
+{-| The tailwind class `placeholder-orange-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_transparent : Css.Style
-placeholder_transparent =
+placeholder_orange_50 : Css.Style
+placeholder_orange_50 =
     Css.batch
         [ Css.pseudoElement "placeholder"
-            [ Css.property "color" "transparent"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 247, 237, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
-            [ Css.property "color" "transparent"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 247, 237, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
-            [ Css.property "color" "transparent"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 247, 237, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-white`.
+{-| The tailwind class `placeholder-orange-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_white : Css.Style
-placeholder_white =
+placeholder_orange_100 : Css.Style
+placeholder_orange_100 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 237, 213, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 237, 213, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 255, 255, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(255, 237, 213, var(--tw-placeholder-opacity))"
             ]
         ]
 
 
-{-| The tailwind class `placeholder-yellow-100`.
+{-| The tailwind class `placeholder-orange-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_yellow_100 : Css.Style
-placeholder_yellow_100 =
+placeholder_orange_200 : Css.Style
+placeholder_orange_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 215, 170, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 215, 170, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 215, 170, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_300 : Css.Style
+placeholder_orange_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 186, 116, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 186, 116, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 186, 116, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_400 : Css.Style
+placeholder_orange_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 146, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 146, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 146, 60, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_500 : Css.Style
+placeholder_orange_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 115, 22, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 115, 22, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 115, 22, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_600 : Css.Style
+placeholder_orange_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(234, 88, 12, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(234, 88, 12, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(234, 88, 12, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_700 : Css.Style
+placeholder_orange_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(194, 65, 12, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(194, 65, 12, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(194, 65, 12, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_800 : Css.Style
+placeholder_orange_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(154, 52, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(154, 52, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(154, 52, 18, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_orange_900 : Css.Style
+placeholder_orange_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 45, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 45, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 45, 18, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_50 : Css.Style
+placeholder_amber_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_100 : Css.Style
+placeholder_amber_100 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
@@ -42884,13 +43747,13 @@ placeholder_yellow_100 =
         ]
 
 
-{-| The tailwind class `placeholder-yellow-200`.
+{-| The tailwind class `placeholder-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_yellow_200 : Css.Style
-placeholder_yellow_200 =
+placeholder_amber_200 : Css.Style
+placeholder_amber_200 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
@@ -42907,13 +43770,13 @@ placeholder_yellow_200 =
         ]
 
 
-{-| The tailwind class `placeholder-yellow-300`.
+{-| The tailwind class `placeholder-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_yellow_300 : Css.Style
-placeholder_yellow_300 =
+placeholder_amber_300 : Css.Style
+placeholder_amber_300 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
@@ -42930,13 +43793,13 @@ placeholder_yellow_300 =
         ]
 
 
-{-| The tailwind class `placeholder-yellow-400`.
+{-| The tailwind class `placeholder-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-placeholder_yellow_400 : Css.Style
-placeholder_yellow_400 =
+placeholder_amber_400 : Css.Style
+placeholder_amber_400 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
@@ -42949,6 +43812,121 @@ placeholder_yellow_400 =
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
             , Css.property "color" "rgba(251, 191, 36, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_500 : Css.Style
+placeholder_amber_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_600 : Css.Style
+placeholder_amber_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_700 : Css.Style
+placeholder_amber_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_800 : Css.Style
+placeholder_amber_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_amber_900 : Css.Style
+placeholder_amber_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -42963,15 +43941,107 @@ placeholder_yellow_50 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(254, 252, 232, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(254, 252, 232, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(255, 251, 235, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(254, 252, 232, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_yellow_100 : Css.Style
+placeholder_yellow_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 249, 195, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 249, 195, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 249, 195, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_yellow_200 : Css.Style
+placeholder_yellow_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 240, 138, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 240, 138, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 240, 138, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_yellow_300 : Css.Style
+placeholder_yellow_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 224, 71, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 224, 71, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 224, 71, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_yellow_400 : Css.Style
+placeholder_yellow_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 204, 21, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 204, 21, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 204, 21, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -42986,15 +44056,15 @@ placeholder_yellow_500 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(234, 179, 8, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(234, 179, 8, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(245, 158, 11, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(234, 179, 8, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -43009,15 +44079,15 @@ placeholder_yellow_600 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(202, 138, 4, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(202, 138, 4, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(217, 119, 6, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(202, 138, 4, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -43032,15 +44102,15 @@ placeholder_yellow_700 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(161, 98, 7, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(161, 98, 7, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(180, 83, 9, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(161, 98, 7, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -43055,15 +44125,15 @@ placeholder_yellow_800 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(133, 77, 14, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(133, 77, 14, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(146, 64, 14, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(133, 77, 14, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -43078,15 +44148,3005 @@ placeholder_yellow_900 =
     Css.batch
         [ Css.pseudoElement "placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(113, 63, 18, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoClass "-ms-input-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(113, 63, 18, var(--tw-placeholder-opacity))"
             ]
         , Css.pseudoElement "-moz-placeholder"
             [ Css.property "--tw-placeholder-opacity" "1"
-            , Css.property "color" "rgba(120, 53, 15, var(--tw-placeholder-opacity))"
+            , Css.property "color" "rgba(113, 63, 18, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_50 : Css.Style
+placeholder_lime_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(247, 254, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(247, 254, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(247, 254, 231, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_100 : Css.Style
+placeholder_lime_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 252, 203, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 252, 203, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 252, 203, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_200 : Css.Style
+placeholder_lime_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 249, 157, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 249, 157, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 249, 157, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_300 : Css.Style
+placeholder_lime_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 242, 100, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 242, 100, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 242, 100, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_400 : Css.Style
+placeholder_lime_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 230, 53, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 230, 53, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(163, 230, 53, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_500 : Css.Style
+placeholder_lime_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(132, 204, 22, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(132, 204, 22, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(132, 204, 22, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_600 : Css.Style
+placeholder_lime_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(101, 163, 13, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(101, 163, 13, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(101, 163, 13, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_700 : Css.Style
+placeholder_lime_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(77, 124, 15, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(77, 124, 15, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(77, 124, 15, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_800 : Css.Style
+placeholder_lime_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 98, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 98, 18, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(63, 98, 18, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_lime_900 : Css.Style
+placeholder_lime_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(54, 83, 20, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(54, 83, 20, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(54, 83, 20, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_50 : Css.Style
+placeholder_green_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 244, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 244, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 244, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_100 : Css.Style
+placeholder_green_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(220, 252, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(220, 252, 231, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(220, 252, 231, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_200 : Css.Style
+placeholder_green_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(187, 247, 208, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(187, 247, 208, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(187, 247, 208, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_300 : Css.Style
+placeholder_green_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 239, 172, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 239, 172, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 239, 172, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_400 : Css.Style
+placeholder_green_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(74, 222, 128, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(74, 222, 128, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(74, 222, 128, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_500 : Css.Style
+placeholder_green_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 197, 94, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 197, 94, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 197, 94, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_600 : Css.Style
+placeholder_green_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 163, 74, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 163, 74, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 163, 74, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_700 : Css.Style
+placeholder_green_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 128, 61, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 128, 61, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 128, 61, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_800 : Css.Style
+placeholder_green_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 101, 52, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 101, 52, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 101, 52, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_green_900 : Css.Style
+placeholder_green_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 83, 45, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 83, 45, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 83, 45, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_50 : Css.Style
+placeholder_emerald_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 253, 245, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_100 : Css.Style
+placeholder_emerald_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(209, 250, 229, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_200 : Css.Style
+placeholder_emerald_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 243, 208, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_300 : Css.Style
+placeholder_emerald_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(110, 231, 183, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_400 : Css.Style
+placeholder_emerald_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(52, 211, 153, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_500 : Css.Style
+placeholder_emerald_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(16, 185, 129, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_600 : Css.Style
+placeholder_emerald_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(5, 150, 105, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_700 : Css.Style
+placeholder_emerald_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(4, 120, 87, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_800 : Css.Style
+placeholder_emerald_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 95, 70, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_emerald_900 : Css.Style
+placeholder_emerald_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 78, 59, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_50 : Css.Style
+placeholder_teal_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 253, 250, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_100 : Css.Style
+placeholder_teal_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(204, 251, 241, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(204, 251, 241, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(204, 251, 241, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_200 : Css.Style
+placeholder_teal_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(153, 246, 228, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(153, 246, 228, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(153, 246, 228, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_300 : Css.Style
+placeholder_teal_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(94, 234, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(94, 234, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(94, 234, 212, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_400 : Css.Style
+placeholder_teal_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(45, 212, 191, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(45, 212, 191, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(45, 212, 191, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_500 : Css.Style
+placeholder_teal_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 184, 166, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 184, 166, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(20, 184, 166, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_600 : Css.Style
+placeholder_teal_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(13, 148, 136, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(13, 148, 136, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(13, 148, 136, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_700 : Css.Style
+placeholder_teal_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(15, 118, 110, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(15, 118, 110, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(15, 118, 110, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_800 : Css.Style
+placeholder_teal_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 94, 89, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 94, 89, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(17, 94, 89, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_teal_900 : Css.Style
+placeholder_teal_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(19, 78, 74, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(19, 78, 74, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(19, 78, 74, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_50 : Css.Style
+placeholder_cyan_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 254, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 254, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 254, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_100 : Css.Style
+placeholder_cyan_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(207, 250, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(207, 250, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(207, 250, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_200 : Css.Style
+placeholder_cyan_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 243, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 243, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 243, 252, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_300 : Css.Style
+placeholder_cyan_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(103, 232, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(103, 232, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(103, 232, 249, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_400 : Css.Style
+placeholder_cyan_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 211, 238, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 211, 238, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(34, 211, 238, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_500 : Css.Style
+placeholder_cyan_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 182, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 182, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(6, 182, 212, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_600 : Css.Style
+placeholder_cyan_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(8, 145, 178, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(8, 145, 178, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(8, 145, 178, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_700 : Css.Style
+placeholder_cyan_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 116, 144, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 116, 144, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 116, 144, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_800 : Css.Style
+placeholder_cyan_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 94, 117, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 94, 117, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(21, 94, 117, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_cyan_900 : Css.Style
+placeholder_cyan_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 78, 99, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 78, 99, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(22, 78, 99, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_50 : Css.Style
+placeholder_sky_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 249, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 249, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 249, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_100 : Css.Style
+placeholder_sky_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 242, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 242, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 242, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_200 : Css.Style
+placeholder_sky_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(186, 230, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(186, 230, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(186, 230, 253, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_300 : Css.Style
+placeholder_sky_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(125, 211, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(125, 211, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(125, 211, 252, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_400 : Css.Style
+placeholder_sky_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(56, 189, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(56, 189, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(56, 189, 248, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_500 : Css.Style
+placeholder_sky_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 165, 233, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 165, 233, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(14, 165, 233, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_600 : Css.Style
+placeholder_sky_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(2, 132, 199, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(2, 132, 199, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(2, 132, 199, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_700 : Css.Style
+placeholder_sky_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(3, 105, 161, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(3, 105, 161, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(3, 105, 161, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_800 : Css.Style
+placeholder_sky_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(7, 89, 133, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(7, 89, 133, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(7, 89, 133, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_sky_900 : Css.Style
+placeholder_sky_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(12, 74, 110, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(12, 74, 110, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(12, 74, 110, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_50 : Css.Style
+placeholder_blue_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(239, 246, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_100 : Css.Style
+placeholder_blue_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 234, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_200 : Css.Style
+placeholder_blue_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(191, 219, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_300 : Css.Style
+placeholder_blue_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 197, 253, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_400 : Css.Style
+placeholder_blue_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(96, 165, 250, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_500 : Css.Style
+placeholder_blue_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(59, 130, 246, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_600 : Css.Style
+placeholder_blue_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(37, 99, 235, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_700 : Css.Style
+placeholder_blue_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(29, 78, 216, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_800 : Css.Style
+placeholder_blue_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 64, 175, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_blue_900 : Css.Style
+placeholder_blue_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(30, 58, 138, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_50 : Css.Style
+placeholder_indigo_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(238, 242, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_100 : Css.Style
+placeholder_indigo_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(224, 231, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_200 : Css.Style
+placeholder_indigo_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(199, 210, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_300 : Css.Style
+placeholder_indigo_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(165, 180, 252, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_400 : Css.Style
+placeholder_indigo_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(129, 140, 248, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_500 : Css.Style
+placeholder_indigo_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(99, 102, 241, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_600 : Css.Style
+placeholder_indigo_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(79, 70, 229, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_700 : Css.Style
+placeholder_indigo_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(67, 56, 202, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_800 : Css.Style
+placeholder_indigo_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(55, 48, 163, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_indigo_900 : Css.Style
+placeholder_indigo_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(49, 46, 129, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_50 : Css.Style
+placeholder_violet_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 243, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_100 : Css.Style
+placeholder_violet_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(237, 233, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_200 : Css.Style
+placeholder_violet_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(221, 214, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_300 : Css.Style
+placeholder_violet_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(196, 181, 253, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_400 : Css.Style
+placeholder_violet_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(167, 139, 250, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_500 : Css.Style
+placeholder_violet_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(139, 92, 246, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_600 : Css.Style
+placeholder_violet_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(124, 58, 237, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_700 : Css.Style
+placeholder_violet_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(109, 40, 217, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_800 : Css.Style
+placeholder_violet_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(91, 33, 182, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_violet_900 : Css.Style
+placeholder_violet_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(76, 29, 149, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_50 : Css.Style
+placeholder_purple_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 245, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 245, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 245, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_100 : Css.Style
+placeholder_purple_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(243, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(243, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(243, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_200 : Css.Style
+placeholder_purple_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(233, 213, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(233, 213, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(233, 213, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_300 : Css.Style
+placeholder_purple_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(216, 180, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(216, 180, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(216, 180, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_400 : Css.Style
+placeholder_purple_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 132, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 132, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 132, 252, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_500 : Css.Style
+placeholder_purple_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 85, 247, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 85, 247, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(168, 85, 247, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_600 : Css.Style
+placeholder_purple_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 51, 234, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 51, 234, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(147, 51, 234, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_700 : Css.Style
+placeholder_purple_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(126, 34, 206, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(126, 34, 206, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(126, 34, 206, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_800 : Css.Style
+placeholder_purple_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(107, 33, 168, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(107, 33, 168, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(107, 33, 168, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_purple_900 : Css.Style
+placeholder_purple_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(88, 28, 135, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(88, 28, 135, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(88, 28, 135, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_50 : Css.Style
+placeholder_fuchsia_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 244, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 244, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 244, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_100 : Css.Style
+placeholder_fuchsia_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(250, 232, 255, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_200 : Css.Style
+placeholder_fuchsia_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 208, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 208, 254, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(245, 208, 254, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_300 : Css.Style
+placeholder_fuchsia_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 171, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 171, 252, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(240, 171, 252, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_400 : Css.Style
+placeholder_fuchsia_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(232, 121, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(232, 121, 249, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(232, 121, 249, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_500 : Css.Style
+placeholder_fuchsia_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 70, 239, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 70, 239, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(217, 70, 239, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_600 : Css.Style
+placeholder_fuchsia_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 38, 211, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 38, 211, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(192, 38, 211, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_700 : Css.Style
+placeholder_fuchsia_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(162, 28, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(162, 28, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(162, 28, 175, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_800 : Css.Style
+placeholder_fuchsia_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 25, 143, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 25, 143, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(134, 25, 143, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_fuchsia_900 : Css.Style
+placeholder_fuchsia_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(112, 26, 117, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(112, 26, 117, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(112, 26, 117, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_50 : Css.Style
+placeholder_pink_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 242, 248, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_100 : Css.Style
+placeholder_pink_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(252, 231, 243, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_200 : Css.Style
+placeholder_pink_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 207, 232, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_300 : Css.Style
+placeholder_pink_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(249, 168, 212, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_400 : Css.Style
+placeholder_pink_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 114, 182, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_500 : Css.Style
+placeholder_pink_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(236, 72, 153, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_600 : Css.Style
+placeholder_pink_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(219, 39, 119, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_700 : Css.Style
+placeholder_pink_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 24, 93, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_800 : Css.Style
+placeholder_pink_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(157, 23, 77, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_pink_900 : Css.Style
+placeholder_pink_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(131, 24, 67, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_50 : Css.Style
+placeholder_rose_50 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 241, 242, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 241, 242, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 241, 242, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_100 : Css.Style
+placeholder_rose_100 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 228, 230, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 228, 230, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(255, 228, 230, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_200 : Css.Style
+placeholder_rose_200 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 205, 211, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 205, 211, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(254, 205, 211, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_300 : Css.Style
+placeholder_rose_300 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 164, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 164, 175, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(253, 164, 175, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_400 : Css.Style
+placeholder_rose_400 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 113, 133, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 113, 133, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(251, 113, 133, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_500 : Css.Style
+placeholder_rose_500 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 63, 94, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 63, 94, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(244, 63, 94, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_600 : Css.Style
+placeholder_rose_600 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(225, 29, 72, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(225, 29, 72, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(225, 29, 72, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_700 : Css.Style
+placeholder_rose_700 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 18, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 18, 60, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(190, 18, 60, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_800 : Css.Style
+placeholder_rose_800 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(159, 18, 57, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(159, 18, 57, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(159, 18, 57, var(--tw-placeholder-opacity))"
+            ]
+        ]
+
+
+{-| The tailwind class `placeholder-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+placeholder_rose_900 : Css.Style
+placeholder_rose_900 =
+    Css.batch
+        [ Css.pseudoElement "placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(136, 19, 55, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoClass "-ms-input-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(136, 19, 55, var(--tw-placeholder-opacity))"
+            ]
+        , Css.pseudoElement "-moz-placeholder"
+            [ Css.property "--tw-placeholder-opacity" "1"
+            , Css.property "color" "rgba(136, 19, 55, var(--tw-placeholder-opacity))"
             ]
         ]
 
@@ -47090,136 +51150,6 @@ ring_black =
         ]
 
 
-{-| The tailwind class `ring-blue-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_100 : Css.Style
-ring_blue_100 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(219, 234, 254, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_200 : Css.Style
-ring_blue_200 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(191, 219, 254, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_300 : Css.Style
-ring_blue_300 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(147, 197, 253, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_400 : Css.Style
-ring_blue_400 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(96, 165, 250, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_50 : Css.Style
-ring_blue_50 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(239, 246, 255, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_500 : Css.Style
-ring_blue_500 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(59, 130, 246, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_600 : Css.Style
-ring_blue_600 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(37, 99, 235, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_700 : Css.Style
-ring_blue_700 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(29, 78, 216, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_800 : Css.Style
-ring_blue_800 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(30, 64, 175, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_blue_900 : Css.Style
-ring_blue_900 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(30, 58, 138, var(--tw-ring-opacity))"
-        ]
-
-
 {-| The tailwind class `ring-current`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
@@ -47228,396 +51158,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 ring_current : Css.Style
 ring_current =
     Css.property "--tw-ring-color" "currentColor"
-
-
-{-| The tailwind class `ring-gray-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_100 : Css.Style
-ring_gray_100 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(243, 244, 246, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_200 : Css.Style
-ring_gray_200 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(229, 231, 235, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_300 : Css.Style
-ring_gray_300 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(209, 213, 219, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_400 : Css.Style
-ring_gray_400 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(156, 163, 175, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_50 : Css.Style
-ring_gray_50 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(249, 250, 251, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_500 : Css.Style
-ring_gray_500 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(107, 114, 128, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_600 : Css.Style
-ring_gray_600 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(75, 85, 99, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_700 : Css.Style
-ring_gray_700 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(55, 65, 81, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_800 : Css.Style
-ring_gray_800 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(31, 41, 55, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-gray-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_gray_900 : Css.Style
-ring_gray_900 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(17, 24, 39, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_100 : Css.Style
-ring_green_100 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(209, 250, 229, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_200 : Css.Style
-ring_green_200 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(167, 243, 208, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_300 : Css.Style
-ring_green_300 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(110, 231, 183, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_400 : Css.Style
-ring_green_400 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(52, 211, 153, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_50 : Css.Style
-ring_green_50 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(236, 253, 245, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_500 : Css.Style
-ring_green_500 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(16, 185, 129, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_600 : Css.Style
-ring_green_600 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(5, 150, 105, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_700 : Css.Style
-ring_green_700 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(4, 120, 87, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_800 : Css.Style
-ring_green_800 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(6, 95, 70, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_green_900 : Css.Style
-ring_green_900 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(6, 78, 59, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_100 : Css.Style
-ring_indigo_100 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(224, 231, 255, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_200 : Css.Style
-ring_indigo_200 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(199, 210, 254, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_300 : Css.Style
-ring_indigo_300 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(165, 180, 252, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_400 : Css.Style
-ring_indigo_400 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(129, 140, 248, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_50 : Css.Style
-ring_indigo_50 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(238, 242, 255, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_500 : Css.Style
-ring_indigo_500 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(99, 102, 241, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_600 : Css.Style
-ring_indigo_600 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(79, 70, 229, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_700 : Css.Style
-ring_indigo_700 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(67, 56, 202, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_800 : Css.Style
-ring_indigo_800 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(55, 48, 163, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_indigo_900 : Css.Style
-ring_indigo_900 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(49, 46, 129, var(--tw-ring-opacity))"
-        ]
 
 
 {-| The tailwind class `ring-inset`.
@@ -47690,106 +51230,6 @@ ring_offset_black =
     Css.property "--tw-ring-offset-color" "#000"
 
 
-{-| The tailwind class `ring-offset-blue-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_100 : Css.Style
-ring_offset_blue_100 =
-    Css.property "--tw-ring-offset-color" "#dbeafe"
-
-
-{-| The tailwind class `ring-offset-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_200 : Css.Style
-ring_offset_blue_200 =
-    Css.property "--tw-ring-offset-color" "#bfdbfe"
-
-
-{-| The tailwind class `ring-offset-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_300 : Css.Style
-ring_offset_blue_300 =
-    Css.property "--tw-ring-offset-color" "#93c5fd"
-
-
-{-| The tailwind class `ring-offset-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_400 : Css.Style
-ring_offset_blue_400 =
-    Css.property "--tw-ring-offset-color" "#60a5fa"
-
-
-{-| The tailwind class `ring-offset-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_50 : Css.Style
-ring_offset_blue_50 =
-    Css.property "--tw-ring-offset-color" "#eff6ff"
-
-
-{-| The tailwind class `ring-offset-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_500 : Css.Style
-ring_offset_blue_500 =
-    Css.property "--tw-ring-offset-color" "#3b82f6"
-
-
-{-| The tailwind class `ring-offset-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_600 : Css.Style
-ring_offset_blue_600 =
-    Css.property "--tw-ring-offset-color" "#2563eb"
-
-
-{-| The tailwind class `ring-offset-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_700 : Css.Style
-ring_offset_blue_700 =
-    Css.property "--tw-ring-offset-color" "#1d4ed8"
-
-
-{-| The tailwind class `ring-offset-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_800 : Css.Style
-ring_offset_blue_800 =
-    Css.property "--tw-ring-offset-color" "#1e40af"
-
-
-{-| The tailwind class `ring-offset-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_blue_900 : Css.Style
-ring_offset_blue_900 =
-    Css.property "--tw-ring-offset-color" "#1e3a8a"
-
-
 {-| The tailwind class `ring-offset-current`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
@@ -47798,606 +51238,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 ring_offset_current : Css.Style
 ring_offset_current =
     Css.property "--tw-ring-offset-color" "currentColor"
-
-
-{-| The tailwind class `ring-offset-gray-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_100 : Css.Style
-ring_offset_gray_100 =
-    Css.property "--tw-ring-offset-color" "#f3f4f6"
-
-
-{-| The tailwind class `ring-offset-gray-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_200 : Css.Style
-ring_offset_gray_200 =
-    Css.property "--tw-ring-offset-color" "#e5e7eb"
-
-
-{-| The tailwind class `ring-offset-gray-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_300 : Css.Style
-ring_offset_gray_300 =
-    Css.property "--tw-ring-offset-color" "#d1d5db"
-
-
-{-| The tailwind class `ring-offset-gray-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_400 : Css.Style
-ring_offset_gray_400 =
-    Css.property "--tw-ring-offset-color" "#9ca3af"
-
-
-{-| The tailwind class `ring-offset-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_50 : Css.Style
-ring_offset_gray_50 =
-    Css.property "--tw-ring-offset-color" "#f9fafb"
-
-
-{-| The tailwind class `ring-offset-gray-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_500 : Css.Style
-ring_offset_gray_500 =
-    Css.property "--tw-ring-offset-color" "#6b7280"
-
-
-{-| The tailwind class `ring-offset-gray-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_600 : Css.Style
-ring_offset_gray_600 =
-    Css.property "--tw-ring-offset-color" "#4b5563"
-
-
-{-| The tailwind class `ring-offset-gray-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_700 : Css.Style
-ring_offset_gray_700 =
-    Css.property "--tw-ring-offset-color" "#374151"
-
-
-{-| The tailwind class `ring-offset-gray-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_800 : Css.Style
-ring_offset_gray_800 =
-    Css.property "--tw-ring-offset-color" "#1f2937"
-
-
-{-| The tailwind class `ring-offset-gray-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_gray_900 : Css.Style
-ring_offset_gray_900 =
-    Css.property "--tw-ring-offset-color" "#111827"
-
-
-{-| The tailwind class `ring-offset-green-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_100 : Css.Style
-ring_offset_green_100 =
-    Css.property "--tw-ring-offset-color" "#d1fae5"
-
-
-{-| The tailwind class `ring-offset-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_200 : Css.Style
-ring_offset_green_200 =
-    Css.property "--tw-ring-offset-color" "#a7f3d0"
-
-
-{-| The tailwind class `ring-offset-green-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_300 : Css.Style
-ring_offset_green_300 =
-    Css.property "--tw-ring-offset-color" "#6ee7b7"
-
-
-{-| The tailwind class `ring-offset-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_400 : Css.Style
-ring_offset_green_400 =
-    Css.property "--tw-ring-offset-color" "#34d399"
-
-
-{-| The tailwind class `ring-offset-green-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_50 : Css.Style
-ring_offset_green_50 =
-    Css.property "--tw-ring-offset-color" "#ecfdf5"
-
-
-{-| The tailwind class `ring-offset-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_500 : Css.Style
-ring_offset_green_500 =
-    Css.property "--tw-ring-offset-color" "#10b981"
-
-
-{-| The tailwind class `ring-offset-green-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_600 : Css.Style
-ring_offset_green_600 =
-    Css.property "--tw-ring-offset-color" "#059669"
-
-
-{-| The tailwind class `ring-offset-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_700 : Css.Style
-ring_offset_green_700 =
-    Css.property "--tw-ring-offset-color" "#047857"
-
-
-{-| The tailwind class `ring-offset-green-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_800 : Css.Style
-ring_offset_green_800 =
-    Css.property "--tw-ring-offset-color" "#065f46"
-
-
-{-| The tailwind class `ring-offset-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_green_900 : Css.Style
-ring_offset_green_900 =
-    Css.property "--tw-ring-offset-color" "#064e3b"
-
-
-{-| The tailwind class `ring-offset-indigo-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_100 : Css.Style
-ring_offset_indigo_100 =
-    Css.property "--tw-ring-offset-color" "#e0e7ff"
-
-
-{-| The tailwind class `ring-offset-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_200 : Css.Style
-ring_offset_indigo_200 =
-    Css.property "--tw-ring-offset-color" "#c7d2fe"
-
-
-{-| The tailwind class `ring-offset-indigo-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_300 : Css.Style
-ring_offset_indigo_300 =
-    Css.property "--tw-ring-offset-color" "#a5b4fc"
-
-
-{-| The tailwind class `ring-offset-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_400 : Css.Style
-ring_offset_indigo_400 =
-    Css.property "--tw-ring-offset-color" "#818cf8"
-
-
-{-| The tailwind class `ring-offset-indigo-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_50 : Css.Style
-ring_offset_indigo_50 =
-    Css.property "--tw-ring-offset-color" "#eef2ff"
-
-
-{-| The tailwind class `ring-offset-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_500 : Css.Style
-ring_offset_indigo_500 =
-    Css.property "--tw-ring-offset-color" "#6366f1"
-
-
-{-| The tailwind class `ring-offset-indigo-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_600 : Css.Style
-ring_offset_indigo_600 =
-    Css.property "--tw-ring-offset-color" "#4f46e5"
-
-
-{-| The tailwind class `ring-offset-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_700 : Css.Style
-ring_offset_indigo_700 =
-    Css.property "--tw-ring-offset-color" "#4338ca"
-
-
-{-| The tailwind class `ring-offset-indigo-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_800 : Css.Style
-ring_offset_indigo_800 =
-    Css.property "--tw-ring-offset-color" "#3730a3"
-
-
-{-| The tailwind class `ring-offset-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_indigo_900 : Css.Style
-ring_offset_indigo_900 =
-    Css.property "--tw-ring-offset-color" "#312e81"
-
-
-{-| The tailwind class `ring-offset-pink-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_100 : Css.Style
-ring_offset_pink_100 =
-    Css.property "--tw-ring-offset-color" "#fce7f3"
-
-
-{-| The tailwind class `ring-offset-pink-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_200 : Css.Style
-ring_offset_pink_200 =
-    Css.property "--tw-ring-offset-color" "#fbcfe8"
-
-
-{-| The tailwind class `ring-offset-pink-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_300 : Css.Style
-ring_offset_pink_300 =
-    Css.property "--tw-ring-offset-color" "#f9a8d4"
-
-
-{-| The tailwind class `ring-offset-pink-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_400 : Css.Style
-ring_offset_pink_400 =
-    Css.property "--tw-ring-offset-color" "#f472b6"
-
-
-{-| The tailwind class `ring-offset-pink-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_50 : Css.Style
-ring_offset_pink_50 =
-    Css.property "--tw-ring-offset-color" "#fdf2f8"
-
-
-{-| The tailwind class `ring-offset-pink-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_500 : Css.Style
-ring_offset_pink_500 =
-    Css.property "--tw-ring-offset-color" "#ec4899"
-
-
-{-| The tailwind class `ring-offset-pink-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_600 : Css.Style
-ring_offset_pink_600 =
-    Css.property "--tw-ring-offset-color" "#db2777"
-
-
-{-| The tailwind class `ring-offset-pink-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_700 : Css.Style
-ring_offset_pink_700 =
-    Css.property "--tw-ring-offset-color" "#be185d"
-
-
-{-| The tailwind class `ring-offset-pink-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_800 : Css.Style
-ring_offset_pink_800 =
-    Css.property "--tw-ring-offset-color" "#9d174d"
-
-
-{-| The tailwind class `ring-offset-pink-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_pink_900 : Css.Style
-ring_offset_pink_900 =
-    Css.property "--tw-ring-offset-color" "#831843"
-
-
-{-| The tailwind class `ring-offset-purple-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_100 : Css.Style
-ring_offset_purple_100 =
-    Css.property "--tw-ring-offset-color" "#ede9fe"
-
-
-{-| The tailwind class `ring-offset-purple-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_200 : Css.Style
-ring_offset_purple_200 =
-    Css.property "--tw-ring-offset-color" "#ddd6fe"
-
-
-{-| The tailwind class `ring-offset-purple-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_300 : Css.Style
-ring_offset_purple_300 =
-    Css.property "--tw-ring-offset-color" "#c4b5fd"
-
-
-{-| The tailwind class `ring-offset-purple-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_400 : Css.Style
-ring_offset_purple_400 =
-    Css.property "--tw-ring-offset-color" "#a78bfa"
-
-
-{-| The tailwind class `ring-offset-purple-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_50 : Css.Style
-ring_offset_purple_50 =
-    Css.property "--tw-ring-offset-color" "#f5f3ff"
-
-
-{-| The tailwind class `ring-offset-purple-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_500 : Css.Style
-ring_offset_purple_500 =
-    Css.property "--tw-ring-offset-color" "#8b5cf6"
-
-
-{-| The tailwind class `ring-offset-purple-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_600 : Css.Style
-ring_offset_purple_600 =
-    Css.property "--tw-ring-offset-color" "#7c3aed"
-
-
-{-| The tailwind class `ring-offset-purple-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_700 : Css.Style
-ring_offset_purple_700 =
-    Css.property "--tw-ring-offset-color" "#6d28d9"
-
-
-{-| The tailwind class `ring-offset-purple-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_800 : Css.Style
-ring_offset_purple_800 =
-    Css.property "--tw-ring-offset-color" "#5b21b6"
-
-
-{-| The tailwind class `ring-offset-purple-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_purple_900 : Css.Style
-ring_offset_purple_900 =
-    Css.property "--tw-ring-offset-color" "#4c1d95"
-
-
-{-| The tailwind class `ring-offset-red-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_100 : Css.Style
-ring_offset_red_100 =
-    Css.property "--tw-ring-offset-color" "#fee2e2"
-
-
-{-| The tailwind class `ring-offset-red-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_200 : Css.Style
-ring_offset_red_200 =
-    Css.property "--tw-ring-offset-color" "#fecaca"
-
-
-{-| The tailwind class `ring-offset-red-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_300 : Css.Style
-ring_offset_red_300 =
-    Css.property "--tw-ring-offset-color" "#fca5a5"
-
-
-{-| The tailwind class `ring-offset-red-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_400 : Css.Style
-ring_offset_red_400 =
-    Css.property "--tw-ring-offset-color" "#f87171"
-
-
-{-| The tailwind class `ring-offset-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_50 : Css.Style
-ring_offset_red_50 =
-    Css.property "--tw-ring-offset-color" "#fef2f2"
-
-
-{-| The tailwind class `ring-offset-red-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_500 : Css.Style
-ring_offset_red_500 =
-    Css.property "--tw-ring-offset-color" "#ef4444"
-
-
-{-| The tailwind class `ring-offset-red-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_600 : Css.Style
-ring_offset_red_600 =
-    Css.property "--tw-ring-offset-color" "#dc2626"
-
-
-{-| The tailwind class `ring-offset-red-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_700 : Css.Style
-ring_offset_red_700 =
-    Css.property "--tw-ring-offset-color" "#b91c1c"
-
-
-{-| The tailwind class `ring-offset-red-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_800 : Css.Style
-ring_offset_red_800 =
-    Css.property "--tw-ring-offset-color" "#991b1b"
-
-
-{-| The tailwind class `ring-offset-red-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_red_900 : Css.Style
-ring_offset_red_900 =
-    Css.property "--tw-ring-offset-color" "#7f1d1d"
 
 
 {-| The tailwind class `ring-offset-transparent`.
@@ -48418,106 +51258,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 ring_offset_white : Css.Style
 ring_offset_white =
     Css.property "--tw-ring-offset-color" "#fff"
-
-
-{-| The tailwind class `ring-offset-yellow-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_100 : Css.Style
-ring_offset_yellow_100 =
-    Css.property "--tw-ring-offset-color" "#fef3c7"
-
-
-{-| The tailwind class `ring-offset-yellow-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_200 : Css.Style
-ring_offset_yellow_200 =
-    Css.property "--tw-ring-offset-color" "#fde68a"
-
-
-{-| The tailwind class `ring-offset-yellow-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_300 : Css.Style
-ring_offset_yellow_300 =
-    Css.property "--tw-ring-offset-color" "#fcd34d"
-
-
-{-| The tailwind class `ring-offset-yellow-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_400 : Css.Style
-ring_offset_yellow_400 =
-    Css.property "--tw-ring-offset-color" "#fbbf24"
-
-
-{-| The tailwind class `ring-offset-yellow-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_50 : Css.Style
-ring_offset_yellow_50 =
-    Css.property "--tw-ring-offset-color" "#fffbeb"
-
-
-{-| The tailwind class `ring-offset-yellow-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_500 : Css.Style
-ring_offset_yellow_500 =
-    Css.property "--tw-ring-offset-color" "#f59e0b"
-
-
-{-| The tailwind class `ring-offset-yellow-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_600 : Css.Style
-ring_offset_yellow_600 =
-    Css.property "--tw-ring-offset-color" "#d97706"
-
-
-{-| The tailwind class `ring-offset-yellow-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_700 : Css.Style
-ring_offset_yellow_700 =
-    Css.property "--tw-ring-offset-color" "#b45309"
-
-
-{-| The tailwind class `ring-offset-yellow-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_800 : Css.Style
-ring_offset_yellow_800 =
-    Css.property "--tw-ring-offset-color" "#92400e"
-
-
-{-| The tailwind class `ring-offset-yellow-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_offset_yellow_900 : Css.Style
-ring_offset_yellow_900 =
-    Css.property "--tw-ring-offset-color" "#78350f"
 
 
 {-| The tailwind class `ring-opacity-0`.
@@ -48670,263 +51410,689 @@ ring_opacity_95 =
     Css.property "--tw-ring-opacity" "0.95"
 
 
-{-| The tailwind class `ring-pink-100`.
+{-| The tailwind class `ring-transparent`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_100 : Css.Style
-ring_pink_100 =
+ring_transparent : Css.Style
+ring_transparent =
+    Css.property "--tw-ring-color" "transparent"
+
+
+{-| The tailwind class `ring-white`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_white : Css.Style
+ring_white =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(252, 231, 243, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(255, 255, 255, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-200`.
+{-| The tailwind class `ring-slate-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_200 : Css.Style
-ring_pink_200 =
+ring_slate_50 : Css.Style
+ring_slate_50 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(251, 207, 232, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(248, 250, 252, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-300`.
+{-| The tailwind class `ring-slate-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_300 : Css.Style
-ring_pink_300 =
+ring_slate_100 : Css.Style
+ring_slate_100 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(249, 168, 212, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(241, 245, 249, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-400`.
+{-| The tailwind class `ring-slate-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_400 : Css.Style
-ring_pink_400 =
+ring_slate_200 : Css.Style
+ring_slate_200 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(244, 114, 182, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(226, 232, 240, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-50`.
+{-| The tailwind class `ring-slate-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_50 : Css.Style
-ring_pink_50 =
+ring_slate_300 : Css.Style
+ring_slate_300 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(253, 242, 248, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(203, 213, 225, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-500`.
+{-| The tailwind class `ring-slate-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_500 : Css.Style
-ring_pink_500 =
+ring_slate_400 : Css.Style
+ring_slate_400 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(236, 72, 153, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(148, 163, 184, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-600`.
+{-| The tailwind class `ring-slate-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_600 : Css.Style
-ring_pink_600 =
+ring_slate_500 : Css.Style
+ring_slate_500 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(219, 39, 119, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(100, 116, 139, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-700`.
+{-| The tailwind class `ring-slate-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_700 : Css.Style
-ring_pink_700 =
+ring_slate_600 : Css.Style
+ring_slate_600 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(190, 24, 93, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(71, 85, 105, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-800`.
+{-| The tailwind class `ring-slate-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_800 : Css.Style
-ring_pink_800 =
+ring_slate_700 : Css.Style
+ring_slate_700 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(157, 23, 77, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(51, 65, 85, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-pink-900`.
+{-| The tailwind class `ring-slate-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_pink_900 : Css.Style
-ring_pink_900 =
+ring_slate_800 : Css.Style
+ring_slate_800 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(131, 24, 67, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(30, 41, 59, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-100`.
+{-| The tailwind class `ring-slate-900`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_100 : Css.Style
-ring_purple_100 =
+ring_slate_900 : Css.Style
+ring_slate_900 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(237, 233, 254, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(15, 23, 42, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-200`.
+{-| The tailwind class `ring-gray-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_200 : Css.Style
-ring_purple_200 =
+ring_gray_50 : Css.Style
+ring_gray_50 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(221, 214, 254, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(249, 250, 251, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-300`.
+{-| The tailwind class `ring-gray-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_300 : Css.Style
-ring_purple_300 =
+ring_gray_100 : Css.Style
+ring_gray_100 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(196, 181, 253, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(243, 244, 246, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-400`.
+{-| The tailwind class `ring-gray-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_400 : Css.Style
-ring_purple_400 =
+ring_gray_200 : Css.Style
+ring_gray_200 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(167, 139, 250, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(229, 231, 235, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-50`.
+{-| The tailwind class `ring-gray-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_50 : Css.Style
-ring_purple_50 =
+ring_gray_300 : Css.Style
+ring_gray_300 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(245, 243, 255, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(209, 213, 219, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-500`.
+{-| The tailwind class `ring-gray-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_500 : Css.Style
-ring_purple_500 =
+ring_gray_400 : Css.Style
+ring_gray_400 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(139, 92, 246, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(156, 163, 175, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-600`.
+{-| The tailwind class `ring-gray-500`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_600 : Css.Style
-ring_purple_600 =
+ring_gray_500 : Css.Style
+ring_gray_500 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(124, 58, 237, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(107, 114, 128, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-700`.
+{-| The tailwind class `ring-gray-600`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_700 : Css.Style
-ring_purple_700 =
+ring_gray_600 : Css.Style
+ring_gray_600 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(109, 40, 217, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(75, 85, 99, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-800`.
+{-| The tailwind class `ring-gray-700`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_800 : Css.Style
-ring_purple_800 =
+ring_gray_700 : Css.Style
+ring_gray_700 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(91, 33, 182, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(55, 65, 81, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-purple-900`.
+{-| The tailwind class `ring-gray-800`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_purple_900 : Css.Style
-ring_purple_900 =
+ring_gray_800 : Css.Style
+ring_gray_800 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(76, 29, 149, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(31, 41, 55, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-gray-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_gray_900 : Css.Style
+ring_gray_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(17, 24, 39, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_50 : Css.Style
+ring_zinc_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 250, 250, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_100 : Css.Style
+ring_zinc_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(244, 244, 245, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_200 : Css.Style
+ring_zinc_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(228, 228, 231, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_300 : Css.Style
+ring_zinc_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(212, 212, 216, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_400 : Css.Style
+ring_zinc_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(161, 161, 170, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_500 : Css.Style
+ring_zinc_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(113, 113, 122, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_600 : Css.Style
+ring_zinc_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(82, 82, 91, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_700 : Css.Style
+ring_zinc_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(63, 63, 70, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_800 : Css.Style
+ring_zinc_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(39, 39, 42, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_zinc_900 : Css.Style
+ring_zinc_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(24, 24, 27, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_50 : Css.Style
+ring_neutral_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 250, 250, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_100 : Css.Style
+ring_neutral_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(245, 245, 245, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_200 : Css.Style
+ring_neutral_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(229, 229, 229, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_300 : Css.Style
+ring_neutral_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(212, 212, 212, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_400 : Css.Style
+ring_neutral_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(163, 163, 163, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_500 : Css.Style
+ring_neutral_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(115, 115, 115, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_600 : Css.Style
+ring_neutral_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(82, 82, 82, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_700 : Css.Style
+ring_neutral_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(64, 64, 64, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_800 : Css.Style
+ring_neutral_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(38, 38, 38, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_neutral_900 : Css.Style
+ring_neutral_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(23, 23, 23, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_50 : Css.Style
+ring_stone_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 250, 249, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_100 : Css.Style
+ring_stone_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(245, 245, 244, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_200 : Css.Style
+ring_stone_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(231, 229, 228, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_300 : Css.Style
+ring_stone_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(214, 211, 209, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_400 : Css.Style
+ring_stone_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(168, 162, 158, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_500 : Css.Style
+ring_stone_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(120, 113, 108, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_600 : Css.Style
+ring_stone_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(87, 83, 78, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_700 : Css.Style
+ring_stone_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(68, 64, 60, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_800 : Css.Style
+ring_stone_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(41, 37, 36, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_stone_900 : Css.Style
+ring_stone_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(28, 25, 23, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_red_50 : Css.Style
+ring_red_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(254, 242, 242, var(--tw-ring-opacity))"
         ]
 
 
@@ -48979,19 +52145,6 @@ ring_red_400 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
         , Css.property "--tw-ring-color" "rgba(248, 113, 113, var(--tw-ring-opacity))"
-        ]
-
-
-{-| The tailwind class `ring-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_red_50 : Css.Style
-ring_red_50 =
-    Css.batch
-        [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(254, 242, 242, var(--tw-ring-opacity))"
         ]
 
 
@@ -49060,78 +52213,263 @@ ring_red_900 =
         ]
 
 
-{-| The tailwind class `ring-transparent`.
+{-| The tailwind class `ring-orange-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_transparent : Css.Style
-ring_transparent =
-    Css.property "--tw-ring-color" "transparent"
-
-
-{-| The tailwind class `ring-white`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-ring_white : Css.Style
-ring_white =
+ring_orange_50 : Css.Style
+ring_orange_50 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(255, 255, 255, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(255, 247, 237, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-yellow-100`.
+{-| The tailwind class `ring-orange-100`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_yellow_100 : Css.Style
-ring_yellow_100 =
+ring_orange_100 : Css.Style
+ring_orange_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(255, 237, 213, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_200 : Css.Style
+ring_orange_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(254, 215, 170, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_300 : Css.Style
+ring_orange_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(253, 186, 116, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_400 : Css.Style
+ring_orange_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(251, 146, 60, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_500 : Css.Style
+ring_orange_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(249, 115, 22, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_600 : Css.Style
+ring_orange_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(234, 88, 12, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_700 : Css.Style
+ring_orange_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(194, 65, 12, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_800 : Css.Style
+ring_orange_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(154, 52, 18, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_orange_900 : Css.Style
+ring_orange_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(124, 45, 18, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_50 : Css.Style
+ring_amber_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(255, 251, 235, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_100 : Css.Style
+ring_amber_100 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
         , Css.property "--tw-ring-color" "rgba(254, 243, 199, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-yellow-200`.
+{-| The tailwind class `ring-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_yellow_200 : Css.Style
-ring_yellow_200 =
+ring_amber_200 : Css.Style
+ring_amber_200 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
         , Css.property "--tw-ring-color" "rgba(253, 230, 138, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-yellow-300`.
+{-| The tailwind class `ring-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_yellow_300 : Css.Style
-ring_yellow_300 =
+ring_amber_300 : Css.Style
+ring_amber_300 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
         , Css.property "--tw-ring-color" "rgba(252, 211, 77, var(--tw-ring-opacity))"
         ]
 
 
-{-| The tailwind class `ring-yellow-400`.
+{-| The tailwind class `ring-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-ring_yellow_400 : Css.Style
-ring_yellow_400 =
+ring_amber_400 : Css.Style
+ring_amber_400 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
         , Css.property "--tw-ring-color" "rgba(251, 191, 36, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_500 : Css.Style
+ring_amber_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(245, 158, 11, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_600 : Css.Style
+ring_amber_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(217, 119, 6, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_700 : Css.Style
+ring_amber_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(180, 83, 9, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_800 : Css.Style
+ring_amber_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(146, 64, 14, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_amber_900 : Css.Style
+ring_amber_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(120, 53, 15, var(--tw-ring-opacity))"
         ]
 
 
@@ -49144,7 +52482,59 @@ ring_yellow_50 : Css.Style
 ring_yellow_50 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(255, 251, 235, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(254, 252, 232, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_yellow_100 : Css.Style
+ring_yellow_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(254, 249, 195, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_yellow_200 : Css.Style
+ring_yellow_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(254, 240, 138, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_yellow_300 : Css.Style
+ring_yellow_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(253, 224, 71, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_yellow_400 : Css.Style
+ring_yellow_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 204, 21, var(--tw-ring-opacity))"
         ]
 
 
@@ -49157,7 +52547,7 @@ ring_yellow_500 : Css.Style
 ring_yellow_500 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(245, 158, 11, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(234, 179, 8, var(--tw-ring-opacity))"
         ]
 
 
@@ -49170,7 +52560,7 @@ ring_yellow_600 : Css.Style
 ring_yellow_600 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(217, 119, 6, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(202, 138, 4, var(--tw-ring-opacity))"
         ]
 
 
@@ -49183,7 +52573,7 @@ ring_yellow_700 : Css.Style
 ring_yellow_700 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(180, 83, 9, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(161, 98, 7, var(--tw-ring-opacity))"
         ]
 
 
@@ -49196,7 +52586,7 @@ ring_yellow_800 : Css.Style
 ring_yellow_800 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(146, 64, 14, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(133, 77, 14, var(--tw-ring-opacity))"
         ]
 
 
@@ -49209,8 +52599,3898 @@ ring_yellow_900 : Css.Style
 ring_yellow_900 =
     Css.batch
         [ Css.property "--tw-ring-opacity" "1"
-        , Css.property "--tw-ring-color" "rgba(120, 53, 15, var(--tw-ring-opacity))"
+        , Css.property "--tw-ring-color" "rgba(113, 63, 18, var(--tw-ring-opacity))"
         ]
+
+
+{-| The tailwind class `ring-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_50 : Css.Style
+ring_lime_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(247, 254, 231, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_100 : Css.Style
+ring_lime_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(236, 252, 203, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_200 : Css.Style
+ring_lime_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(217, 249, 157, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_300 : Css.Style
+ring_lime_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(190, 242, 100, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_400 : Css.Style
+ring_lime_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(163, 230, 53, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_500 : Css.Style
+ring_lime_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(132, 204, 22, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_600 : Css.Style
+ring_lime_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(101, 163, 13, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_700 : Css.Style
+ring_lime_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(77, 124, 15, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_800 : Css.Style
+ring_lime_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(63, 98, 18, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_lime_900 : Css.Style
+ring_lime_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(54, 83, 20, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_50 : Css.Style
+ring_green_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(240, 253, 244, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_100 : Css.Style
+ring_green_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(220, 252, 231, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_200 : Css.Style
+ring_green_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(187, 247, 208, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_300 : Css.Style
+ring_green_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(134, 239, 172, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_400 : Css.Style
+ring_green_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(74, 222, 128, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_500 : Css.Style
+ring_green_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(34, 197, 94, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_600 : Css.Style
+ring_green_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(22, 163, 74, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_700 : Css.Style
+ring_green_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(21, 128, 61, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_800 : Css.Style
+ring_green_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(22, 101, 52, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_green_900 : Css.Style
+ring_green_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(20, 83, 45, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_50 : Css.Style
+ring_emerald_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(236, 253, 245, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_100 : Css.Style
+ring_emerald_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(209, 250, 229, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_200 : Css.Style
+ring_emerald_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(167, 243, 208, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_300 : Css.Style
+ring_emerald_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(110, 231, 183, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_400 : Css.Style
+ring_emerald_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(52, 211, 153, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_500 : Css.Style
+ring_emerald_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(16, 185, 129, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_600 : Css.Style
+ring_emerald_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(5, 150, 105, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_700 : Css.Style
+ring_emerald_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(4, 120, 87, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_800 : Css.Style
+ring_emerald_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(6, 95, 70, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_emerald_900 : Css.Style
+ring_emerald_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(6, 78, 59, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_50 : Css.Style
+ring_teal_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(240, 253, 250, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_100 : Css.Style
+ring_teal_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(204, 251, 241, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_200 : Css.Style
+ring_teal_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(153, 246, 228, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_300 : Css.Style
+ring_teal_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(94, 234, 212, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_400 : Css.Style
+ring_teal_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(45, 212, 191, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_500 : Css.Style
+ring_teal_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(20, 184, 166, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_600 : Css.Style
+ring_teal_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(13, 148, 136, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_700 : Css.Style
+ring_teal_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(15, 118, 110, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_800 : Css.Style
+ring_teal_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(17, 94, 89, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_teal_900 : Css.Style
+ring_teal_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(19, 78, 74, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_50 : Css.Style
+ring_cyan_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(236, 254, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_100 : Css.Style
+ring_cyan_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(207, 250, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_200 : Css.Style
+ring_cyan_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(165, 243, 252, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_300 : Css.Style
+ring_cyan_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(103, 232, 249, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_400 : Css.Style
+ring_cyan_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(34, 211, 238, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_500 : Css.Style
+ring_cyan_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(6, 182, 212, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_600 : Css.Style
+ring_cyan_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(8, 145, 178, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_700 : Css.Style
+ring_cyan_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(14, 116, 144, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_800 : Css.Style
+ring_cyan_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(21, 94, 117, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_cyan_900 : Css.Style
+ring_cyan_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(22, 78, 99, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_50 : Css.Style
+ring_sky_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(240, 249, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_100 : Css.Style
+ring_sky_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(224, 242, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_200 : Css.Style
+ring_sky_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(186, 230, 253, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_300 : Css.Style
+ring_sky_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(125, 211, 252, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_400 : Css.Style
+ring_sky_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(56, 189, 248, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_500 : Css.Style
+ring_sky_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(14, 165, 233, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_600 : Css.Style
+ring_sky_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(2, 132, 199, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_700 : Css.Style
+ring_sky_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(3, 105, 161, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_800 : Css.Style
+ring_sky_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(7, 89, 133, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_sky_900 : Css.Style
+ring_sky_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(12, 74, 110, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_50 : Css.Style
+ring_blue_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(239, 246, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_100 : Css.Style
+ring_blue_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(219, 234, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_200 : Css.Style
+ring_blue_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(191, 219, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_300 : Css.Style
+ring_blue_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(147, 197, 253, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_400 : Css.Style
+ring_blue_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(96, 165, 250, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_500 : Css.Style
+ring_blue_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(59, 130, 246, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_600 : Css.Style
+ring_blue_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(37, 99, 235, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_700 : Css.Style
+ring_blue_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(29, 78, 216, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_800 : Css.Style
+ring_blue_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(30, 64, 175, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_blue_900 : Css.Style
+ring_blue_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(30, 58, 138, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_50 : Css.Style
+ring_indigo_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(238, 242, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_100 : Css.Style
+ring_indigo_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(224, 231, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_200 : Css.Style
+ring_indigo_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(199, 210, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_300 : Css.Style
+ring_indigo_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(165, 180, 252, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_400 : Css.Style
+ring_indigo_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(129, 140, 248, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_500 : Css.Style
+ring_indigo_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(99, 102, 241, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_600 : Css.Style
+ring_indigo_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(79, 70, 229, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_700 : Css.Style
+ring_indigo_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(67, 56, 202, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_800 : Css.Style
+ring_indigo_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(55, 48, 163, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_indigo_900 : Css.Style
+ring_indigo_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(49, 46, 129, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_50 : Css.Style
+ring_violet_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(245, 243, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_100 : Css.Style
+ring_violet_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(237, 233, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_200 : Css.Style
+ring_violet_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(221, 214, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_300 : Css.Style
+ring_violet_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(196, 181, 253, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_400 : Css.Style
+ring_violet_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(167, 139, 250, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_500 : Css.Style
+ring_violet_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(139, 92, 246, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_600 : Css.Style
+ring_violet_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(124, 58, 237, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_700 : Css.Style
+ring_violet_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(109, 40, 217, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_800 : Css.Style
+ring_violet_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(91, 33, 182, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_violet_900 : Css.Style
+ring_violet_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(76, 29, 149, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_50 : Css.Style
+ring_purple_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 245, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_100 : Css.Style
+ring_purple_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(243, 232, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_200 : Css.Style
+ring_purple_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(233, 213, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_300 : Css.Style
+ring_purple_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(216, 180, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_400 : Css.Style
+ring_purple_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(192, 132, 252, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_500 : Css.Style
+ring_purple_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(168, 85, 247, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_600 : Css.Style
+ring_purple_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(147, 51, 234, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_700 : Css.Style
+ring_purple_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(126, 34, 206, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_800 : Css.Style
+ring_purple_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(107, 33, 168, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_purple_900 : Css.Style
+ring_purple_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(88, 28, 135, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_50 : Css.Style
+ring_fuchsia_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(253, 244, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_100 : Css.Style
+ring_fuchsia_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(250, 232, 255, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_200 : Css.Style
+ring_fuchsia_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(245, 208, 254, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_300 : Css.Style
+ring_fuchsia_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(240, 171, 252, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_400 : Css.Style
+ring_fuchsia_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(232, 121, 249, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_500 : Css.Style
+ring_fuchsia_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(217, 70, 239, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_600 : Css.Style
+ring_fuchsia_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(192, 38, 211, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_700 : Css.Style
+ring_fuchsia_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(162, 28, 175, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_800 : Css.Style
+ring_fuchsia_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(134, 25, 143, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_fuchsia_900 : Css.Style
+ring_fuchsia_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(112, 26, 117, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_50 : Css.Style
+ring_pink_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(253, 242, 248, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_100 : Css.Style
+ring_pink_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(252, 231, 243, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_200 : Css.Style
+ring_pink_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(251, 207, 232, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_300 : Css.Style
+ring_pink_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(249, 168, 212, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_400 : Css.Style
+ring_pink_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(244, 114, 182, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_500 : Css.Style
+ring_pink_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(236, 72, 153, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_600 : Css.Style
+ring_pink_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(219, 39, 119, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_700 : Css.Style
+ring_pink_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(190, 24, 93, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_800 : Css.Style
+ring_pink_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(157, 23, 77, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_pink_900 : Css.Style
+ring_pink_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(131, 24, 67, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_50 : Css.Style
+ring_rose_50 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(255, 241, 242, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_100 : Css.Style
+ring_rose_100 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(255, 228, 230, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_200 : Css.Style
+ring_rose_200 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(254, 205, 211, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_300 : Css.Style
+ring_rose_300 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(253, 164, 175, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_400 : Css.Style
+ring_rose_400 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(251, 113, 133, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_500 : Css.Style
+ring_rose_500 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(244, 63, 94, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_600 : Css.Style
+ring_rose_600 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(225, 29, 72, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_700 : Css.Style
+ring_rose_700 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(190, 18, 60, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_800 : Css.Style
+ring_rose_800 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(159, 18, 57, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_rose_900 : Css.Style
+ring_rose_900 =
+    Css.batch
+        [ Css.property "--tw-ring-opacity" "1"
+        , Css.property "--tw-ring-color" "rgba(136, 19, 55, var(--tw-ring-opacity))"
+        ]
+
+
+{-| The tailwind class `ring-offset-slate-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_50 : Css.Style
+ring_offset_slate_50 =
+    Css.property "--tw-ring-offset-color" "#f8fafc"
+
+
+{-| The tailwind class `ring-offset-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_100 : Css.Style
+ring_offset_slate_100 =
+    Css.property "--tw-ring-offset-color" "#f1f5f9"
+
+
+{-| The tailwind class `ring-offset-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_200 : Css.Style
+ring_offset_slate_200 =
+    Css.property "--tw-ring-offset-color" "#e2e8f0"
+
+
+{-| The tailwind class `ring-offset-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_300 : Css.Style
+ring_offset_slate_300 =
+    Css.property "--tw-ring-offset-color" "#cbd5e1"
+
+
+{-| The tailwind class `ring-offset-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_400 : Css.Style
+ring_offset_slate_400 =
+    Css.property "--tw-ring-offset-color" "#94a3b8"
+
+
+{-| The tailwind class `ring-offset-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_500 : Css.Style
+ring_offset_slate_500 =
+    Css.property "--tw-ring-offset-color" "#64748b"
+
+
+{-| The tailwind class `ring-offset-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_600 : Css.Style
+ring_offset_slate_600 =
+    Css.property "--tw-ring-offset-color" "#475569"
+
+
+{-| The tailwind class `ring-offset-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_700 : Css.Style
+ring_offset_slate_700 =
+    Css.property "--tw-ring-offset-color" "#334155"
+
+
+{-| The tailwind class `ring-offset-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_800 : Css.Style
+ring_offset_slate_800 =
+    Css.property "--tw-ring-offset-color" "#1e293b"
+
+
+{-| The tailwind class `ring-offset-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_slate_900 : Css.Style
+ring_offset_slate_900 =
+    Css.property "--tw-ring-offset-color" "#0f172a"
+
+
+{-| The tailwind class `ring-offset-gray-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_50 : Css.Style
+ring_offset_gray_50 =
+    Css.property "--tw-ring-offset-color" "#f9fafb"
+
+
+{-| The tailwind class `ring-offset-gray-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_100 : Css.Style
+ring_offset_gray_100 =
+    Css.property "--tw-ring-offset-color" "#f3f4f6"
+
+
+{-| The tailwind class `ring-offset-gray-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_200 : Css.Style
+ring_offset_gray_200 =
+    Css.property "--tw-ring-offset-color" "#e5e7eb"
+
+
+{-| The tailwind class `ring-offset-gray-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_300 : Css.Style
+ring_offset_gray_300 =
+    Css.property "--tw-ring-offset-color" "#d1d5db"
+
+
+{-| The tailwind class `ring-offset-gray-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_400 : Css.Style
+ring_offset_gray_400 =
+    Css.property "--tw-ring-offset-color" "#9ca3af"
+
+
+{-| The tailwind class `ring-offset-gray-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_500 : Css.Style
+ring_offset_gray_500 =
+    Css.property "--tw-ring-offset-color" "#6b7280"
+
+
+{-| The tailwind class `ring-offset-gray-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_600 : Css.Style
+ring_offset_gray_600 =
+    Css.property "--tw-ring-offset-color" "#4b5563"
+
+
+{-| The tailwind class `ring-offset-gray-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_700 : Css.Style
+ring_offset_gray_700 =
+    Css.property "--tw-ring-offset-color" "#374151"
+
+
+{-| The tailwind class `ring-offset-gray-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_800 : Css.Style
+ring_offset_gray_800 =
+    Css.property "--tw-ring-offset-color" "#1f2937"
+
+
+{-| The tailwind class `ring-offset-gray-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_gray_900 : Css.Style
+ring_offset_gray_900 =
+    Css.property "--tw-ring-offset-color" "#111827"
+
+
+{-| The tailwind class `ring-offset-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_50 : Css.Style
+ring_offset_zinc_50 =
+    Css.property "--tw-ring-offset-color" "#fafafa"
+
+
+{-| The tailwind class `ring-offset-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_100 : Css.Style
+ring_offset_zinc_100 =
+    Css.property "--tw-ring-offset-color" "#f4f4f5"
+
+
+{-| The tailwind class `ring-offset-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_200 : Css.Style
+ring_offset_zinc_200 =
+    Css.property "--tw-ring-offset-color" "#e4e4e7"
+
+
+{-| The tailwind class `ring-offset-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_300 : Css.Style
+ring_offset_zinc_300 =
+    Css.property "--tw-ring-offset-color" "#d4d4d8"
+
+
+{-| The tailwind class `ring-offset-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_400 : Css.Style
+ring_offset_zinc_400 =
+    Css.property "--tw-ring-offset-color" "#a1a1aa"
+
+
+{-| The tailwind class `ring-offset-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_500 : Css.Style
+ring_offset_zinc_500 =
+    Css.property "--tw-ring-offset-color" "#71717a"
+
+
+{-| The tailwind class `ring-offset-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_600 : Css.Style
+ring_offset_zinc_600 =
+    Css.property "--tw-ring-offset-color" "#52525b"
+
+
+{-| The tailwind class `ring-offset-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_700 : Css.Style
+ring_offset_zinc_700 =
+    Css.property "--tw-ring-offset-color" "#3f3f46"
+
+
+{-| The tailwind class `ring-offset-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_800 : Css.Style
+ring_offset_zinc_800 =
+    Css.property "--tw-ring-offset-color" "#27272a"
+
+
+{-| The tailwind class `ring-offset-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_zinc_900 : Css.Style
+ring_offset_zinc_900 =
+    Css.property "--tw-ring-offset-color" "#18181b"
+
+
+{-| The tailwind class `ring-offset-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_50 : Css.Style
+ring_offset_neutral_50 =
+    Css.property "--tw-ring-offset-color" "#fafafa"
+
+
+{-| The tailwind class `ring-offset-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_100 : Css.Style
+ring_offset_neutral_100 =
+    Css.property "--tw-ring-offset-color" "#f5f5f5"
+
+
+{-| The tailwind class `ring-offset-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_200 : Css.Style
+ring_offset_neutral_200 =
+    Css.property "--tw-ring-offset-color" "#e5e5e5"
+
+
+{-| The tailwind class `ring-offset-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_300 : Css.Style
+ring_offset_neutral_300 =
+    Css.property "--tw-ring-offset-color" "#d4d4d4"
+
+
+{-| The tailwind class `ring-offset-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_400 : Css.Style
+ring_offset_neutral_400 =
+    Css.property "--tw-ring-offset-color" "#a3a3a3"
+
+
+{-| The tailwind class `ring-offset-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_500 : Css.Style
+ring_offset_neutral_500 =
+    Css.property "--tw-ring-offset-color" "#737373"
+
+
+{-| The tailwind class `ring-offset-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_600 : Css.Style
+ring_offset_neutral_600 =
+    Css.property "--tw-ring-offset-color" "#525252"
+
+
+{-| The tailwind class `ring-offset-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_700 : Css.Style
+ring_offset_neutral_700 =
+    Css.property "--tw-ring-offset-color" "#404040"
+
+
+{-| The tailwind class `ring-offset-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_800 : Css.Style
+ring_offset_neutral_800 =
+    Css.property "--tw-ring-offset-color" "#262626"
+
+
+{-| The tailwind class `ring-offset-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_neutral_900 : Css.Style
+ring_offset_neutral_900 =
+    Css.property "--tw-ring-offset-color" "#171717"
+
+
+{-| The tailwind class `ring-offset-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_50 : Css.Style
+ring_offset_stone_50 =
+    Css.property "--tw-ring-offset-color" "#fafaf9"
+
+
+{-| The tailwind class `ring-offset-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_100 : Css.Style
+ring_offset_stone_100 =
+    Css.property "--tw-ring-offset-color" "#f5f5f4"
+
+
+{-| The tailwind class `ring-offset-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_200 : Css.Style
+ring_offset_stone_200 =
+    Css.property "--tw-ring-offset-color" "#e7e5e4"
+
+
+{-| The tailwind class `ring-offset-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_300 : Css.Style
+ring_offset_stone_300 =
+    Css.property "--tw-ring-offset-color" "#d6d3d1"
+
+
+{-| The tailwind class `ring-offset-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_400 : Css.Style
+ring_offset_stone_400 =
+    Css.property "--tw-ring-offset-color" "#a8a29e"
+
+
+{-| The tailwind class `ring-offset-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_500 : Css.Style
+ring_offset_stone_500 =
+    Css.property "--tw-ring-offset-color" "#78716c"
+
+
+{-| The tailwind class `ring-offset-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_600 : Css.Style
+ring_offset_stone_600 =
+    Css.property "--tw-ring-offset-color" "#57534e"
+
+
+{-| The tailwind class `ring-offset-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_700 : Css.Style
+ring_offset_stone_700 =
+    Css.property "--tw-ring-offset-color" "#44403c"
+
+
+{-| The tailwind class `ring-offset-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_800 : Css.Style
+ring_offset_stone_800 =
+    Css.property "--tw-ring-offset-color" "#292524"
+
+
+{-| The tailwind class `ring-offset-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_stone_900 : Css.Style
+ring_offset_stone_900 =
+    Css.property "--tw-ring-offset-color" "#1c1917"
+
+
+{-| The tailwind class `ring-offset-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_50 : Css.Style
+ring_offset_red_50 =
+    Css.property "--tw-ring-offset-color" "#fef2f2"
+
+
+{-| The tailwind class `ring-offset-red-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_100 : Css.Style
+ring_offset_red_100 =
+    Css.property "--tw-ring-offset-color" "#fee2e2"
+
+
+{-| The tailwind class `ring-offset-red-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_200 : Css.Style
+ring_offset_red_200 =
+    Css.property "--tw-ring-offset-color" "#fecaca"
+
+
+{-| The tailwind class `ring-offset-red-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_300 : Css.Style
+ring_offset_red_300 =
+    Css.property "--tw-ring-offset-color" "#fca5a5"
+
+
+{-| The tailwind class `ring-offset-red-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_400 : Css.Style
+ring_offset_red_400 =
+    Css.property "--tw-ring-offset-color" "#f87171"
+
+
+{-| The tailwind class `ring-offset-red-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_500 : Css.Style
+ring_offset_red_500 =
+    Css.property "--tw-ring-offset-color" "#ef4444"
+
+
+{-| The tailwind class `ring-offset-red-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_600 : Css.Style
+ring_offset_red_600 =
+    Css.property "--tw-ring-offset-color" "#dc2626"
+
+
+{-| The tailwind class `ring-offset-red-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_700 : Css.Style
+ring_offset_red_700 =
+    Css.property "--tw-ring-offset-color" "#b91c1c"
+
+
+{-| The tailwind class `ring-offset-red-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_800 : Css.Style
+ring_offset_red_800 =
+    Css.property "--tw-ring-offset-color" "#991b1b"
+
+
+{-| The tailwind class `ring-offset-red-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_red_900 : Css.Style
+ring_offset_red_900 =
+    Css.property "--tw-ring-offset-color" "#7f1d1d"
+
+
+{-| The tailwind class `ring-offset-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_50 : Css.Style
+ring_offset_orange_50 =
+    Css.property "--tw-ring-offset-color" "#fff7ed"
+
+
+{-| The tailwind class `ring-offset-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_100 : Css.Style
+ring_offset_orange_100 =
+    Css.property "--tw-ring-offset-color" "#ffedd5"
+
+
+{-| The tailwind class `ring-offset-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_200 : Css.Style
+ring_offset_orange_200 =
+    Css.property "--tw-ring-offset-color" "#fed7aa"
+
+
+{-| The tailwind class `ring-offset-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_300 : Css.Style
+ring_offset_orange_300 =
+    Css.property "--tw-ring-offset-color" "#fdba74"
+
+
+{-| The tailwind class `ring-offset-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_400 : Css.Style
+ring_offset_orange_400 =
+    Css.property "--tw-ring-offset-color" "#fb923c"
+
+
+{-| The tailwind class `ring-offset-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_500 : Css.Style
+ring_offset_orange_500 =
+    Css.property "--tw-ring-offset-color" "#f97316"
+
+
+{-| The tailwind class `ring-offset-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_600 : Css.Style
+ring_offset_orange_600 =
+    Css.property "--tw-ring-offset-color" "#ea580c"
+
+
+{-| The tailwind class `ring-offset-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_700 : Css.Style
+ring_offset_orange_700 =
+    Css.property "--tw-ring-offset-color" "#c2410c"
+
+
+{-| The tailwind class `ring-offset-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_800 : Css.Style
+ring_offset_orange_800 =
+    Css.property "--tw-ring-offset-color" "#9a3412"
+
+
+{-| The tailwind class `ring-offset-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_orange_900 : Css.Style
+ring_offset_orange_900 =
+    Css.property "--tw-ring-offset-color" "#7c2d12"
+
+
+{-| The tailwind class `ring-offset-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_50 : Css.Style
+ring_offset_amber_50 =
+    Css.property "--tw-ring-offset-color" "#fffbeb"
+
+
+{-| The tailwind class `ring-offset-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_100 : Css.Style
+ring_offset_amber_100 =
+    Css.property "--tw-ring-offset-color" "#fef3c7"
+
+
+{-| The tailwind class `ring-offset-amber-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_200 : Css.Style
+ring_offset_amber_200 =
+    Css.property "--tw-ring-offset-color" "#fde68a"
+
+
+{-| The tailwind class `ring-offset-amber-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_300 : Css.Style
+ring_offset_amber_300 =
+    Css.property "--tw-ring-offset-color" "#fcd34d"
+
+
+{-| The tailwind class `ring-offset-amber-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_400 : Css.Style
+ring_offset_amber_400 =
+    Css.property "--tw-ring-offset-color" "#fbbf24"
+
+
+{-| The tailwind class `ring-offset-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_500 : Css.Style
+ring_offset_amber_500 =
+    Css.property "--tw-ring-offset-color" "#f59e0b"
+
+
+{-| The tailwind class `ring-offset-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_600 : Css.Style
+ring_offset_amber_600 =
+    Css.property "--tw-ring-offset-color" "#d97706"
+
+
+{-| The tailwind class `ring-offset-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_700 : Css.Style
+ring_offset_amber_700 =
+    Css.property "--tw-ring-offset-color" "#b45309"
+
+
+{-| The tailwind class `ring-offset-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_800 : Css.Style
+ring_offset_amber_800 =
+    Css.property "--tw-ring-offset-color" "#92400e"
+
+
+{-| The tailwind class `ring-offset-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_amber_900 : Css.Style
+ring_offset_amber_900 =
+    Css.property "--tw-ring-offset-color" "#78350f"
+
+
+{-| The tailwind class `ring-offset-yellow-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_50 : Css.Style
+ring_offset_yellow_50 =
+    Css.property "--tw-ring-offset-color" "#fefce8"
+
+
+{-| The tailwind class `ring-offset-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_100 : Css.Style
+ring_offset_yellow_100 =
+    Css.property "--tw-ring-offset-color" "#fef9c3"
+
+
+{-| The tailwind class `ring-offset-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_200 : Css.Style
+ring_offset_yellow_200 =
+    Css.property "--tw-ring-offset-color" "#fef08a"
+
+
+{-| The tailwind class `ring-offset-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_300 : Css.Style
+ring_offset_yellow_300 =
+    Css.property "--tw-ring-offset-color" "#fde047"
+
+
+{-| The tailwind class `ring-offset-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_400 : Css.Style
+ring_offset_yellow_400 =
+    Css.property "--tw-ring-offset-color" "#facc15"
+
+
+{-| The tailwind class `ring-offset-yellow-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_500 : Css.Style
+ring_offset_yellow_500 =
+    Css.property "--tw-ring-offset-color" "#eab308"
+
+
+{-| The tailwind class `ring-offset-yellow-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_600 : Css.Style
+ring_offset_yellow_600 =
+    Css.property "--tw-ring-offset-color" "#ca8a04"
+
+
+{-| The tailwind class `ring-offset-yellow-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_700 : Css.Style
+ring_offset_yellow_700 =
+    Css.property "--tw-ring-offset-color" "#a16207"
+
+
+{-| The tailwind class `ring-offset-yellow-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_800 : Css.Style
+ring_offset_yellow_800 =
+    Css.property "--tw-ring-offset-color" "#854d0e"
+
+
+{-| The tailwind class `ring-offset-yellow-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_yellow_900 : Css.Style
+ring_offset_yellow_900 =
+    Css.property "--tw-ring-offset-color" "#713f12"
+
+
+{-| The tailwind class `ring-offset-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_50 : Css.Style
+ring_offset_lime_50 =
+    Css.property "--tw-ring-offset-color" "#f7fee7"
+
+
+{-| The tailwind class `ring-offset-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_100 : Css.Style
+ring_offset_lime_100 =
+    Css.property "--tw-ring-offset-color" "#ecfccb"
+
+
+{-| The tailwind class `ring-offset-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_200 : Css.Style
+ring_offset_lime_200 =
+    Css.property "--tw-ring-offset-color" "#d9f99d"
+
+
+{-| The tailwind class `ring-offset-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_300 : Css.Style
+ring_offset_lime_300 =
+    Css.property "--tw-ring-offset-color" "#bef264"
+
+
+{-| The tailwind class `ring-offset-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_400 : Css.Style
+ring_offset_lime_400 =
+    Css.property "--tw-ring-offset-color" "#a3e635"
+
+
+{-| The tailwind class `ring-offset-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_500 : Css.Style
+ring_offset_lime_500 =
+    Css.property "--tw-ring-offset-color" "#84cc16"
+
+
+{-| The tailwind class `ring-offset-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_600 : Css.Style
+ring_offset_lime_600 =
+    Css.property "--tw-ring-offset-color" "#65a30d"
+
+
+{-| The tailwind class `ring-offset-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_700 : Css.Style
+ring_offset_lime_700 =
+    Css.property "--tw-ring-offset-color" "#4d7c0f"
+
+
+{-| The tailwind class `ring-offset-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_800 : Css.Style
+ring_offset_lime_800 =
+    Css.property "--tw-ring-offset-color" "#3f6212"
+
+
+{-| The tailwind class `ring-offset-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_lime_900 : Css.Style
+ring_offset_lime_900 =
+    Css.property "--tw-ring-offset-color" "#365314"
+
+
+{-| The tailwind class `ring-offset-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_50 : Css.Style
+ring_offset_green_50 =
+    Css.property "--tw-ring-offset-color" "#f0fdf4"
+
+
+{-| The tailwind class `ring-offset-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_100 : Css.Style
+ring_offset_green_100 =
+    Css.property "--tw-ring-offset-color" "#dcfce7"
+
+
+{-| The tailwind class `ring-offset-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_200 : Css.Style
+ring_offset_green_200 =
+    Css.property "--tw-ring-offset-color" "#bbf7d0"
+
+
+{-| The tailwind class `ring-offset-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_300 : Css.Style
+ring_offset_green_300 =
+    Css.property "--tw-ring-offset-color" "#86efac"
+
+
+{-| The tailwind class `ring-offset-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_400 : Css.Style
+ring_offset_green_400 =
+    Css.property "--tw-ring-offset-color" "#4ade80"
+
+
+{-| The tailwind class `ring-offset-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_500 : Css.Style
+ring_offset_green_500 =
+    Css.property "--tw-ring-offset-color" "#22c55e"
+
+
+{-| The tailwind class `ring-offset-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_600 : Css.Style
+ring_offset_green_600 =
+    Css.property "--tw-ring-offset-color" "#16a34a"
+
+
+{-| The tailwind class `ring-offset-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_700 : Css.Style
+ring_offset_green_700 =
+    Css.property "--tw-ring-offset-color" "#15803d"
+
+
+{-| The tailwind class `ring-offset-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_800 : Css.Style
+ring_offset_green_800 =
+    Css.property "--tw-ring-offset-color" "#166534"
+
+
+{-| The tailwind class `ring-offset-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_green_900 : Css.Style
+ring_offset_green_900 =
+    Css.property "--tw-ring-offset-color" "#14532d"
+
+
+{-| The tailwind class `ring-offset-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_50 : Css.Style
+ring_offset_emerald_50 =
+    Css.property "--tw-ring-offset-color" "#ecfdf5"
+
+
+{-| The tailwind class `ring-offset-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_100 : Css.Style
+ring_offset_emerald_100 =
+    Css.property "--tw-ring-offset-color" "#d1fae5"
+
+
+{-| The tailwind class `ring-offset-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_200 : Css.Style
+ring_offset_emerald_200 =
+    Css.property "--tw-ring-offset-color" "#a7f3d0"
+
+
+{-| The tailwind class `ring-offset-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_300 : Css.Style
+ring_offset_emerald_300 =
+    Css.property "--tw-ring-offset-color" "#6ee7b7"
+
+
+{-| The tailwind class `ring-offset-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_400 : Css.Style
+ring_offset_emerald_400 =
+    Css.property "--tw-ring-offset-color" "#34d399"
+
+
+{-| The tailwind class `ring-offset-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_500 : Css.Style
+ring_offset_emerald_500 =
+    Css.property "--tw-ring-offset-color" "#10b981"
+
+
+{-| The tailwind class `ring-offset-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_600 : Css.Style
+ring_offset_emerald_600 =
+    Css.property "--tw-ring-offset-color" "#059669"
+
+
+{-| The tailwind class `ring-offset-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_700 : Css.Style
+ring_offset_emerald_700 =
+    Css.property "--tw-ring-offset-color" "#047857"
+
+
+{-| The tailwind class `ring-offset-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_800 : Css.Style
+ring_offset_emerald_800 =
+    Css.property "--tw-ring-offset-color" "#065f46"
+
+
+{-| The tailwind class `ring-offset-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_emerald_900 : Css.Style
+ring_offset_emerald_900 =
+    Css.property "--tw-ring-offset-color" "#064e3b"
+
+
+{-| The tailwind class `ring-offset-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_50 : Css.Style
+ring_offset_teal_50 =
+    Css.property "--tw-ring-offset-color" "#f0fdfa"
+
+
+{-| The tailwind class `ring-offset-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_100 : Css.Style
+ring_offset_teal_100 =
+    Css.property "--tw-ring-offset-color" "#ccfbf1"
+
+
+{-| The tailwind class `ring-offset-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_200 : Css.Style
+ring_offset_teal_200 =
+    Css.property "--tw-ring-offset-color" "#99f6e4"
+
+
+{-| The tailwind class `ring-offset-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_300 : Css.Style
+ring_offset_teal_300 =
+    Css.property "--tw-ring-offset-color" "#5eead4"
+
+
+{-| The tailwind class `ring-offset-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_400 : Css.Style
+ring_offset_teal_400 =
+    Css.property "--tw-ring-offset-color" "#2dd4bf"
+
+
+{-| The tailwind class `ring-offset-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_500 : Css.Style
+ring_offset_teal_500 =
+    Css.property "--tw-ring-offset-color" "#14b8a6"
+
+
+{-| The tailwind class `ring-offset-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_600 : Css.Style
+ring_offset_teal_600 =
+    Css.property "--tw-ring-offset-color" "#0d9488"
+
+
+{-| The tailwind class `ring-offset-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_700 : Css.Style
+ring_offset_teal_700 =
+    Css.property "--tw-ring-offset-color" "#0f766e"
+
+
+{-| The tailwind class `ring-offset-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_800 : Css.Style
+ring_offset_teal_800 =
+    Css.property "--tw-ring-offset-color" "#115e59"
+
+
+{-| The tailwind class `ring-offset-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_teal_900 : Css.Style
+ring_offset_teal_900 =
+    Css.property "--tw-ring-offset-color" "#134e4a"
+
+
+{-| The tailwind class `ring-offset-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_50 : Css.Style
+ring_offset_cyan_50 =
+    Css.property "--tw-ring-offset-color" "#ecfeff"
+
+
+{-| The tailwind class `ring-offset-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_100 : Css.Style
+ring_offset_cyan_100 =
+    Css.property "--tw-ring-offset-color" "#cffafe"
+
+
+{-| The tailwind class `ring-offset-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_200 : Css.Style
+ring_offset_cyan_200 =
+    Css.property "--tw-ring-offset-color" "#a5f3fc"
+
+
+{-| The tailwind class `ring-offset-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_300 : Css.Style
+ring_offset_cyan_300 =
+    Css.property "--tw-ring-offset-color" "#67e8f9"
+
+
+{-| The tailwind class `ring-offset-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_400 : Css.Style
+ring_offset_cyan_400 =
+    Css.property "--tw-ring-offset-color" "#22d3ee"
+
+
+{-| The tailwind class `ring-offset-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_500 : Css.Style
+ring_offset_cyan_500 =
+    Css.property "--tw-ring-offset-color" "#06b6d4"
+
+
+{-| The tailwind class `ring-offset-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_600 : Css.Style
+ring_offset_cyan_600 =
+    Css.property "--tw-ring-offset-color" "#0891b2"
+
+
+{-| The tailwind class `ring-offset-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_700 : Css.Style
+ring_offset_cyan_700 =
+    Css.property "--tw-ring-offset-color" "#0e7490"
+
+
+{-| The tailwind class `ring-offset-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_800 : Css.Style
+ring_offset_cyan_800 =
+    Css.property "--tw-ring-offset-color" "#155e75"
+
+
+{-| The tailwind class `ring-offset-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_cyan_900 : Css.Style
+ring_offset_cyan_900 =
+    Css.property "--tw-ring-offset-color" "#164e63"
+
+
+{-| The tailwind class `ring-offset-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_50 : Css.Style
+ring_offset_sky_50 =
+    Css.property "--tw-ring-offset-color" "#f0f9ff"
+
+
+{-| The tailwind class `ring-offset-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_100 : Css.Style
+ring_offset_sky_100 =
+    Css.property "--tw-ring-offset-color" "#e0f2fe"
+
+
+{-| The tailwind class `ring-offset-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_200 : Css.Style
+ring_offset_sky_200 =
+    Css.property "--tw-ring-offset-color" "#bae6fd"
+
+
+{-| The tailwind class `ring-offset-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_300 : Css.Style
+ring_offset_sky_300 =
+    Css.property "--tw-ring-offset-color" "#7dd3fc"
+
+
+{-| The tailwind class `ring-offset-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_400 : Css.Style
+ring_offset_sky_400 =
+    Css.property "--tw-ring-offset-color" "#38bdf8"
+
+
+{-| The tailwind class `ring-offset-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_500 : Css.Style
+ring_offset_sky_500 =
+    Css.property "--tw-ring-offset-color" "#0ea5e9"
+
+
+{-| The tailwind class `ring-offset-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_600 : Css.Style
+ring_offset_sky_600 =
+    Css.property "--tw-ring-offset-color" "#0284c7"
+
+
+{-| The tailwind class `ring-offset-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_700 : Css.Style
+ring_offset_sky_700 =
+    Css.property "--tw-ring-offset-color" "#0369a1"
+
+
+{-| The tailwind class `ring-offset-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_800 : Css.Style
+ring_offset_sky_800 =
+    Css.property "--tw-ring-offset-color" "#075985"
+
+
+{-| The tailwind class `ring-offset-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_sky_900 : Css.Style
+ring_offset_sky_900 =
+    Css.property "--tw-ring-offset-color" "#0c4a6e"
+
+
+{-| The tailwind class `ring-offset-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_50 : Css.Style
+ring_offset_blue_50 =
+    Css.property "--tw-ring-offset-color" "#eff6ff"
+
+
+{-| The tailwind class `ring-offset-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_100 : Css.Style
+ring_offset_blue_100 =
+    Css.property "--tw-ring-offset-color" "#dbeafe"
+
+
+{-| The tailwind class `ring-offset-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_200 : Css.Style
+ring_offset_blue_200 =
+    Css.property "--tw-ring-offset-color" "#bfdbfe"
+
+
+{-| The tailwind class `ring-offset-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_300 : Css.Style
+ring_offset_blue_300 =
+    Css.property "--tw-ring-offset-color" "#93c5fd"
+
+
+{-| The tailwind class `ring-offset-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_400 : Css.Style
+ring_offset_blue_400 =
+    Css.property "--tw-ring-offset-color" "#60a5fa"
+
+
+{-| The tailwind class `ring-offset-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_500 : Css.Style
+ring_offset_blue_500 =
+    Css.property "--tw-ring-offset-color" "#3b82f6"
+
+
+{-| The tailwind class `ring-offset-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_600 : Css.Style
+ring_offset_blue_600 =
+    Css.property "--tw-ring-offset-color" "#2563eb"
+
+
+{-| The tailwind class `ring-offset-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_700 : Css.Style
+ring_offset_blue_700 =
+    Css.property "--tw-ring-offset-color" "#1d4ed8"
+
+
+{-| The tailwind class `ring-offset-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_800 : Css.Style
+ring_offset_blue_800 =
+    Css.property "--tw-ring-offset-color" "#1e40af"
+
+
+{-| The tailwind class `ring-offset-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_blue_900 : Css.Style
+ring_offset_blue_900 =
+    Css.property "--tw-ring-offset-color" "#1e3a8a"
+
+
+{-| The tailwind class `ring-offset-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_50 : Css.Style
+ring_offset_indigo_50 =
+    Css.property "--tw-ring-offset-color" "#eef2ff"
+
+
+{-| The tailwind class `ring-offset-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_100 : Css.Style
+ring_offset_indigo_100 =
+    Css.property "--tw-ring-offset-color" "#e0e7ff"
+
+
+{-| The tailwind class `ring-offset-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_200 : Css.Style
+ring_offset_indigo_200 =
+    Css.property "--tw-ring-offset-color" "#c7d2fe"
+
+
+{-| The tailwind class `ring-offset-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_300 : Css.Style
+ring_offset_indigo_300 =
+    Css.property "--tw-ring-offset-color" "#a5b4fc"
+
+
+{-| The tailwind class `ring-offset-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_400 : Css.Style
+ring_offset_indigo_400 =
+    Css.property "--tw-ring-offset-color" "#818cf8"
+
+
+{-| The tailwind class `ring-offset-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_500 : Css.Style
+ring_offset_indigo_500 =
+    Css.property "--tw-ring-offset-color" "#6366f1"
+
+
+{-| The tailwind class `ring-offset-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_600 : Css.Style
+ring_offset_indigo_600 =
+    Css.property "--tw-ring-offset-color" "#4f46e5"
+
+
+{-| The tailwind class `ring-offset-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_700 : Css.Style
+ring_offset_indigo_700 =
+    Css.property "--tw-ring-offset-color" "#4338ca"
+
+
+{-| The tailwind class `ring-offset-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_800 : Css.Style
+ring_offset_indigo_800 =
+    Css.property "--tw-ring-offset-color" "#3730a3"
+
+
+{-| The tailwind class `ring-offset-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_indigo_900 : Css.Style
+ring_offset_indigo_900 =
+    Css.property "--tw-ring-offset-color" "#312e81"
+
+
+{-| The tailwind class `ring-offset-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_50 : Css.Style
+ring_offset_violet_50 =
+    Css.property "--tw-ring-offset-color" "#f5f3ff"
+
+
+{-| The tailwind class `ring-offset-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_100 : Css.Style
+ring_offset_violet_100 =
+    Css.property "--tw-ring-offset-color" "#ede9fe"
+
+
+{-| The tailwind class `ring-offset-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_200 : Css.Style
+ring_offset_violet_200 =
+    Css.property "--tw-ring-offset-color" "#ddd6fe"
+
+
+{-| The tailwind class `ring-offset-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_300 : Css.Style
+ring_offset_violet_300 =
+    Css.property "--tw-ring-offset-color" "#c4b5fd"
+
+
+{-| The tailwind class `ring-offset-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_400 : Css.Style
+ring_offset_violet_400 =
+    Css.property "--tw-ring-offset-color" "#a78bfa"
+
+
+{-| The tailwind class `ring-offset-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_500 : Css.Style
+ring_offset_violet_500 =
+    Css.property "--tw-ring-offset-color" "#8b5cf6"
+
+
+{-| The tailwind class `ring-offset-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_600 : Css.Style
+ring_offset_violet_600 =
+    Css.property "--tw-ring-offset-color" "#7c3aed"
+
+
+{-| The tailwind class `ring-offset-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_700 : Css.Style
+ring_offset_violet_700 =
+    Css.property "--tw-ring-offset-color" "#6d28d9"
+
+
+{-| The tailwind class `ring-offset-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_800 : Css.Style
+ring_offset_violet_800 =
+    Css.property "--tw-ring-offset-color" "#5b21b6"
+
+
+{-| The tailwind class `ring-offset-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_violet_900 : Css.Style
+ring_offset_violet_900 =
+    Css.property "--tw-ring-offset-color" "#4c1d95"
+
+
+{-| The tailwind class `ring-offset-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_50 : Css.Style
+ring_offset_purple_50 =
+    Css.property "--tw-ring-offset-color" "#faf5ff"
+
+
+{-| The tailwind class `ring-offset-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_100 : Css.Style
+ring_offset_purple_100 =
+    Css.property "--tw-ring-offset-color" "#f3e8ff"
+
+
+{-| The tailwind class `ring-offset-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_200 : Css.Style
+ring_offset_purple_200 =
+    Css.property "--tw-ring-offset-color" "#e9d5ff"
+
+
+{-| The tailwind class `ring-offset-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_300 : Css.Style
+ring_offset_purple_300 =
+    Css.property "--tw-ring-offset-color" "#d8b4fe"
+
+
+{-| The tailwind class `ring-offset-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_400 : Css.Style
+ring_offset_purple_400 =
+    Css.property "--tw-ring-offset-color" "#c084fc"
+
+
+{-| The tailwind class `ring-offset-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_500 : Css.Style
+ring_offset_purple_500 =
+    Css.property "--tw-ring-offset-color" "#a855f7"
+
+
+{-| The tailwind class `ring-offset-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_600 : Css.Style
+ring_offset_purple_600 =
+    Css.property "--tw-ring-offset-color" "#9333ea"
+
+
+{-| The tailwind class `ring-offset-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_700 : Css.Style
+ring_offset_purple_700 =
+    Css.property "--tw-ring-offset-color" "#7e22ce"
+
+
+{-| The tailwind class `ring-offset-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_800 : Css.Style
+ring_offset_purple_800 =
+    Css.property "--tw-ring-offset-color" "#6b21a8"
+
+
+{-| The tailwind class `ring-offset-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_purple_900 : Css.Style
+ring_offset_purple_900 =
+    Css.property "--tw-ring-offset-color" "#581c87"
+
+
+{-| The tailwind class `ring-offset-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_50 : Css.Style
+ring_offset_fuchsia_50 =
+    Css.property "--tw-ring-offset-color" "#fdf4ff"
+
+
+{-| The tailwind class `ring-offset-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_100 : Css.Style
+ring_offset_fuchsia_100 =
+    Css.property "--tw-ring-offset-color" "#fae8ff"
+
+
+{-| The tailwind class `ring-offset-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_200 : Css.Style
+ring_offset_fuchsia_200 =
+    Css.property "--tw-ring-offset-color" "#f5d0fe"
+
+
+{-| The tailwind class `ring-offset-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_300 : Css.Style
+ring_offset_fuchsia_300 =
+    Css.property "--tw-ring-offset-color" "#f0abfc"
+
+
+{-| The tailwind class `ring-offset-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_400 : Css.Style
+ring_offset_fuchsia_400 =
+    Css.property "--tw-ring-offset-color" "#e879f9"
+
+
+{-| The tailwind class `ring-offset-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_500 : Css.Style
+ring_offset_fuchsia_500 =
+    Css.property "--tw-ring-offset-color" "#d946ef"
+
+
+{-| The tailwind class `ring-offset-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_600 : Css.Style
+ring_offset_fuchsia_600 =
+    Css.property "--tw-ring-offset-color" "#c026d3"
+
+
+{-| The tailwind class `ring-offset-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_700 : Css.Style
+ring_offset_fuchsia_700 =
+    Css.property "--tw-ring-offset-color" "#a21caf"
+
+
+{-| The tailwind class `ring-offset-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_800 : Css.Style
+ring_offset_fuchsia_800 =
+    Css.property "--tw-ring-offset-color" "#86198f"
+
+
+{-| The tailwind class `ring-offset-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_fuchsia_900 : Css.Style
+ring_offset_fuchsia_900 =
+    Css.property "--tw-ring-offset-color" "#701a75"
+
+
+{-| The tailwind class `ring-offset-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_50 : Css.Style
+ring_offset_pink_50 =
+    Css.property "--tw-ring-offset-color" "#fdf2f8"
+
+
+{-| The tailwind class `ring-offset-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_100 : Css.Style
+ring_offset_pink_100 =
+    Css.property "--tw-ring-offset-color" "#fce7f3"
+
+
+{-| The tailwind class `ring-offset-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_200 : Css.Style
+ring_offset_pink_200 =
+    Css.property "--tw-ring-offset-color" "#fbcfe8"
+
+
+{-| The tailwind class `ring-offset-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_300 : Css.Style
+ring_offset_pink_300 =
+    Css.property "--tw-ring-offset-color" "#f9a8d4"
+
+
+{-| The tailwind class `ring-offset-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_400 : Css.Style
+ring_offset_pink_400 =
+    Css.property "--tw-ring-offset-color" "#f472b6"
+
+
+{-| The tailwind class `ring-offset-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_500 : Css.Style
+ring_offset_pink_500 =
+    Css.property "--tw-ring-offset-color" "#ec4899"
+
+
+{-| The tailwind class `ring-offset-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_600 : Css.Style
+ring_offset_pink_600 =
+    Css.property "--tw-ring-offset-color" "#db2777"
+
+
+{-| The tailwind class `ring-offset-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_700 : Css.Style
+ring_offset_pink_700 =
+    Css.property "--tw-ring-offset-color" "#be185d"
+
+
+{-| The tailwind class `ring-offset-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_800 : Css.Style
+ring_offset_pink_800 =
+    Css.property "--tw-ring-offset-color" "#9d174d"
+
+
+{-| The tailwind class `ring-offset-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_pink_900 : Css.Style
+ring_offset_pink_900 =
+    Css.property "--tw-ring-offset-color" "#831843"
+
+
+{-| The tailwind class `ring-offset-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_50 : Css.Style
+ring_offset_rose_50 =
+    Css.property "--tw-ring-offset-color" "#fff1f2"
+
+
+{-| The tailwind class `ring-offset-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_100 : Css.Style
+ring_offset_rose_100 =
+    Css.property "--tw-ring-offset-color" "#ffe4e6"
+
+
+{-| The tailwind class `ring-offset-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_200 : Css.Style
+ring_offset_rose_200 =
+    Css.property "--tw-ring-offset-color" "#fecdd3"
+
+
+{-| The tailwind class `ring-offset-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_300 : Css.Style
+ring_offset_rose_300 =
+    Css.property "--tw-ring-offset-color" "#fda4af"
+
+
+{-| The tailwind class `ring-offset-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_400 : Css.Style
+ring_offset_rose_400 =
+    Css.property "--tw-ring-offset-color" "#fb7185"
+
+
+{-| The tailwind class `ring-offset-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_500 : Css.Style
+ring_offset_rose_500 =
+    Css.property "--tw-ring-offset-color" "#f43f5e"
+
+
+{-| The tailwind class `ring-offset-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_600 : Css.Style
+ring_offset_rose_600 =
+    Css.property "--tw-ring-offset-color" "#e11d48"
+
+
+{-| The tailwind class `ring-offset-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_700 : Css.Style
+ring_offset_rose_700 =
+    Css.property "--tw-ring-offset-color" "#be123c"
+
+
+{-| The tailwind class `ring-offset-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_800 : Css.Style
+ring_offset_rose_800 =
+    Css.property "--tw-ring-offset-color" "#9f1239"
+
+
+{-| The tailwind class `ring-offset-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+ring_offset_rose_900 : Css.Style
+ring_offset_rose_900 =
+    Css.property "--tw-ring-offset-color" "#881337"
 
 
 {-| The tailwind class `rotate-0`.

--- a/src/Tailwind/Utilities.elm
+++ b/src/Tailwind/Utilities.elm
@@ -4605,6 +4605,146 @@ module Tailwind.Utilities exposing
     , to_rose_700
     , to_rose_800
     , to_rose_900
+    , text_slate_50
+    , text_slate_100
+    , text_slate_200
+    , text_slate_300
+    , text_slate_400
+    , text_slate_500
+    , text_slate_600
+    , text_slate_700
+    , text_slate_800
+    , text_slate_900
+    , text_zinc_50
+    , text_zinc_100
+    , text_zinc_200
+    , text_zinc_300
+    , text_zinc_400
+    , text_zinc_500
+    , text_zinc_600
+    , text_zinc_700
+    , text_zinc_800
+    , text_zinc_900
+    , text_neutral_50
+    , text_neutral_100
+    , text_neutral_200
+    , text_neutral_300
+    , text_neutral_400
+    , text_neutral_500
+    , text_neutral_600
+    , text_neutral_700
+    , text_neutral_800
+    , text_neutral_900
+    , text_stone_50
+    , text_stone_100
+    , text_stone_200
+    , text_stone_300
+    , text_stone_400
+    , text_stone_500
+    , text_stone_600
+    , text_stone_700
+    , text_stone_800
+    , text_stone_900
+    , text_orange_50
+    , text_orange_100
+    , text_orange_200
+    , text_orange_300
+    , text_orange_400
+    , text_orange_500
+    , text_orange_600
+    , text_orange_700
+    , text_orange_800
+    , text_orange_900
+    , text_amber_50
+    , text_amber_100
+    , text_amber_200
+    , text_amber_300
+    , text_amber_400
+    , text_amber_500
+    , text_amber_600
+    , text_amber_700
+    , text_amber_800
+    , text_amber_900
+    , text_lime_50
+    , text_lime_100
+    , text_lime_200
+    , text_lime_300
+    , text_lime_400
+    , text_lime_500
+    , text_lime_600
+    , text_lime_700
+    , text_lime_800
+    , text_lime_900
+    , text_emerald_50
+    , text_emerald_100
+    , text_emerald_200
+    , text_emerald_300
+    , text_emerald_400
+    , text_emerald_500
+    , text_emerald_600
+    , text_emerald_700
+    , text_emerald_800
+    , text_emerald_900
+    , text_teal_50
+    , text_teal_100
+    , text_teal_200
+    , text_teal_300
+    , text_teal_400
+    , text_teal_500
+    , text_teal_600
+    , text_teal_700
+    , text_teal_800
+    , text_teal_900
+    , text_cyan_50
+    , text_cyan_100
+    , text_cyan_200
+    , text_cyan_300
+    , text_cyan_400
+    , text_cyan_500
+    , text_cyan_600
+    , text_cyan_700
+    , text_cyan_800
+    , text_cyan_900
+    , text_sky_50
+    , text_sky_100
+    , text_sky_200
+    , text_sky_300
+    , text_sky_400
+    , text_sky_500
+    , text_sky_600
+    , text_sky_700
+    , text_sky_800
+    , text_sky_900
+    , text_violet_50
+    , text_violet_100
+    , text_violet_200
+    , text_violet_300
+    , text_violet_400
+    , text_violet_500
+    , text_violet_600
+    , text_violet_700
+    , text_violet_800
+    , text_violet_900
+    , text_fuchsia_50
+    , text_fuchsia_100
+    , text_fuchsia_200
+    , text_fuchsia_300
+    , text_fuchsia_400
+    , text_fuchsia_500
+    , text_fuchsia_600
+    , text_fuchsia_700
+    , text_fuchsia_800
+    , text_fuchsia_900
+    , text_rose_50
+    , text_rose_100
+    , text_rose_200
+    , text_rose_300
+    , text_rose_400
+    , text_rose_500
+    , text_rose_600
+    , text_rose_700
+    , text_rose_800
+    , text_rose_900
     )
 
 {-|
@@ -9226,6 +9366,226 @@ This module contains
 @docs to_rose_700
 @docs to_rose_800
 @docs to_rose_900
+@docs text_slate_50
+@docs text_slate_100
+@docs text_slate_200
+@docs text_slate_300
+@docs text_slate_400
+@docs text_slate_500
+@docs text_slate_600
+@docs text_slate_700
+@docs text_slate_800
+@docs text_slate_900
+@docs text_gray_50
+@docs text_gray_100
+@docs text_gray_200
+@docs text_gray_300
+@docs text_gray_400
+@docs text_gray_500
+@docs text_gray_600
+@docs text_gray_700
+@docs text_gray_800
+@docs text_gray_900
+@docs text_zinc_50
+@docs text_zinc_100
+@docs text_zinc_200
+@docs text_zinc_300
+@docs text_zinc_400
+@docs text_zinc_500
+@docs text_zinc_600
+@docs text_zinc_700
+@docs text_zinc_800
+@docs text_zinc_900
+@docs text_neutral_50
+@docs text_neutral_100
+@docs text_neutral_200
+@docs text_neutral_300
+@docs text_neutral_400
+@docs text_neutral_500
+@docs text_neutral_600
+@docs text_neutral_700
+@docs text_neutral_800
+@docs text_neutral_900
+@docs text_stone_50
+@docs text_stone_100
+@docs text_stone_200
+@docs text_stone_300
+@docs text_stone_400
+@docs text_stone_500
+@docs text_stone_600
+@docs text_stone_700
+@docs text_stone_800
+@docs text_stone_900
+@docs text_red_50
+@docs text_red_100
+@docs text_red_200
+@docs text_red_300
+@docs text_red_400
+@docs text_red_500
+@docs text_red_600
+@docs text_red_700
+@docs text_red_800
+@docs text_red_900
+@docs text_orange_50
+@docs text_orange_100
+@docs text_orange_200
+@docs text_orange_300
+@docs text_orange_400
+@docs text_orange_500
+@docs text_orange_600
+@docs text_orange_700
+@docs text_orange_800
+@docs text_orange_900
+@docs text_amber_50
+@docs text_amber_100
+@docs text_amber_200
+@docs text_amber_300
+@docs text_amber_400
+@docs text_amber_500
+@docs text_amber_600
+@docs text_amber_700
+@docs text_amber_800
+@docs text_amber_900
+@docs text_yellow_50
+@docs text_yellow_100
+@docs text_yellow_200
+@docs text_yellow_300
+@docs text_yellow_400
+@docs text_yellow_500
+@docs text_yellow_600
+@docs text_yellow_700
+@docs text_yellow_800
+@docs text_yellow_900
+@docs text_lime_50
+@docs text_lime_100
+@docs text_lime_200
+@docs text_lime_300
+@docs text_lime_400
+@docs text_lime_500
+@docs text_lime_600
+@docs text_lime_700
+@docs text_lime_800
+@docs text_lime_900
+@docs text_green_50
+@docs text_green_100
+@docs text_green_200
+@docs text_green_300
+@docs text_green_400
+@docs text_green_500
+@docs text_green_600
+@docs text_green_700
+@docs text_green_800
+@docs text_green_900
+@docs text_emerald_50
+@docs text_emerald_100
+@docs text_emerald_200
+@docs text_emerald_300
+@docs text_emerald_400
+@docs text_emerald_500
+@docs text_emerald_600
+@docs text_emerald_700
+@docs text_emerald_800
+@docs text_emerald_900
+@docs text_teal_50
+@docs text_teal_100
+@docs text_teal_200
+@docs text_teal_300
+@docs text_teal_400
+@docs text_teal_500
+@docs text_teal_600
+@docs text_teal_700
+@docs text_teal_800
+@docs text_teal_900
+@docs text_cyan_50
+@docs text_cyan_100
+@docs text_cyan_200
+@docs text_cyan_300
+@docs text_cyan_400
+@docs text_cyan_500
+@docs text_cyan_600
+@docs text_cyan_700
+@docs text_cyan_800
+@docs text_cyan_900
+@docs text_sky_50
+@docs text_sky_100
+@docs text_sky_200
+@docs text_sky_300
+@docs text_sky_400
+@docs text_sky_500
+@docs text_sky_600
+@docs text_sky_700
+@docs text_sky_800
+@docs text_sky_900
+@docs text_blue_50
+@docs text_blue_100
+@docs text_blue_200
+@docs text_blue_300
+@docs text_blue_400
+@docs text_blue_500
+@docs text_blue_600
+@docs text_blue_700
+@docs text_blue_800
+@docs text_blue_900
+@docs text_indigo_50
+@docs text_indigo_100
+@docs text_indigo_200
+@docs text_indigo_300
+@docs text_indigo_400
+@docs text_indigo_500
+@docs text_indigo_600
+@docs text_indigo_700
+@docs text_indigo_800
+@docs text_indigo_900
+@docs text_violet_50
+@docs text_violet_100
+@docs text_violet_200
+@docs text_violet_300
+@docs text_violet_400
+@docs text_violet_500
+@docs text_violet_600
+@docs text_violet_700
+@docs text_violet_800
+@docs text_violet_900
+@docs text_purple_50
+@docs text_purple_100
+@docs text_purple_200
+@docs text_purple_300
+@docs text_purple_400
+@docs text_purple_500
+@docs text_purple_600
+@docs text_purple_700
+@docs text_purple_800
+@docs text_purple_900
+@docs text_fuchsia_50
+@docs text_fuchsia_100
+@docs text_fuchsia_200
+@docs text_fuchsia_300
+@docs text_fuchsia_400
+@docs text_fuchsia_500
+@docs text_fuchsia_600
+@docs text_fuchsia_700
+@docs text_fuchsia_800
+@docs text_fuchsia_900
+@docs text_pink_50
+@docs text_pink_100
+@docs text_pink_200
+@docs text_pink_300
+@docs text_pink_400
+@docs text_pink_500
+@docs text_pink_600
+@docs text_pink_700
+@docs text_pink_800
+@docs text_pink_900
+@docs text_rose_50
+@docs text_rose_100
+@docs text_rose_200
+@docs text_rose_300
+@docs text_rose_400
+@docs text_rose_500
+@docs text_rose_600
+@docs text_rose_700
+@docs text_rose_800
+@docs text_rose_900
 
 -}
 
@@ -52513,136 +52873,6 @@ text_black =
         ]
 
 
-{-| The tailwind class `text-blue-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_100 : Css.Style
-text_blue_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(219, 234, 254, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_200 : Css.Style
-text_blue_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(191, 219, 254, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_300 : Css.Style
-text_blue_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(147, 197, 253, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_400 : Css.Style
-text_blue_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(96, 165, 250, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_50 : Css.Style
-text_blue_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(239, 246, 255, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_500 : Css.Style
-text_blue_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(59, 130, 246, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_600 : Css.Style
-text_blue_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(37, 99, 235, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_700 : Css.Style
-text_blue_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(29, 78, 216, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_800 : Css.Style
-text_blue_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(30, 64, 175, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-blue-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_blue_900 : Css.Style
-text_blue_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(30, 58, 138, var(--tw-text-opacity))"
-        ]
-
-
 {-| The tailwind class `text-center`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
@@ -52661,396 +52891,6 @@ Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs
 text_current : Css.Style
 text_current =
     Css.property "color" "currentColor"
-
-
-{-| The tailwind class `text-gray-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_100 : Css.Style
-text_gray_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(243, 244, 246, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_200 : Css.Style
-text_gray_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(229, 231, 235, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_300 : Css.Style
-text_gray_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(209, 213, 219, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_400 : Css.Style
-text_gray_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(156, 163, 175, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_50 : Css.Style
-text_gray_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(249, 250, 251, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_500 : Css.Style
-text_gray_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(107, 114, 128, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_600 : Css.Style
-text_gray_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(75, 85, 99, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_700 : Css.Style
-text_gray_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(55, 65, 81, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_800 : Css.Style
-text_gray_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(31, 41, 55, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-gray-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_gray_900 : Css.Style
-text_gray_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(17, 24, 39, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_100 : Css.Style
-text_green_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(209, 250, 229, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_200 : Css.Style
-text_green_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(167, 243, 208, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_300 : Css.Style
-text_green_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(110, 231, 183, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_400 : Css.Style
-text_green_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(52, 211, 153, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_50 : Css.Style
-text_green_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(236, 253, 245, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_500 : Css.Style
-text_green_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(16, 185, 129, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_600 : Css.Style
-text_green_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(5, 150, 105, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_700 : Css.Style
-text_green_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(4, 120, 87, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_800 : Css.Style
-text_green_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(6, 95, 70, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-green-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_green_900 : Css.Style
-text_green_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(6, 78, 59, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_100 : Css.Style
-text_indigo_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(224, 231, 255, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_200 : Css.Style
-text_indigo_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(199, 210, 254, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_300 : Css.Style
-text_indigo_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(165, 180, 252, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_400 : Css.Style
-text_indigo_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(129, 140, 248, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_50 : Css.Style
-text_indigo_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(238, 242, 255, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_500 : Css.Style
-text_indigo_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(99, 102, 241, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_600 : Css.Style
-text_indigo_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(79, 70, 229, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_700 : Css.Style
-text_indigo_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(67, 56, 202, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_800 : Css.Style
-text_indigo_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(55, 48, 163, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-indigo-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_indigo_900 : Css.Style
-text_indigo_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(49, 46, 129, var(--tw-text-opacity))"
-        ]
 
 
 {-| The tailwind class `text-justify`.
@@ -53236,396 +53076,6 @@ text_opacity_95 =
     Css.property "--tw-text-opacity" "0.95"
 
 
-{-| The tailwind class `text-pink-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_100 : Css.Style
-text_pink_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(252, 231, 243, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_200 : Css.Style
-text_pink_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(251, 207, 232, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_300 : Css.Style
-text_pink_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(249, 168, 212, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_400 : Css.Style
-text_pink_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(244, 114, 182, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_50 : Css.Style
-text_pink_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(253, 242, 248, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_500 : Css.Style
-text_pink_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(236, 72, 153, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_600 : Css.Style
-text_pink_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(219, 39, 119, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_700 : Css.Style
-text_pink_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(190, 24, 93, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_800 : Css.Style
-text_pink_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(157, 23, 77, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-pink-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_pink_900 : Css.Style
-text_pink_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(131, 24, 67, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_100 : Css.Style
-text_purple_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(237, 233, 254, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_200 : Css.Style
-text_purple_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(221, 214, 254, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_300 : Css.Style
-text_purple_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(196, 181, 253, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_400 : Css.Style
-text_purple_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(167, 139, 250, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_50 : Css.Style
-text_purple_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(245, 243, 255, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_500 : Css.Style
-text_purple_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(139, 92, 246, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_600 : Css.Style
-text_purple_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(124, 58, 237, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_700 : Css.Style
-text_purple_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(109, 40, 217, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_800 : Css.Style
-text_purple_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(91, 33, 182, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-purple-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_purple_900 : Css.Style
-text_purple_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(76, 29, 149, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-100`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_100 : Css.Style
-text_red_100 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(254, 226, 226, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-200`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_200 : Css.Style
-text_red_200 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(254, 202, 202, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-300`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_300 : Css.Style
-text_red_300 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(252, 165, 165, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-400`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_400 : Css.Style
-text_red_400 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(248, 113, 113, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-50`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_50 : Css.Style
-text_red_50 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(254, 242, 242, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-500`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_500 : Css.Style
-text_red_500 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(239, 68, 68, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-600`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_600 : Css.Style
-text_red_600 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(220, 38, 38, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-700`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_700 : Css.Style
-text_red_700 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(185, 28, 28, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-800`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_800 : Css.Style
-text_red_800 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(153, 27, 27, var(--tw-text-opacity))"
-        ]
-
-
-{-| The tailwind class `text-red-900`.
-
-Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
-
--}
-text_red_900 : Css.Style
-text_red_900 =
-    Css.batch
-        [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(127, 29, 29, var(--tw-text-opacity))"
-        ]
-
-
 {-| The tailwind class `text-right`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
@@ -53698,55 +53148,1043 @@ text_xs =
         ]
 
 
-{-| The tailwind class `text-yellow-100`.
+{-| The tailwind class `text-slate-50`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-text_yellow_100 : Css.Style
-text_yellow_100 =
+text_slate_50 : Css.Style
+text_slate_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(248, 250, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_100 : Css.Style
+text_slate_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(241, 245, 249, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_200 : Css.Style
+text_slate_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(226, 232, 240, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_300 : Css.Style
+text_slate_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(203, 213, 225, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_400 : Css.Style
+text_slate_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(148, 163, 184, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_500 : Css.Style
+text_slate_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(100, 116, 139, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_600 : Css.Style
+text_slate_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(71, 85, 105, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_700 : Css.Style
+text_slate_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(51, 65, 85, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_800 : Css.Style
+text_slate_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(30, 41, 59, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-slate-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_slate_900 : Css.Style
+text_slate_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(15, 23, 42, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_50 : Css.Style
+text_gray_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(249, 250, 251, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_100 : Css.Style
+text_gray_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(243, 244, 246, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_200 : Css.Style
+text_gray_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(229, 231, 235, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_300 : Css.Style
+text_gray_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(209, 213, 219, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_400 : Css.Style
+text_gray_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(156, 163, 175, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_500 : Css.Style
+text_gray_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(107, 114, 128, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_600 : Css.Style
+text_gray_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(75, 85, 99, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_700 : Css.Style
+text_gray_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(55, 65, 81, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_800 : Css.Style
+text_gray_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(31, 41, 55, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-gray-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_gray_900 : Css.Style
+text_gray_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(17, 24, 39, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_50 : Css.Style
+text_zinc_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 250, 250, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_100 : Css.Style
+text_zinc_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(244, 244, 245, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_200 : Css.Style
+text_zinc_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(228, 228, 231, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_300 : Css.Style
+text_zinc_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(212, 212, 216, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_400 : Css.Style
+text_zinc_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(161, 161, 170, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_500 : Css.Style
+text_zinc_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(113, 113, 122, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_600 : Css.Style
+text_zinc_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(82, 82, 91, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_700 : Css.Style
+text_zinc_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(63, 63, 70, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_800 : Css.Style
+text_zinc_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(39, 39, 42, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-zinc-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_zinc_900 : Css.Style
+text_zinc_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(24, 24, 27, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_50 : Css.Style
+text_neutral_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 250, 250, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_100 : Css.Style
+text_neutral_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(245, 245, 245, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_200 : Css.Style
+text_neutral_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(229, 229, 229, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_300 : Css.Style
+text_neutral_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(212, 212, 212, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_400 : Css.Style
+text_neutral_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(163, 163, 163, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_500 : Css.Style
+text_neutral_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(115, 115, 115, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_600 : Css.Style
+text_neutral_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(82, 82, 82, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_700 : Css.Style
+text_neutral_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(64, 64, 64, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_800 : Css.Style
+text_neutral_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(38, 38, 38, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-neutral-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_neutral_900 : Css.Style
+text_neutral_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(23, 23, 23, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_50 : Css.Style
+text_stone_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 250, 249, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_100 : Css.Style
+text_stone_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(245, 245, 244, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_200 : Css.Style
+text_stone_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(231, 229, 228, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_300 : Css.Style
+text_stone_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(214, 211, 209, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_400 : Css.Style
+text_stone_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(168, 162, 158, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_500 : Css.Style
+text_stone_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(120, 113, 108, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_600 : Css.Style
+text_stone_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(87, 83, 78, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_700 : Css.Style
+text_stone_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(68, 64, 60, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_800 : Css.Style
+text_stone_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(41, 37, 36, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-stone-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_stone_900 : Css.Style
+text_stone_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(28, 25, 23, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_50 : Css.Style
+text_red_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 242, 242, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_100 : Css.Style
+text_red_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 226, 226, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_200 : Css.Style
+text_red_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 202, 202, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_300 : Css.Style
+text_red_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(252, 165, 165, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_400 : Css.Style
+text_red_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(248, 113, 113, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_500 : Css.Style
+text_red_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(239, 68, 68, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_600 : Css.Style
+text_red_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(220, 38, 38, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_700 : Css.Style
+text_red_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(185, 28, 28, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_800 : Css.Style
+text_red_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(153, 27, 27, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-red-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_red_900 : Css.Style
+text_red_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(127, 29, 29, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_50 : Css.Style
+text_orange_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(255, 247, 237, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_100 : Css.Style
+text_orange_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(255, 237, 213, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_200 : Css.Style
+text_orange_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 215, 170, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_300 : Css.Style
+text_orange_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(253, 186, 116, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_400 : Css.Style
+text_orange_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(251, 146, 60, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_500 : Css.Style
+text_orange_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(249, 115, 22, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_600 : Css.Style
+text_orange_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(234, 88, 12, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_700 : Css.Style
+text_orange_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(194, 65, 12, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_800 : Css.Style
+text_orange_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(154, 52, 18, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-orange-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_orange_900 : Css.Style
+text_orange_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(124, 45, 18, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_50 : Css.Style
+text_amber_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(255, 251, 235, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_100 : Css.Style
+text_amber_100 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
         , Css.property "color" "rgba(254, 243, 199, var(--tw-text-opacity))"
         ]
 
 
-{-| The tailwind class `text-yellow-200`.
+{-| The tailwind class `text-amber-200`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-text_yellow_200 : Css.Style
-text_yellow_200 =
+text_amber_200 : Css.Style
+text_amber_200 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
         , Css.property "color" "rgba(253, 230, 138, var(--tw-text-opacity))"
         ]
 
 
-{-| The tailwind class `text-yellow-300`.
+{-| The tailwind class `text-amber-300`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-text_yellow_300 : Css.Style
-text_yellow_300 =
+text_amber_300 : Css.Style
+text_amber_300 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
         , Css.property "color" "rgba(252, 211, 77, var(--tw-text-opacity))"
         ]
 
 
-{-| The tailwind class `text-yellow-400`.
+{-| The tailwind class `text-amber-400`.
 
 Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
 
 -}
-text_yellow_400 : Css.Style
-text_yellow_400 =
+text_amber_400 : Css.Style
+text_amber_400 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
         , Css.property "color" "rgba(251, 191, 36, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_500 : Css.Style
+text_amber_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(245, 158, 11, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_600 : Css.Style
+text_amber_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(217, 119, 6, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_700 : Css.Style
+text_amber_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(180, 83, 9, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_800 : Css.Style
+text_amber_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(146, 64, 14, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-amber-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_amber_900 : Css.Style
+text_amber_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(120, 53, 15, var(--tw-text-opacity))"
         ]
 
 
@@ -53759,7 +54197,59 @@ text_yellow_50 : Css.Style
 text_yellow_50 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(255, 251, 235, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(254, 252, 232, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-yellow-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_yellow_100 : Css.Style
+text_yellow_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 249, 195, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-yellow-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_yellow_200 : Css.Style
+text_yellow_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 240, 138, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-yellow-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_yellow_300 : Css.Style
+text_yellow_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(253, 224, 71, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-yellow-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_yellow_400 : Css.Style
+text_yellow_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 204, 21, var(--tw-text-opacity))"
         ]
 
 
@@ -53772,7 +54262,7 @@ text_yellow_500 : Css.Style
 text_yellow_500 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(245, 158, 11, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(234, 179, 8, var(--tw-text-opacity))"
         ]
 
 
@@ -53785,7 +54275,7 @@ text_yellow_600 : Css.Style
 text_yellow_600 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(217, 119, 6, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(202, 138, 4, var(--tw-text-opacity))"
         ]
 
 
@@ -53798,7 +54288,7 @@ text_yellow_700 : Css.Style
 text_yellow_700 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(180, 83, 9, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(161, 98, 7, var(--tw-text-opacity))"
         ]
 
 
@@ -53811,7 +54301,7 @@ text_yellow_800 : Css.Style
 text_yellow_800 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(146, 64, 14, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(133, 77, 14, var(--tw-text-opacity))"
         ]
 
 
@@ -53824,7 +54314,1697 @@ text_yellow_900 : Css.Style
 text_yellow_900 =
     Css.batch
         [ Css.property "--tw-text-opacity" "1"
-        , Css.property "color" "rgba(120, 53, 15, var(--tw-text-opacity))"
+        , Css.property "color" "rgba(113, 63, 18, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_50 : Css.Style
+text_lime_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(247, 254, 231, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_100 : Css.Style
+text_lime_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(236, 252, 203, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_200 : Css.Style
+text_lime_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(217, 249, 157, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_300 : Css.Style
+text_lime_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(190, 242, 100, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_400 : Css.Style
+text_lime_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(163, 230, 53, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_500 : Css.Style
+text_lime_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(132, 204, 22, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_600 : Css.Style
+text_lime_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(101, 163, 13, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_700 : Css.Style
+text_lime_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(77, 124, 15, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_800 : Css.Style
+text_lime_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(63, 98, 18, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-lime-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_lime_900 : Css.Style
+text_lime_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(54, 83, 20, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_50 : Css.Style
+text_green_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(240, 253, 244, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_100 : Css.Style
+text_green_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(220, 252, 231, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_200 : Css.Style
+text_green_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(187, 247, 208, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_300 : Css.Style
+text_green_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(134, 239, 172, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_400 : Css.Style
+text_green_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(74, 222, 128, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_500 : Css.Style
+text_green_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(34, 197, 94, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_600 : Css.Style
+text_green_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(22, 163, 74, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_700 : Css.Style
+text_green_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(21, 128, 61, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_800 : Css.Style
+text_green_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(22, 101, 52, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-green-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_green_900 : Css.Style
+text_green_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(20, 83, 45, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_50 : Css.Style
+text_emerald_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(236, 253, 245, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_100 : Css.Style
+text_emerald_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(209, 250, 229, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_200 : Css.Style
+text_emerald_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(167, 243, 208, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_300 : Css.Style
+text_emerald_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(110, 231, 183, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_400 : Css.Style
+text_emerald_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(52, 211, 153, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_500 : Css.Style
+text_emerald_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(16, 185, 129, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_600 : Css.Style
+text_emerald_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(5, 150, 105, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_700 : Css.Style
+text_emerald_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(4, 120, 87, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_800 : Css.Style
+text_emerald_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(6, 95, 70, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-emerald-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_emerald_900 : Css.Style
+text_emerald_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(6, 78, 59, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_50 : Css.Style
+text_teal_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(240, 253, 250, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_100 : Css.Style
+text_teal_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(204, 251, 241, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_200 : Css.Style
+text_teal_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(153, 246, 228, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_300 : Css.Style
+text_teal_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(94, 234, 212, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_400 : Css.Style
+text_teal_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(45, 212, 191, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_500 : Css.Style
+text_teal_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(20, 184, 166, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_600 : Css.Style
+text_teal_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(13, 148, 136, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_700 : Css.Style
+text_teal_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(15, 118, 110, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_800 : Css.Style
+text_teal_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(17, 94, 89, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-teal-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_teal_900 : Css.Style
+text_teal_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(19, 78, 74, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_50 : Css.Style
+text_cyan_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(236, 254, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_100 : Css.Style
+text_cyan_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(207, 250, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_200 : Css.Style
+text_cyan_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(165, 243, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_300 : Css.Style
+text_cyan_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(103, 232, 249, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_400 : Css.Style
+text_cyan_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(34, 211, 238, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_500 : Css.Style
+text_cyan_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(6, 182, 212, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_600 : Css.Style
+text_cyan_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(8, 145, 178, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_700 : Css.Style
+text_cyan_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(14, 116, 144, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_800 : Css.Style
+text_cyan_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(21, 94, 117, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-cyan-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_cyan_900 : Css.Style
+text_cyan_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(22, 78, 99, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_50 : Css.Style
+text_sky_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(240, 249, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_100 : Css.Style
+text_sky_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(224, 242, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_200 : Css.Style
+text_sky_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(186, 230, 253, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_300 : Css.Style
+text_sky_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(125, 211, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_400 : Css.Style
+text_sky_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(56, 189, 248, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_500 : Css.Style
+text_sky_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(14, 165, 233, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_600 : Css.Style
+text_sky_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(2, 132, 199, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_700 : Css.Style
+text_sky_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(3, 105, 161, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_800 : Css.Style
+text_sky_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(7, 89, 133, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-sky-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_sky_900 : Css.Style
+text_sky_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(12, 74, 110, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_50 : Css.Style
+text_blue_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(239, 246, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_100 : Css.Style
+text_blue_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(219, 234, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_200 : Css.Style
+text_blue_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(191, 219, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_300 : Css.Style
+text_blue_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(147, 197, 253, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_400 : Css.Style
+text_blue_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(96, 165, 250, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_500 : Css.Style
+text_blue_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(59, 130, 246, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_600 : Css.Style
+text_blue_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(37, 99, 235, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_700 : Css.Style
+text_blue_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(29, 78, 216, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_800 : Css.Style
+text_blue_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(30, 64, 175, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-blue-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_blue_900 : Css.Style
+text_blue_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(30, 58, 138, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_50 : Css.Style
+text_indigo_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(238, 242, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_100 : Css.Style
+text_indigo_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(224, 231, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_200 : Css.Style
+text_indigo_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(199, 210, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_300 : Css.Style
+text_indigo_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(165, 180, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_400 : Css.Style
+text_indigo_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(129, 140, 248, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_500 : Css.Style
+text_indigo_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(99, 102, 241, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_600 : Css.Style
+text_indigo_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(79, 70, 229, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_700 : Css.Style
+text_indigo_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(67, 56, 202, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_800 : Css.Style
+text_indigo_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(55, 48, 163, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-indigo-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_indigo_900 : Css.Style
+text_indigo_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(49, 46, 129, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_50 : Css.Style
+text_violet_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(245, 243, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_100 : Css.Style
+text_violet_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(237, 233, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_200 : Css.Style
+text_violet_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(221, 214, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_300 : Css.Style
+text_violet_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(196, 181, 253, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_400 : Css.Style
+text_violet_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(167, 139, 250, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_500 : Css.Style
+text_violet_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(139, 92, 246, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_600 : Css.Style
+text_violet_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(124, 58, 237, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_700 : Css.Style
+text_violet_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(109, 40, 217, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_800 : Css.Style
+text_violet_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(91, 33, 182, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-violet-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_violet_900 : Css.Style
+text_violet_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(76, 29, 149, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_50 : Css.Style
+text_purple_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 245, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_100 : Css.Style
+text_purple_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(243, 232, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_200 : Css.Style
+text_purple_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(233, 213, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_300 : Css.Style
+text_purple_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(216, 180, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_400 : Css.Style
+text_purple_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(192, 132, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_500 : Css.Style
+text_purple_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(168, 85, 247, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_600 : Css.Style
+text_purple_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(147, 51, 234, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_700 : Css.Style
+text_purple_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(126, 34, 206, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_800 : Css.Style
+text_purple_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(107, 33, 168, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-purple-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_purple_900 : Css.Style
+text_purple_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(88, 28, 135, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_50 : Css.Style
+text_fuchsia_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(253, 244, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_100 : Css.Style
+text_fuchsia_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(250, 232, 255, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_200 : Css.Style
+text_fuchsia_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(245, 208, 254, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_300 : Css.Style
+text_fuchsia_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(240, 171, 252, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_400 : Css.Style
+text_fuchsia_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(232, 121, 249, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_500 : Css.Style
+text_fuchsia_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(217, 70, 239, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_600 : Css.Style
+text_fuchsia_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(192, 38, 211, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_700 : Css.Style
+text_fuchsia_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(162, 28, 175, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_800 : Css.Style
+text_fuchsia_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(134, 25, 143, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-fuchsia-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_fuchsia_900 : Css.Style
+text_fuchsia_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(112, 26, 117, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_50 : Css.Style
+text_pink_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(253, 242, 248, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_100 : Css.Style
+text_pink_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(252, 231, 243, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_200 : Css.Style
+text_pink_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(251, 207, 232, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_300 : Css.Style
+text_pink_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(249, 168, 212, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_400 : Css.Style
+text_pink_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(244, 114, 182, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_500 : Css.Style
+text_pink_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(236, 72, 153, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_600 : Css.Style
+text_pink_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(219, 39, 119, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_700 : Css.Style
+text_pink_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(190, 24, 93, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_800 : Css.Style
+text_pink_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(157, 23, 77, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-pink-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_pink_900 : Css.Style
+text_pink_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(131, 24, 67, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-50`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_50 : Css.Style
+text_rose_50 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(255, 241, 242, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-100`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_100 : Css.Style
+text_rose_100 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(255, 228, 230, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-200`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_200 : Css.Style
+text_rose_200 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(254, 205, 211, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-300`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_300 : Css.Style
+text_rose_300 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(253, 164, 175, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-400`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_400 : Css.Style
+text_rose_400 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(251, 113, 133, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-500`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_500 : Css.Style
+text_rose_500 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(244, 63, 94, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-600`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_600 : Css.Style
+text_rose_600 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(225, 29, 72, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-700`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_700 : Css.Style
+text_rose_700 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(190, 18, 60, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-800`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_800 : Css.Style
+text_rose_800 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(159, 18, 57, var(--tw-text-opacity))"
+        ]
+
+
+{-| The tailwind class `text-rose-900`.
+
+Make sure to check out the [tailwind documentation](https://tailwindcss.com/docs)!
+
+-}
+text_rose_900 : Css.Style
+text_rose_900 =
+    Css.batch
+        [ Css.property "--tw-text-opacity" "1"
+        , Css.property "color" "rgba(136, 19, 55, var(--tw-text-opacity))"
         ]
 
 


### PR DESCRIPTION
The repository was missing many default colors that were added in Tailwind v3, such as cyan or orange. This pull request simply adds the missing colors.

It is important to note that Tailwind changed the default value of green, purple and yellow colors (these were renamed to emerald, violet and amber respectively, and the old names were repurposed for other color values) - details available [here](https://github.com/tailwindlabs/tailwindcss/pull/5384). Therefore, any code that uses this package should be modified to reflect this change. **This may be considered a breaking change.**

Also, I do not have a utility to automatically sort the functions alphabetically, as is the case in the base repository, so the ordering is sort of all out of whack. Feel free to modify this when merging.